### PR TITLE
feat(widget): add render_ref method to Widget trait

### DIFF
--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -19,7 +19,7 @@ impl<'a> Default for Label<'a> {
 }
 
 impl<'a> Widget for Label<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         buf.set_string(area.left(), area.top(), self.text, Style::default());
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -103,6 +103,13 @@ where
         widget.render(area, self.terminal.current_buffer_mut());
     }
 
+    pub fn render_widget_ref<W>(&mut self, widget: &mut W, area: Rect)
+    where
+        W: Widget + ?Sized,
+    {
+        widget.render_ref(area, self.terminal.current_buffer_mut());
+    }
+
     /// Render a [`StatefulWidget`] to the current buffer using [`StatefulWidget::render`].
     ///
     /// The last argument should be an instance of the [`StatefulWidget::State`] associated to the

--- a/src/widgets/barchart.rs
+++ b/src/widgets/barchart.rs
@@ -127,7 +127,7 @@ impl<'a> BarChart<'a> {
 }
 
 impl<'a> Widget for BarChart<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
 
         let chart_area = match self.block.take() {

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -140,7 +140,7 @@ impl<'a> Block<'a> {
 }
 
 impl<'a> Widget for Block<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         if area.area() == 0 {
             return;
         }
@@ -202,7 +202,7 @@ impl<'a> Widget for Block<'a> {
         }
 
         // Title
