### PR TITLE
feat(table): allow page up/down in table

### DIFF
--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -340,6 +340,7 @@ impl<'a> Table<'a> {
 pub struct TableState {
     offset: usize,
     selected: Option<usize>,
+    pub page_size: Option<usize>,
 }
 
 impl TableState {
@@ -425,6 +426,7 @@ impl<'a> StatefulWidget for Table<'a> {
         }
         let (start, end) = self.get_row_bounds(state.selected, state.offset, rows_height);
         state.offset = start;
+        state.page_size = Some(end - start);
         for (i, table_row) in self
             .rows
             .iter_mut()


### PR DESCRIPTION
NOTE FOR IMPLEMENTER: Please read the following before picking this up for implementation:
- https://github.com/tui-rs-revival/ratatui/issues/174

> Upstream: [#246](https://github.com/fdehau/tui-rs/pull/246)

Hi!

I started playing with the table example and though that for bigger tables it would be nice to be able to scroll the data a page at a time, so I altered the `Table` widget's `TableState` to store a page size for the table and its `render` function to update this at the relevant point. I have also updated the example for the `Table` widget to use this.

Let me know if you think this is a good addition or any other feedback. 😁