### PR TITLE
docs: Add hncli to list of applications made with tui-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ You can run all examples by running `cargo make run-examples` (require
 * [trippy](https://github.com/fujiapple852/trippy): a network diagnostic tool.
 * [cotp](https://github.com/replydev/cotp): a trustworthy, encrypted, command-line TOTP/HOTP authenticator app with import functionality.
 * [hg-tui](https://github.com/kaixinbaba/hg-tui): view [hellogithub.com](https://hellogithub.com/) website on the terminal.
+* [hncli](https://github.com/pierreyoda/hncli): an Hacker News TUI reader.
 
 ### Alternatives
 


### PR DESCRIPTION
> Upstream: [#687](https://github.com/fdehau/tui-rs/pull/687)

## Description

Add [hncli](https://github.com/pierreyoda/hncli), an Hacker News TUI reader, to the list of applications made with `tui-rs`. Thanks for the library, can help with maintenance if needed!

## Testing guidelines

N/A

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.