### PR TITLE
feat(backend): deref impl for backend types

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -5,7 +5,10 @@
 //! [`Backend`]: trait.Backend.html
 //! [`CrosstermBackend`]: struct.CrosstermBackend.html
 
-use std::io::{self, Write};
+use std::{
+    io::{self, Write},
+    ops::{Deref, DerefMut},
+};
 
 use crossterm::{
     cursor::{Hide, MoveTo, Show},
@@ -68,6 +71,20 @@ where
     /// Flushes the underlying buffer.
     fn flush(&mut self) -> io::Result<()> {
         self.buffer.flush()
+    }
+}
+
+impl<W: Write> Deref for CrosstermBackend<W> {
+    type Target = W;
+
+    fn deref(&self) -> &Self::Target {
+        &self.buffer
+    }
+}
+
+impl<W: Write> DerefMut for CrosstermBackend<W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buffer
     }
 }
 

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -7,6 +7,7 @@
 use std::{
     fmt,
     io::{self, Write},
+    ops::{Deref, DerefMut},
 };
 
 use crate::{
@@ -58,6 +59,20 @@ where
 
     fn flush(&mut self) -> io::Result<()> {
         self.stdout.flush()
+    }
+}
+
+impl<W: Write> Deref for TermionBackend<W> {
+    type Target = W;
+
+    fn deref(&self) -> &Self::Target {
+        &self.stdout
+    }
+}
+
+impl<W: Write> DerefMut for TermionBackend<W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.stdout
     }
 }
 


### PR DESCRIPTION
> Upstream: [#632](https://github.com/fdehau/tui-rs/pull/632)

## Description

This PR fixes [#630](https://github.com/fdehau/tui-rs/issues/630) issue, and adds the implementation of the `std::ops::Deref` and `std::ops::DerefMut` traits on backend types `CrosstermBackend<W>` and `TermionBackend<W>`. This allows to access the methods of the underlying data of the backend types, especially the `RawTerminal::activate_raw_mode` and `RawTerminal::suspend_raw_mode` methods for `termion` backend.

The `termion` part of the demo example has also been modified. It now restores the terminal before ending the `main` function. Either way, the example hasn't been modified, but we can now display the errors after restoring the terminal like with the `crossterm` backend.

## Testing guidelines

Because it only concerns a trait implementation on the backend types and it doesn't concern any drawing issue, this PR doesn't need any new relevant tests.

## Checklist

* [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
