### PR TITLE
refactor(style): make bitflags smaller

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -39,16 +39,16 @@ bitflags! {
     /// let m = Modifier::BOLD | Modifier::ITALIC;
     /// ```
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct Modifier: u16 {
-        const BOLD              = 0b0000_0000_0001;
-        const DIM               = 0b0000_0000_0010;
-        const ITALIC            = 0b0000_0000_0100;
-        const UNDERLINED        = 0b0000_0000_1000;
-        const SLOW_BLINK        = 0b0000_0001_0000;
-        const RAPID_BLINK       = 0b0000_0010_0000;
-        const REVERSED          = 0b0000_0100_0000;
-        const HIDDEN            = 0b0000_1000_0000;
-        const CROSSED_OUT       = 0b0001_0000_0000;
+    pub struct Modifier: u8 {
+        const BOLD              = 0b0000_0000;
+        const DIM               = 0b0000_0001;
+        const ITALIC            = 0b0000_0010;
+        const UNDERLINED        = 0b0000_0100;
+        const SLOW_BLINK        = 0b0000_1000;
+        const RAPID_BLINK       = 0b0001_0000;
+        const REVERSED          = 0b0010_0000;
+        const HIDDEN            = 0b0100_0000;
+        const CROSSED_OUT       = 0b1000_0000;
     }
 }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -44,17 +44,17 @@ use bitflags::bitflags;
 
 bitflags! {
     /// Bitflags that can be composed to set the visible borders essentially on the block widget.
-    pub struct Borders: u32 {
+    pub struct Borders: u8 {
         /// Show no border (default)
-        const NONE  = 0b0000_0001;
+        const NONE   = 0b0000;
         /// Show the top border
-        const TOP   = 0b0000_0010;
+        const TOP    = 0b0001;
         /// Show the right border
-        const RIGHT = 0b0000_0100;
+        const RIGHT  = 0b0010;
         /// Show the bottom border
-        const BOTTOM = 0b000_1000;
+        const BOTTOM = 0b0100;
         /// Show the left border
-        const LEFT = 0b0001_0000;
+        const LEFT   = 0b1000;
         /// Show all borders
         const ALL = Self::TOP.bits | Self::RIGHT.bits | Self::BOTTOM.bits | Self::LEFT.bits;
     }


### PR DESCRIPTION
> Upstream: [#505](https://github.com/fdehau/tui-rs/pull/505)

## Description

This reduces the size of bitflags so that they are less wastful. They can be grown again later if required.

## Testing guidelines

`cargo test` still passes, the behavior is unchanged.

## Checklist

* [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [X] I have added relevant tests.
* [X] I have documented all new additions.