-        if let Some(title) = self.title {
+        if let Some(title) = self.title.as_ref() {
             let left_border_dx = if self.borders.intersects(Borders::LEFT) {
                 1
             } else {
@@ -232,7 +232,7 @@ impl<'a> Widget for Block<'a> {
             let title_x = area.left() + title_dx;
             let title_y = area.top();
 
-            buf.set_spans(title_x, title_y, &title, title_area_width);
+            buf.set_spans(title_x, title_y, title, title_area_width);
         }
     }
 }

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -423,7 +423,7 @@ impl<'a, F> Widget for Canvas<'a, F>
 where
     F: Fn(&mut Context),
 {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         let canvas_area = match self.block.take() {
             Some(b) => {
                 let inner_area = b.inner(area);

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -431,7 +431,7 @@ impl<'a> Chart<'a> {
 }
 
 impl<'a> Widget for Chart<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         if area.area() == 0 {
             return;
         }
@@ -525,7 +525,7 @@ impl<'a> Widget for Chart<'a> {
         }
 
         if let Some((x, y)) = layout.title_x {
-            let title = self.x_axis.title.unwrap();
+            let title = self.x_axis.title.as_ref().unwrap();
             let width = graph_area.right().saturating_sub(x);
             buf.set_style(
                 Rect {
@@ -536,11 +536,11 @@ impl<'a> Widget for Chart<'a> {
                 },
                 original_style,
             );
-            buf.set_spans(x, y, &title, width);
+            buf.set_spans(x, y, title, width);
         }
 
         if let Some((x, y)) = layout.title_y {
-            let title = self.y_axis.title.unwrap();
+            let title = self.y_axis.title.as_ref().unwrap();
             let width = graph_area.right().saturating_sub(x);
             buf.set_style(
                 Rect {
@@ -551,7 +551,7 @@ impl<'a> Widget for Chart<'a> {
                 },
                 original_style,
             );
-            buf.set_spans(x, y, &title, width);
+            buf.set_spans(x, y, title, width);
         }
     }
 }

--- a/src/widgets/clear.rs
+++ b/src/widgets/clear.rs
@@ -27,7 +27,7 @@ use crate::{buffer::Buffer, layout::Rect, widgets::Widget};
 pub struct Clear;
 
 impl Widget for Clear {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         for x in area.left()..area.right() {
             for y in area.top()..area.bottom() {
                 buf.get_mut(x, y).reset();

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -92,7 +92,7 @@ impl<'a> Gauge<'a> {
 }
 
 impl<'a> Widget for Gauge<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
         let gauge_area = match self.block.take() {
             Some(b) => {
@@ -109,11 +109,9 @@ impl<'a> Widget for Gauge<'a> {
 
         // compute label value and its position
         // label is put at the center of the gauge_area
-        let label = {
-            let pct = f64::round(self.ratio * 100.0);
-            self.label
-                .unwrap_or_else(|| Span::from(format!("{}%", pct)))
-        };
+        let pct = f64::round(self.ratio * 100.0);
+        let default_label = Span::from(format!("{}%", pct));
+        let label = { self.label.as_ref().unwrap_or(&default_label) };
         let clamped_label_width = gauge_area.width.min(label.width() as u16);
         let label_col = gauge_area.left() + (gauge_area.width - clamped_label_width) / 2;
         let label_row = gauge_area.top() + gauge_area.height / 2;
@@ -140,7 +138,7 @@ impl<'a> Widget for Gauge<'a> {
             }
         }
         // set the span
-        buf.set_span(label_col, label_row, &label, clamped_label_width);
+        buf.set_span(label_col, label_row, label, clamped_label_width);
     }
 }
 
@@ -234,7 +232,7 @@ impl<'a> LineGauge<'a> {
 }
 
 impl<'a> Widget for LineGauge<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
         let gauge_area = match self.block.take() {
             Some(b) => {
@@ -249,16 +247,10 @@ impl<'a> Widget for LineGauge<'a> {
             return;
         }
 
-        let ratio = self.ratio;
-        let label = self
-            .label
-            .unwrap_or_else(move || Spans::from(format!("{:.0}%", ratio * 100.0)));
-        let (col, row) = buf.set_spans(
-            gauge_area.left(),
-            gauge_area.top(),
-            &label,
-            gauge_area.width,
-        );
+        let default_spans = Spans::from(format!("{:.0}%", self.ratio * 100.0));
+        let label = self.label.as_ref().unwrap_or(&default_spans);
+        let (col, row) =
+            buf.set_spans(gauge_area.left(), gauge_area.top(), label, gauge_area.width);
         let start = col + 1;
         if start >= gauge_area.right() {
             return;

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -171,7 +171,7 @@ impl<'a> List<'a> {
 impl<'a> StatefulWidget for List<'a> {
     type State = ListState;
 
-    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         buf.set_style(area, self.style);
         let list_area = match self.block.take() {
             Some(b) => {
@@ -250,8 +250,8 @@ impl<'a> StatefulWidget for List<'a> {
 }
 
 impl<'a> Widget for List<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         let mut state = ListState::default();
-        StatefulWidget::render(self, area, buf, &mut state);
+        StatefulWidget::render_ref(self, area, buf, &mut state);
     }
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -64,7 +64,14 @@ bitflags! {
 pub trait Widget {
     /// Draws the current state of the widget in the given buffer. That is the only method required
     /// to implement a custom widget.
-    fn render(self, area: Rect, buf: &mut Buffer);
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer);
+
+    fn render(mut self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        Widget::render_ref(&mut self, area, buf);
+    }
 }
 
 /// A `StatefulWidget` is a widget that can take advantage of some local state to remember things
@@ -181,5 +188,12 @@ pub trait Widget {
 /// ```
 pub trait StatefulWidget {
     type State;
-    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State);
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State);
+
+    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State)
+    where
+        Self: Sized,
+    {
+        StatefulWidget::render_ref(&mut self, area, buf, state);
+    }
 }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -133,7 +133,7 @@ impl<'a> Paragraph<'a> {
 }
 
 impl<'a> Widget for Paragraph<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
         let text_area = match self.block.take() {
             Some(b) => {

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -75,7 +75,7 @@ impl<'a> Sparkline<'a> {
 }
 
 impl<'a> Widget for Sparkline<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         let spark_area = match self.block.take() {
             Some(b) => {
                 let inner_area = b.inner(area);

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -366,7 +366,7 @@ impl TableState {
 impl<'a> StatefulWidget for Table<'a> {
     type State = TableState;
 
-    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         if area.area() == 0 {
             return;
         }
@@ -487,9 +487,9 @@ fn render_cell(buf: &mut Buffer, cell: &Cell, area: Rect) {
 }
 
 impl<'a> Widget for Table<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         let mut state = TableState::default();
-        StatefulWidget::render(self, area, buf, &mut state);
+        StatefulWidget::render_ref(self, area, buf, &mut state);
     }
 }
 

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -81,7 +81,7 @@ impl<'a> Tabs<'a> {
 }
 
 impl<'a> Widget for Tabs<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render_ref(&mut self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
         let tabs_area = match self.block.take() {
             Some(b) => {
@@ -98,14 +98,14 @@ impl<'a> Widget for Tabs<'a> {
 
         let mut x = tabs_area.left();
         let titles_length = self.titles.len();
-        for (i, title) in self.titles.into_iter().enumerate() {
+        for (i, title) in self.titles.iter().enumerate() {
             let last_title = titles_length - 1 == i;
             x = x.saturating_add(1);
             let remaining_width = tabs_area.right().saturating_sub(x);
             if remaining_width == 0 {
                 break;
             }
-            let pos = buf.set_spans(x, tabs_area.top(), &title, remaining_width);
+            let pos = buf.set_spans(x, tabs_area.top(), title, remaining_width);
             if i == self.selected {
                 buf.set_style(
                     Rect {


### PR DESCRIPTION
> Upstream: [#528](https://github.com/fdehau/tui-rs/pull/528)

## Description
This PR adds `Terminal::render_widget_ref()` and `(Stateful)Widget::render_ref()` functions that take Widgets by reference instead of taking ownership. This allows to call render on a Trait object with unknown size with is useful where the exact object implementing Widget is unknown or depends on some kind of condition. I decided not to change the `render_widget() `and `render()` signatures as to keep backwards compatibility but sadly all custom widgets are still broken because they are now required to implement `render_ref()` instead. This is just a proof of concept PR and I would appreciate any help on getting it up to the standards since this is my first time contributing to a big rust project. I made this to fix issue #526 I posted yesterday and I'm already using this PR in a project of mine. 

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [ ] I have added relevant tests.
* [ ] I have documented all new additions.