### PR TITLE
feat(backend): add window size api

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -18,9 +18,10 @@ use crossterm::{
 };
 
 use crate::{
-    backend::{Backend, ClearType},
+    backend::{Backend, ClearType, WindowSize},
     buffer::Cell,
-    layout::Rect,
+    layout::Size,
+    prelude::Rect,
     style::{Color, Modifier},
 };
 
@@ -169,10 +170,24 @@ where
     }
 
     fn size(&self) -> io::Result<Rect> {
-        let (width, height) =
-            terminal::size().map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
-
+        let (width, height) = terminal::size()?;
         Ok(Rect::new(0, 0, width, height))
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, io::Error> {
+        let crossterm::terminal::WindowSize {
+            columns,
+            rows,
+            width,
+            height,
+        } = terminal::window_size()?;
+        Ok(WindowSize {
+            columns_rows: Size {
+                width: columns,
+                height: rows,
+            },
+            pixels: Size { width, height },
+        })
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -10,9 +10,9 @@ use std::{
 };
 
 use crate::{
-    backend::{Backend, ClearType},
+    backend::{Backend, ClearType, WindowSize},
     buffer::Cell,
-    layout::Rect,
+    prelude::Rect,
     style::{Color, Modifier},
 };
 
@@ -158,6 +158,13 @@ where
     fn size(&self) -> io::Result<Rect> {
         let terminal = termion::terminal_size()?;
         Ok(Rect::new(0, 0, terminal.0, terminal.1))
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, io::Error> {
+        Ok(WindowSize {
+            columns_rows: termion::terminal_size()?.into(),
+            pixels: termion::terminal_size_pixels()?.into(),
+        })
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -9,9 +9,9 @@ use std::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
-    backend::Backend,
+    backend::{Backend, WindowSize},
     buffer::{Buffer, Cell},
-    layout::Rect,
+    layout::{Rect, Size},
 };
 
 /// A backend used for the integration tests.
@@ -177,6 +177,18 @@ impl Backend for TestBackend {
 
     fn size(&self) -> Result<Rect, io::Error> {
         Ok(Rect::new(0, 0, self.width, self.height))
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, io::Error> {
+        // Some arbitrary window pixel size, probably doesn't need much testing.
+        static WINDOW_PIXEL_SIZE: Size = Size {
+            width: 640,
+            height: 480,
+        };
+        Ok(WindowSize {
+            columns_rows: (self.width, self.height).into(),
+            pixels: WINDOW_PIXEL_SIZE,
+        })
     }
 
     fn flush(&mut self) -> Result<(), io::Error> {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -647,6 +647,19 @@ fn try_split(area: Rect, layout: &Layout) -> Result<Rc<[Rect]>, AddConstraintErr
     Ok(results)
 }
 
+/// A simple size struct
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Size {
+    pub width: u16,
+    pub height: u16,
+}
+
+impl From<(u16, u16)> for Size {
+    fn from((width, height): (u16, u16)) -> Self {
+        Size { width, height }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use strum::ParseError;


### PR DESCRIPTION
Depends on https://github.com/crossterm-rs/crossterm/pull/790, and should update crossterm in an independent PR. Related to #215

For image (sixel, iTerm2, Kitty...) support that handles graphics in
terms of `Rect` so that the image area can be included in layouts.

For example: an image is loaded with a known pixel-size, and drawn, but
the image protocol has no mechanism of knowing the actual cell/character
area that been drawn on. It is then impossible to skip overdrawing the
area.

Returning the window size in pixel-width / pixel-height, together with
colums / rows, it can be possible to account the pixel size of each cell
/ character, and then known the `Rect` of a given image, and also resize
the image so that it fits exactly in a `Rect` and avoid artifacts.

![image](https://github.com/tui-rs-revival/ratatui/assets/310215/6271814b-3d4f-4cd0-ad9e-f810e54b9f59)
