### PR TITLE
feat(list): allow widgets as list items

### DIFF
--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -19,7 +19,7 @@ struct Label<'a> {
 }
 
 impl<'a> Widget for Label<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_string(area.left(), area.top(), self.text, Style::default());
     }
 }

--- a/examples/widget_list.rs
+++ b/examples/widget_list.rs
@@ -1,0 +1,254 @@
+use crossterm::{
+    event::{DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span, Text},
+    widgets::{
+        Block, BorderType, Borders, Gauge, List, ListItem, ListState, Paragraph, Widget,
+        WidgetWrapper,
+    },
+    Terminal,
+};
+use std::{error::Error, io, time::Duration};
+
+const TICK_RATE: Duration = Duration::from_millis(250);
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut terminal = setup_terminal()?;
+    let app = App::new(&mut terminal, TICK_RATE);
+    app.run()?;
+    restore_terminal(terminal)?;
+    Ok(())
+}
+
+fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>, Box<dyn Error>> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let terminal = Terminal::new(backend)?;
+    Ok(terminal)
+}
+
+fn restore_terminal(
+    mut terminal: Terminal<CrosstermBackend<io::Stdout>>,
+) -> Result<(), Box<dyn Error>> {
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+struct App<'a, B>
+where
+    B: Backend,
+{
+    terminal: &'a mut Terminal<B>,
+    tick_rate: Duration,
+    list: WidgetList<'a>,
+}
+
+impl<'a, B> App<'a, B>
+where
+    B: Backend,
+{
+    pub fn new(terminal: &'a mut Terminal<B>, tick_rate: Duration) -> Self {
+        let list = WidgetList::with_items(vec![
+            WidgetListItem::String("string"),
+            WidgetListItem::Raw("raw"),
+            WidgetListItem::Styled("styled", Style::default().fg(Color::Red)),
+            WidgetListItem::Text(Text::from("text")),
+            WidgetListItem::Paragraph(
+                Paragraph::new("paragraph").block(
+                    Block::default()
+                        .title("paragraph block")
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::Red)),
+                ),
+            ),
+            WidgetListItem::Block(
+                Block::default()
+                    .title("block")
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Double)
+                    .border_style(Style::default().fg(Color::Red)),
+            ),
+            WidgetListItem::Book(BookWidget::new(
+                "The Rust Programming Language",
+                "Steve Klabnik and Carol Nichols",
+                "https://doc.rust-lang.org/stable/book/",
+            )),
+            WidgetListItem::Gauge(50),
+        ]);
+        Self {
+            terminal,
+            tick_rate,
+            list,
+        }
+    }
+    pub fn run(mut self) -> Result<(), Box<dyn Error>> {
+        loop {
+            self.draw()?;
+            if !crossterm::event::poll(self.tick_rate)? {
+                continue;
+            }
+            match crossterm::event::read()? {
+                Event::Key(event) => match event.code {
+                    KeyCode::Char('q') => break,
+                    KeyCode::Down => self.list.next(),
+                    KeyCode::Up => self.list.previous(),
+                    KeyCode::Esc => self.list.unselect(),
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn draw(&mut self) -> Result<(), Box<dyn Error>> {
+        self.terminal.draw(|frame| {
+            let items = self
+                .list
+                .items
+                .iter()
+                .map(|i| match i {
+                    // These are just testing the backwards compatibility of the ListItem
+                    WidgetListItem::String(s) => ListItem::new(*s),
+                    WidgetListItem::Raw(s) => ListItem::new(Text::raw(*s)),
+                    WidgetListItem::Styled(s, style) => ListItem::new(Text::styled(*s, *style)),
+                    WidgetListItem::Text(t) => ListItem::new(t.clone()),
+                    // We don't recommend this approach, but it is possible to store a widget in
+                    // a list item and then render it in the render closure
+                    WidgetListItem::Paragraph(p) => {
+                        ListItem::new(WidgetWrapper::new(p.clone(), 3, 10))
+                    }
+                    WidgetListItem::Block(b) => ListItem::new(WidgetWrapper::new(b.clone(), 3, 10)),
+                    WidgetListItem::Book(b) => ListItem::new(WidgetWrapper::new(b.clone(), 5, 10)),
+                    // Creating the widget in the render closure is the recommended approach
+                    WidgetListItem::Gauge(g) => {
+                        let guage = Gauge::default()
+                            .block(Block::default().borders(Borders::ALL).title("Progress"))
+                            .gauge_style(
+                                Style::default()
+                                    .fg(Color::White)
+                                    .bg(Color::Black)
+                                    .add_modifier(Modifier::ITALIC),
+                            )
+                            .percent(*g);
+                        ListItem::new(WidgetWrapper::new(guage, 3, 10))
+                    }
+                })
+                .collect::<Vec<ListItem>>();
+            let list = List::new(items).highlight_symbol(">>").block(
+                Block::default()
+                    .title("Widget List Example")
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            );
+            frame.render_stateful_widget(list, frame.size(), &mut self.list.state);
+        })?;
+        Ok(())
+    }
+}
+
+struct WidgetList<'a> {
+    pub state: ListState,
+    pub items: Vec<WidgetListItem<'a>>,
+}
+
+enum WidgetListItem<'a> {
+    String(&'a str),
+    Raw(&'a str),
+    Styled(&'a str, Style),
+    Text(Text<'a>),
+    Paragraph(Paragraph<'a>),
+    Block(Block<'a>),
+    Book(BookWidget<'a>),
+    Gauge(u16),
+}
+
+struct BookWidget<'a> {
+    title: &'a str,
+    author: &'a str,
+    url: &'a str,
+}
+
+impl<'a> BookWidget<'a> {
+    pub fn new(title: &'a str, author: &'a str, url: &'a str) -> Self {
+        Self { title, author, url }
+    }
+}
+
+impl Widget for &BookWidget<'_> {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let contents = vec![
+            Line::from(vec![
+                Span::raw("Title: "),
+                Span::styled(self.title, Style::default()),
+            ]),
+            Line::from(vec![
+                Span::raw("Author: "),
+                Span::styled(self.author, Style::default()),
+            ]),
+            Line::from(vec![
+                Span::raw("URL: "),
+                Span::styled(
+                    self.url,
+                    Style::default()
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::UNDERLINED),
+                ),
+            ]),
+        ];
+        Paragraph::new(contents)
+            .block(
+                Block::default()
+                    .title(self.title)
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded),
+            )
+            .render(area, buf);
+    }
+}
+
+impl<'a> WidgetList<'a> {
+    fn with_items(items: Vec<WidgetListItem<'a>>) -> Self {
+        Self {
+            state: ListState::default(),
+            items: items,
+        }
+    }
+
+    /// select next item wrapping around
+    fn next(&mut self) {
+        let i = match self.state.selected() {
+            Some(i) => (i + 1) % self.items.len(),
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    // select previous item wrapping around
+    fn previous(&mut self) {
+        let i = match self.state.selected() {
+            Some(i) => (i + self.items.len() - 1) % self.items.len(),
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    fn unselect(&mut self) {
+        self.state.select(None);
+    }
+}

--- a/src/widgets/barchart.rs
+++ b/src/widgets/barchart.rs
@@ -127,10 +127,10 @@ impl<'a> BarChart<'a> {
 }
 
 impl<'a> Widget for BarChart<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
 
-        let chart_area = match self.block.take() {
+        let chart_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -250,7 +250,7 @@ impl<'a> Block<'a> {
 }
 
 impl<'a> Widget for Block<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         if area.area() == 0 {
             return;
         }
@@ -312,7 +312,7 @@ impl<'a> Widget for Block<'a> {
         }
 
         // Title
-        if let Some(title) = self.title {
+        if let Some(title) = &self.title {
             let left_border_dx = u16::from(self.borders.intersects(Borders::LEFT));
             let right_border_dx = u16::from(self.borders.intersects(Borders::RIGHT));
 
@@ -337,7 +337,7 @@ impl<'a> Widget for Block<'a> {
                 area.top()
             };
 
-            buf.set_line(title_x, title_y, &title, title_area_width);
+            buf.set_line(title_x, title_y, title, title_area_width);
         }
     }
 }

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -108,10 +108,10 @@ impl<'a, S: DateStyler> Monthly<'a, S> {
 }
 
 impl<'a, S: DateStyler> Widget for Monthly<'a, S> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         // Block is used for borders and such
         // Draw that first, and use the blank area inside the block for our own purposes
-        let mut area = match self.block.take() {
+        let mut area = match &self.block {
             None => area,
             Some(b) => {
                 let inner = b.inner(area);

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -443,8 +443,8 @@ impl<'a, F> Widget for Canvas<'a, F>
 where
     F: Fn(&mut Context),
 {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
-        let canvas_area = match self.block.take() {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let canvas_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -379,7 +379,7 @@ impl<'a> Chart<'a> {
     }
 
     fn render_x_labels(
-        &mut self,
+        &self,
         buf: &mut Buffer,
         layout: &ChartLayout,
         chart_area: Rect,
@@ -461,7 +461,7 @@ impl<'a> Chart<'a> {
     }
 
     fn render_y_labels(
-        &mut self,
+        &self,
         buf: &mut Buffer,
         layout: &ChartLayout,
         chart_area: Rect,
@@ -486,7 +486,7 @@ impl<'a> Chart<'a> {
 }
 
 impl<'a> Widget for Chart<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         if area.area() == 0 {
             return;
         }
@@ -496,7 +496,7 @@ impl<'a> Widget for Chart<'a> {
         // axis names).
         let original_style = buf.get(area.left(), area.top()).style();
 
-        let chart_area = match self.block.take() {
+        let chart_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);
@@ -580,7 +580,7 @@ impl<'a> Widget for Chart<'a> {
         }
 
         if let Some((x, y)) = layout.title_x {
-            let title = self.x_axis.title.unwrap();
+            let title = self.x_axis.title.as_ref().unwrap();
             let width = graph_area.right().saturating_sub(x);
             buf.set_style(
                 Rect {
@@ -591,11 +591,11 @@ impl<'a> Widget for Chart<'a> {
                 },
                 original_style,
             );
-            buf.set_line(x, y, &title, width);
+            buf.set_line(x, y, title, width);
         }
 
         if let Some((x, y)) = layout.title_y {
-            let title = self.y_axis.title.unwrap();
+            let title = self.y_axis.title.as_ref().unwrap();
             let width = graph_area.right().saturating_sub(x);
             buf.set_style(
                 Rect {
@@ -606,7 +606,7 @@ impl<'a> Widget for Chart<'a> {
                 },
                 original_style,
             );
-            buf.set_line(x, y, &title, width);
+            buf.set_line(x, y, title, width);
         }
     }
 }

--- a/src/widgets/clear.rs
+++ b/src/widgets/clear.rs
@@ -27,7 +27,7 @@ use crate::{buffer::Buffer, layout::Rect, widgets::Widget};
 pub struct Clear;
 
 impl Widget for Clear {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         for x in area.left()..area.right() {
             for y in area.top()..area.bottom() {
                 buf.get_mut(x, y).reset();

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -92,9 +92,9 @@ impl<'a> Gauge<'a> {
 }
 
 impl<'a> Widget for Gauge<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
-        let gauge_area = match self.block.take() {
+        let gauge_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);
@@ -111,7 +111,9 @@ impl<'a> Widget for Gauge<'a> {
         // label is put at the center of the gauge_area
         let label = {
             let pct = f64::round(self.ratio * 100.0);
-            self.label.unwrap_or_else(|| Span::from(format!("{pct}%")))
+            self.label
+                .clone()
+                .unwrap_or_else(|| Span::from(format!("{pct}%")))
         };
         let clamped_label_width = gauge_area.width.min(label.width() as u16);
         let label_col = gauge_area.left() + (gauge_area.width - clamped_label_width) / 2;
@@ -233,9 +235,9 @@ impl<'a> LineGauge<'a> {
 }
 
 impl<'a> Widget for LineGauge<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
-        let gauge_area = match self.block.take() {
+        let gauge_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);
@@ -251,6 +253,7 @@ impl<'a> Widget for LineGauge<'a> {
         let ratio = self.ratio;
         let label = self
             .label
+            .clone()
             .unwrap_or_else(move || Line::from(format!("{:.0}%", ratio * 100.0)));
         let (col, row) = buf.set_line(
             gauge_area.left(),

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -200,9 +200,9 @@ impl<'a> List<'a> {
 impl<'a> StatefulWidget for List<'a> {
     type State = ListState;
 
-    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         buf.set_style(area, self.style);
-        let list_area = match self.block.take() {
+        let list_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);
@@ -230,7 +230,7 @@ impl<'a> StatefulWidget for List<'a> {
         let has_selection = state.selected.is_some();
         for (i, item) in self
             .items
-            .iter_mut()
+            .iter()
             .enumerate()
             .skip(state.offset)
             .take(end - start)
@@ -284,7 +284,7 @@ impl<'a> StatefulWidget for List<'a> {
 }
 
 impl<'a> Widget for List<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         let mut state = ListState::default();
         StatefulWidget::render(self, area, buf, &mut state);
     }
@@ -417,7 +417,7 @@ mod tests {
     /// helper method to render a widget to an empty buffer with the default state
     fn render_widget(widget: List<'_>, width: u16, height: u16) -> Buffer {
         let mut buffer = Buffer::empty(Rect::new(0, 0, width, height));
-        Widget::render(widget, buffer.area, &mut buffer);
+        Widget::render(&widget, buffer.area, &mut buffer);
         buffer
     }
 
@@ -429,7 +429,7 @@ mod tests {
         height: u16,
     ) -> Buffer {
         let mut buffer = Buffer::empty(Rect::new(0, 0, width, height));
-        StatefulWidget::render(widget, buffer.area, &mut buffer, state);
+        StatefulWidget::render(&widget, buffer.area, &mut buffer, state);
         buffer
     }
 
@@ -440,11 +440,11 @@ mod tests {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
 
         // attempt to render into an area of the buffer with 0 width
-        Widget::render(list.clone(), Rect::new(0, 0, 0, 3), &mut buffer);
+        Widget::render(&list.clone(), Rect::new(0, 0, 0, 3), &mut buffer);
         assert_buffer_eq!(buffer, Buffer::empty(buffer.area));
 
         // attempt to render into an area of the buffer with 0 height
-        Widget::render(list.clone(), Rect::new(0, 0, 15, 0), &mut buffer);
+        Widget::render(&list.clone(), Rect::new(0, 0, 15, 0), &mut buffer);
         assert_buffer_eq!(buffer, Buffer::empty(buffer.area));
 
         let list = List::new(items)
@@ -452,7 +452,7 @@ mod tests {
             .block(Block::default().borders(Borders::all()));
         // attempt to render into an area of the buffer with zero height after
         // setting the block borders
-        Widget::render(list, Rect::new(0, 0, 15, 2), &mut buffer);
+        Widget::render(&list, Rect::new(0, 0, 15, 2), &mut buffer);
         assert_buffer_eq!(
             buffer,
             Buffer::with_lines(vec![
@@ -469,7 +469,7 @@ mod tests {
             let list = List::new(items.to_owned()).highlight_symbol(">>");
             let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 5));
 
-            Widget::render(list, buffer.area, &mut buffer);
+            Widget::render(&list, buffer.area, &mut buffer);
 
             let expected = Buffer::with_lines(expected_lines);
             assert_buffer_eq!(buffer, expected);
@@ -483,7 +483,7 @@ mod tests {
             let mut state = ListState::default().with_selected(selected);
             let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 5));
 
-            StatefulWidget::render(list, buffer.area, &mut buffer, &mut state);
+            StatefulWidget::render(&list, buffer.area, &mut buffer, &mut state);
 
             let expected = Buffer::with_lines(expected_lines);
             assert_buffer_eq!(buffer, expected);

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -38,7 +38,7 @@ pub use self::block::{Block, BorderType, Padding};
 pub use self::chart::{Axis, Chart, Dataset, GraphType};
 pub use self::clear::Clear;
 pub use self::gauge::{Gauge, LineGauge};
-pub use self::list::{List, ListItem, ListState};
+pub use self::list::{List, ListItem, ListState, WidgetWrapper};
 pub use self::paragraph::{Paragraph, Wrap};
 pub use self::sparkline::{RenderDirection, Sparkline};
 pub use self::table::{Cell, Row, Table, TableState};

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -133,9 +133,9 @@ impl<'a> Paragraph<'a> {
 }
 
 impl<'a> Widget for Paragraph<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
-        let text_area = match self.block.take() {
+        let text_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -89,8 +89,8 @@ impl<'a> Sparkline<'a> {
 }
 
 impl<'a> Widget for Sparkline<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
-        let spark_area = match self.block.take() {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let spark_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -375,12 +375,12 @@ impl TableState {
 impl<'a> StatefulWidget for Table<'a> {
     type State = TableState;
 
-    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         if area.area() == 0 {
             return;
         }
         buf.set_style(area, self.style);
-        let table_area = match self.block.take() {
+        let table_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);
@@ -437,7 +437,7 @@ impl<'a> StatefulWidget for Table<'a> {
         state.offset = start;
         for (i, table_row) in self
             .rows
-            .iter_mut()
+            .iter()
             .enumerate()
             .skip(state.offset)
             .take(end - start)
@@ -496,7 +496,7 @@ fn render_cell(buf: &mut Buffer, cell: &Cell, area: Rect) {
 }
 
 impl<'a> Widget for Table<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         let mut state = TableState::default();
         StatefulWidget::render(self, area, buf, &mut state);
     }

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -84,9 +84,9 @@ impl<'a> Tabs<'a> {
 }
 
 impl<'a> Widget for Tabs<'a> {
-    fn render(mut self, area: Rect, buf: &mut Buffer) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
-        let tabs_area = match self.block.take() {
+        let tabs_area = match &self.block {
             Some(b) => {
                 let inner_area = b.inner(area);
                 b.render(area, buf);
@@ -101,14 +101,14 @@ impl<'a> Widget for Tabs<'a> {
 
         let mut x = tabs_area.left();
         let titles_length = self.titles.len();
-        for (i, title) in self.titles.into_iter().enumerate() {
+        for (i, title) in self.titles.iter().enumerate() {
             let last_title = titles_length - 1 == i;
             x = x.saturating_add(1);
             let remaining_width = tabs_area.right().saturating_sub(x);
             if remaining_width == 0 {
                 break;
             }
-            let pos = buf.set_line(x, tabs_area.top(), &title, remaining_width);
+            let pos = buf.set_line(x, tabs_area.top(), title, remaining_width);
             if i == self.selected {
                 buf.set_style(
                     Rect {

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -96,7 +96,7 @@ fn widgets_list_should_truncate_items() {
         state.select(case.selected);
         terminal
             .draw(|f| {
-                let list = List::new(case.items.clone())
+                let list = List::new(case.items)
                     .block(Block::default().borders(Borders::RIGHT))
                     .highlight_symbol(">> ");
                 f.render_stateful_widget(list, Rect::new(0, 0, 8, 2), &mut state);


### PR DESCRIPTION
This is a WIP alternative to #155, built on top of #122.

Instead of creating a new widget list type, this PR extends the existing list type to allow it to render widgets as well as text (and does so without impacting existing code that uses lists).

The majority of this PR is from the the changes in #122, which make it possible to render widgets by ref rather than value.

This doesn't implement the widget sizing in #155 however (this is currently manual and TODO).

Ping @karthago1 for some thoughts.