### PR TITLE
feat: simplify backend and terminal creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ unicode-width = "0.1"
 [dev-dependencies]
 anyhow = "1.0.71"
 argh = "0.1"
+better-panic = "0.3.0"
 cargo-husky = { version = "1.5.0", default-features = false, features = [
   "user-hooks",
 ] }
@@ -60,6 +61,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 fakeit = "1.1"
 rand = "0.8"
 pretty_assertions = "1.4.0"
+serial_test = "2.0.0"
 
 [[bench]]
 name = "block"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ project.
 [![Crates.io](https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square)](https://crates.io/crates/ratatui)
 [![License](https://img.shields.io/crates/l/ratatui?style=flat-square)](./LICENSE) [![GitHub CI
 Status](https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github)](https://github.com/ratatui-org/ratatui/actions?query=workflow%3ACI+)
-[![Docs.rs](https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square)](https://docs.rs/crate/ratatui/)  
+[![Docs.rs](https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square)](https://docs.rs/crate/ratatui/)\
 [![Dependency
 Status](https://deps.rs/repo/github/ratatui-org/ratatui/status.svg?style=flat-square)](https://deps.rs/repo/github/ratatui-org/ratatui)
 [![Codecov](https://img.shields.io/codecov/c/github/ratatui-org/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST)](https://app.codecov.io/gh/ratatui-org/ratatui)
@@ -94,30 +94,16 @@ the [Docs](https://docs.rs/ratatui) and [Examples](#examples). There is also a s
 available at [rust-tui-template](https://github.com/ratatui-org/rust-tui-template).
 
 ```rust
-fn main() -> Result<(), Box<dyn Error>> {
-    let mut terminal = setup_terminal()?;
-    run(&mut terminal)?;
-    restore_terminal(&mut terminal)?;
-    Ok(())
-}
+use std::time::Duration;
 
-fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>, Box<dyn Error>> {
-    let mut stdout = io::stdout();
-    enable_raw_mode()?;
-    execute!(stdout, EnterAlternateScreen)?;
-    Ok(Terminal::new(CrosstermBackend::new(stdout))?)
-}
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
+use ratatui::{prelude::*, widgets::Paragraph};
 
-fn restore_terminal(
-    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-) -> Result<(), Box<dyn Error>> {
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen,)?;
-    Ok(terminal.show_cursor()?)
-}
-
-fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<(), Box<dyn Error>> {
-    Ok(loop {
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
+    let mut terminal = Terminal::new(backend)?;
+    loop {
         terminal.draw(|frame| {
             let greeting = Paragraph::new("Hello World!");
             frame.render_widget(greeting, frame.size());
@@ -125,11 +111,11 @@ fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<(), Box<dyn 
         if event::poll(Duration::from_millis(250))? {
             if let Event::Key(key) = event::read()? {
                 if KeyCode::Char('q') == key.code {
-                    break;
+                    return Ok(());
                 }
             }
         }
-    })
+    }
 }
 ```
 
@@ -220,8 +206,8 @@ be installed with `cargo install cargo-make`).
   `tui::text::Text`
 * [color-to-tui](https://github.com/uttarayan21/color-to-tui) — Parse hex colors to
   `tui::style::Color`
-* [rust-tui-template](https://github.com/ratatui-org/rust-tui-template) — A template for bootstrapping a
-  Rust TUI application with Tui-rs & crossterm
+* [rust-tui-template](https://github.com/ratatui-org/rust-tui-template) — A template for
+  bootstrapping a Rust TUI application with Tui-rs & crossterm
 * [simple-tui-rs](https://github.com/pmsanford/simple-tui-rs) — A simple example tui-rs app
 * [tui-builder](https://github.com/jkelleyrtp/tui-builder) — Batteries-included MVC framework for
   Tui-rs + Crossterm apps

--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, widgets::Paragraph};
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout();
     loop {
         terminal.draw(|frame| {
             let greeting = Paragraph::new("Hello World!");

--- a/bacon.toml
+++ b/bacon.toml
@@ -12,44 +12,84 @@ command = ["cargo", "check", "--all-features", "--color", "always"]
 need_stdout = false
 
 [jobs.check-all]
-command = ["cargo", "check", "--all-targets", "--all-features", "--color", "always"]
+command = [
+    "cargo",
+    "check",
+    "--all-targets",
+    "--all-features",
+    "--color",
+    "always",
+]
 need_stdout = false
 
 [jobs.check-crossterm]
-command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "crossterm"]
+command = [
+    "cargo",
+    "check",
+    "--color",
+    "always",
+    "--all-targets",
+    "--no-default-features",
+    "--features",
+    "crossterm",
+]
 need_stdout = false
 
 [jobs.check-termion]
-command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "termion"]
+command = [
+    "cargo",
+    "check",
+    "--color",
+    "always",
+    "--all-targets",
+    "--no-default-features",
+    "--features",
+    "termion",
+]
 need_stdout = false
 
 [jobs.check-termwiz]
-command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "termwiz"]
+command = [
+    "cargo",
+    "check",
+    "--color",
+    "always",
+    "--all-targets",
+    "--no-default-features",
+    "--features",
+    "termwiz",
+]
 need_stdout = false
 
 [jobs.clippy]
-command = [
-    "cargo", "clippy",
-    "--all-targets",
-    "--color", "always",
-]
+command = ["cargo", "clippy", "--all-targets", "--color", "always"]
 need_stdout = false
 
 [jobs.test]
 command = [
-    "cargo", "test",
+    "cargo",
+    "test",
     "--all-features",
-    "--color", "always",
-    "--", "--color", "always", # see https://github.com/Canop/bacon/issues/124
+    "--color",
+    "always",
+    "--",
+    "--skip",
+    "terminal_builder::tests::termion", # competes with bacon for the terminal
+    "--color",
+    "always",                           # see https://github.com/Canop/bacon/issues/124
 ]
 need_stdout = true
 
 [jobs.doc]
 command = [
-    "cargo", "+nightly", "doc",
-    "-Zunstable-options", "-Zrustdoc-scrape-examples",
+    "cargo",
+    "+nightly",
+    "doc",
+    "-Zunstable-options",
+    "-Zrustdoc-scrape-examples",
     "--all-features",
-    "--color", "always",
+    "--color",
+    "always",
     "--no-deps",
 ]
 env.RUSTDOCFLAGS = "--cfg docsrs"
@@ -59,10 +99,14 @@ need_stdout = false
 # to the previous job
 [jobs.doc-open]
 command = [
-    "cargo", "+nightly", "doc",
-    "-Zunstable-options", "-Zrustdoc-scrape-examples",
+    "cargo",
+    "+nightly",
+    "doc",
+    "-Zunstable-options",
+    "-Zrustdoc-scrape-examples",
     "--all-features",
-    "--color", "always",
+    "--color",
+    "always",
     "--no-deps",
     "--open",
 ]
@@ -72,19 +116,27 @@ on_success = "job:doc" # so that we don't open the browser at each change
 
 [jobs.coverage]
 command = [
-    "cargo", "llvm-cov",
-    "--lcov", "--output-path", "target/lcov.info",
-    "--all-features", 
-    "--color", "always",
+    "cargo",
+    "llvm-cov",
+    "--lcov",
+    "--output-path",
+    "target/lcov.info",
+    "--all-features",
+    "--color",
+    "always",
 ]
 
 [jobs.coverage-unit-tests-only]
 command = [
-    "cargo", "llvm-cov",
-    "--lcov", "--output-path", "target/lcov.info",
+    "cargo",
+    "llvm-cov",
+    "--lcov",
+    "--output-path",
+    "target/lcov.info",
     "--lib",
     "--all-features",
-    "--color", "always",
+    "--color",
+    "always",
 ]
 
 # You may define here keybindings that would be specific to

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -75,8 +75,7 @@ impl<'a> App<'a> {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let tick_rate = Duration::from_millis(250);
     let mut app = App::new();

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -1,14 +1,7 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, widgets::*};
 
 struct Company<'a> {
@@ -81,40 +74,13 @@ impl<'a> App<'a> {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
     let tick_rate = Duration::from_millis(250);
-    let app = App::new();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui(f, &app))?;

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -14,11 +14,9 @@ use ratatui::{
 // These type aliases are used to make the code more readable by reducing repetition of the generic
 // types. They are not necessary for the functionality of the code.
 type Frame<'a> = ratatui::Frame<'a, CrosstermBackend<Stdout>>;
-type Terminal = ratatui::Terminal<CrosstermBackend<Stdout>>;
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     loop {
         terminal.draw(ui)?;

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -1,15 +1,7 @@
-use std::{
-    error::Error,
-    io::{stdout, Stdout},
-    ops::ControlFlow,
-    time::Duration,
-};
+use std::{io::Stdout, ops::ControlFlow, time::Duration};
 
-use crossterm::{
-    event::{self, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use itertools::Itertools;
 use ratatui::{
     prelude::*,
@@ -23,35 +15,11 @@ use ratatui::{
 // types. They are not necessary for the functionality of the code.
 type Frame<'a> = ratatui::Frame<'a, CrosstermBackend<Stdout>>;
 type Terminal = ratatui::Terminal<CrosstermBackend<Stdout>>;
-type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 fn main() -> Result<()> {
-    let mut terminal = setup_terminal()?;
-    let result = run(&mut terminal);
-    restore_terminal(terminal)?;
+    let backend = CrosstermBackend::on_stdout()?;
+    let mut terminal = Terminal::new(backend)?;
 
-    if let Err(err) = result {
-        eprintln!("{err:?}");
-    }
-    Ok(())
-}
-
-fn setup_terminal() -> Result<Terminal> {
-    enable_raw_mode()?;
-    let mut stdout = stdout();
-    execute!(stdout, EnterAlternateScreen)?;
-    let backend = CrosstermBackend::new(stdout);
-    let terminal = Terminal::new(backend)?;
-    Ok(terminal)
-}
-
-fn restore_terminal(mut terminal: Terminal) -> Result<()> {
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    Ok(())
-}
-
-fn run(terminal: &mut Terminal) -> Result<()> {
     loop {
         terminal.draw(ui)?;
         if handle_events()?.is_break() {

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -6,8 +6,7 @@ use ratatui::{prelude::*, widgets::calendar::*};
 use time::{Date, Month, OffsetDateTime};
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     loop {
         let _ = terminal.draw(|f| draw(f));

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -1,18 +1,12 @@
-use std::{error::Error, io, rc::Rc};
+use std::rc::Rc;
 
-use crossterm::{
-    event::{self, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, widgets::calendar::*};
 use time::{Date, Month, OffsetDateTime};
 
-fn main() -> Result<(), Box<dyn Error>> {
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
     loop {
@@ -22,17 +16,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             #[allow(clippy::single_match)]
             match key.code {
                 KeyCode::Char(_) => {
-                    break;
+                    return Ok(());
                 }
                 _ => {}
             };
         }
     }
-
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
-    Ok(())
 }
 
 fn draw<B: Backend>(f: &mut Frame<B>) {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -79,9 +79,7 @@ impl App {
 }
 
 fn main() -> Result<()> {
-    // setup terminal
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let tick_rate = Duration::from_millis(250);
     let mut app = App::new();

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -1,14 +1,7 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{
     prelude::*,
     widgets::{canvas::*, *},
@@ -85,40 +78,14 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
     let tick_rate = Duration::from_millis(250);
-    let app = App::new();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui(f, &app))?;

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -1,14 +1,7 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, widgets::*};
 
 const DATA: [(f64, f64); 5] = [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0)];
@@ -87,40 +80,13 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
     let tick_rate = Duration::from_millis(250);
-    let app = App::new();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui(f, &app))?;
@@ -128,7 +94,7 @@ fn run_app<B: Backend>(
         let timeout = tick_rate
             .checked_sub(last_tick.elapsed())
             .unwrap_or_else(|| Duration::from_secs(0));
-        if crossterm::event::poll(timeout)? {
+        if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 if let KeyCode::Char('q') = key.code {
                     return Ok(());

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -81,8 +81,7 @@ impl App {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let tick_rate = Duration::from_millis(250);
     let mut app = App::new();

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -20,8 +20,7 @@ impl<'a> Label<'a> {
 }
 
 fn main() -> anyhow::Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     loop {
         terminal.draw(ui)?;

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -1,10 +1,4 @@
-use std::{error::Error, io};
-
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, widgets::*};
 
 #[derive(Default)]
@@ -25,34 +19,10 @@ impl<'a> Label<'a> {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> anyhow::Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
-    let res = run_app(&mut terminal);
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> io::Result<()> {
     loop {
         terminal.draw(ui)?;
 

--- a/examples/demo/crossterm.rs
+++ b/examples/demo/crossterm.rs
@@ -1,51 +1,15 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::prelude::*;
 
 use crate::{app::App, ui};
 
-pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> anyhow::Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
+    let mut app = App::new("Crossterm Demo", enhanced_graphics);
 
-    // create app and run it
-    let app = App::new("Crossterm Demo", enhanced_graphics);
-    let res = run_app(&mut terminal, app, tick_rate);
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui::draw(f, &mut app))?;

--- a/examples/demo/crossterm.rs
+++ b/examples/demo/crossterm.rs
@@ -6,8 +6,8 @@ use ratatui::prelude::*;
 use crate::{app::App, ui};
 
 pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> anyhow::Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
+
     let mut app = App::new("Crossterm Demo", enhanced_graphics);
 
     let mut last_tick = Instant::now();

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -27,10 +27,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let cli: Cli = argh::from_env();
     let tick_rate = Duration::from_millis(cli.tick_rate);
     #[cfg(feature = "crossterm")]
-    crate::crossterm::run(tick_rate, cli.enhanced_graphics)?;
+    crossterm::run(tick_rate, cli.enhanced_graphics)?;
     #[cfg(feature = "termion")]
-    crate::termion::run(tick_rate, cli.enhanced_graphics)?;
+    termion::run(tick_rate, cli.enhanced_graphics)?;
     #[cfg(feature = "termwiz")]
-    crate::termwiz::run(tick_rate, cli.enhanced_graphics)?;
+    termwiz::run(tick_rate, cli.enhanced_graphics)?;
     Ok(())
 }

--- a/examples/demo/termion.rs
+++ b/examples/demo/termion.rs
@@ -1,39 +1,17 @@
-use std::{error::Error, io, sync::mpsc, thread, time::Duration};
+use std::{io::stdin, sync::mpsc, thread, time::Duration};
 
+use anyhow::Result;
 use ratatui::prelude::*;
-use termion::{
-    event::Key,
-    input::{MouseTerminal, TermRead},
-    raw::IntoRawMode,
-    screen::IntoAlternateScreen,
-};
+use termion::{event::Key, input::TermRead};
 
 use crate::{app::App, ui};
 
-pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    let stdout = io::stdout()
-        .into_raw_mode()
-        .unwrap()
-        .into_alternate_screen()
-        .unwrap();
-    let stdout = MouseTerminal::from(stdout);
-    let backend = TermionBackend::new(stdout);
+pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<()> {
+    let backend = TermionBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
-
-    // create app and run it
-    let app = App::new("Termion demo", enhanced_graphics);
-    run_app(&mut terminal, app, tick_rate)?;
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> Result<(), Box<dyn Error>> {
+    let mut app = App::new("Termion demo", enhanced_graphics);
     let events = events(tick_rate);
+
     loop {
         terminal.draw(|f| ui::draw(f, &mut app))?;
 
@@ -63,7 +41,7 @@ fn events(tick_rate: Duration) -> mpsc::Receiver<Event> {
     let (tx, rx) = mpsc::channel();
     let keys_tx = tx.clone();
     thread::spawn(move || {
-        let stdin = io::stdin();
+        let stdin = stdin();
         for key in stdin.keys().flatten() {
             if let Err(err) = keys_tx.send(Event::Input(key)) {
                 eprintln!("{err}");

--- a/examples/demo/termion.rs
+++ b/examples/demo/termion.rs
@@ -7,8 +7,7 @@ use termion::{event::Key, input::TermRead};
 use crate::{app::App, ui};
 
 pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<()> {
-    let backend = TermionBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::termion_on_stdout().build()?;
     let mut app = App::new("Termion demo", enhanced_graphics);
     let events = events(tick_rate);
 

--- a/examples/demo/termwiz.rs
+++ b/examples/demo/termwiz.rs
@@ -1,6 +1,5 @@
 use std::{
     error::Error,
-    io,
     time::{Duration, Instant},
 };
 
@@ -15,24 +14,8 @@ pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn E
     terminal.hide_cursor()?;
 
     // create app and run it
-    let app = App::new("Termwiz Demo", enhanced_graphics);
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::new("Termwiz Demo", enhanced_graphics);
 
-    terminal.show_cursor()?;
-    terminal.flush()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app(
-    terminal: &mut Terminal<TermwizBackend>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui::draw(f, &mut app))?;
@@ -40,30 +23,7 @@ fn run_app(
         let timeout = tick_rate
             .checked_sub(last_tick.elapsed())
             .unwrap_or_else(|| Duration::from_secs(0));
-        if let Ok(Some(input)) = terminal
-            .backend_mut()
-            .buffered_terminal_mut()
-            .terminal()
-            .poll_input(Some(timeout))
-        {
-            match input {
-                InputEvent::Key(key_code) => match key_code.key {
-                    KeyCode::UpArrow => app.on_up(),
-                    KeyCode::DownArrow => app.on_down(),
-                    KeyCode::LeftArrow => app.on_left(),
-                    KeyCode::RightArrow => app.on_right(),
-                    KeyCode::Char(c) => app.on_key(c),
-                    _ => {}
-                },
-                InputEvent::Resized { cols, rows } => {
-                    terminal
-                        .backend_mut()
-                        .buffered_terminal_mut()
-                        .resize(cols, rows);
-                }
-                _ => {}
-            }
-        }
+        handle_events(&mut terminal, timeout, &mut app);
 
         if last_tick.elapsed() >= tick_rate {
             app.on_tick();
@@ -71,6 +31,33 @@ fn run_app(
         }
         if app.should_quit {
             return Ok(());
+        }
+    }
+}
+
+fn handle_events(terminal: &mut Terminal<TermwizBackend>, timeout: Duration, app: &mut App<'_>) {
+    if let Ok(Some(input)) = terminal
+        .backend_mut()
+        .buffered_terminal_mut()
+        .terminal()
+        .poll_input(Some(timeout))
+    {
+        match input {
+            InputEvent::Key(key_code) => match key_code.key {
+                KeyCode::UpArrow => app.on_up(),
+                KeyCode::DownArrow => app.on_down(),
+                KeyCode::LeftArrow => app.on_left(),
+                KeyCode::RightArrow => app.on_right(),
+                KeyCode::Char(c) => app.on_key(c),
+                _ => {}
+            },
+            InputEvent::Resized { cols, rows } => {
+                terminal
+                    .backend_mut()
+                    .buffered_terminal_mut()
+                    .resize(cols, rows);
+            }
+            _ => {}
         }
     }
 }

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -1,14 +1,7 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, widgets::*};
 
 struct App {
@@ -48,40 +41,13 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
     let tick_rate = Duration::from_millis(250);
-    let app = App::new();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui(f, &app))?;

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -42,8 +42,7 @@ impl App {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let tick_rate = Duration::from_millis(250);
     let mut app = App::new();

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -13,8 +13,7 @@ use ratatui::{prelude::*, widgets::*};
 /// events or update the application state. It just draws a greeting and exits when the user
 /// presses 'q'.
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
     run(&mut terminal)
 }
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,14 +1,7 @@
-use std::{
-    io::{self, Stdout},
-    time::Duration,
-};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
-use crossterm::{
-    event::{self, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, widgets::*};
 
 /// This is a bare minimum example. There are many approaches to running an application loop, so
@@ -20,36 +13,16 @@ use ratatui::{prelude::*, widgets::*};
 /// events or update the application state. It just draws a greeting and exits when the user
 /// presses 'q'.
 fn main() -> Result<()> {
-    let mut terminal = setup_terminal().context("setup failed")?;
-    run(&mut terminal).context("app loop failed")?;
-    restore_terminal(&mut terminal).context("restore terminal failed")?;
-    Ok(())
-}
-
-/// Setup the terminal. This is where you would enable raw mode, enter the alternate screen, and
-/// hide the cursor. This example does not handle errors. A more robust application would probably
-/// want to handle errors and ensure that the terminal is restored to a sane state before exiting.
-fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
-    let mut stdout = io::stdout();
-    enable_raw_mode().context("failed to enable raw mode")?;
-    execute!(stdout, EnterAlternateScreen).context("unable to enter alternate screen")?;
-    Terminal::new(CrosstermBackend::new(stdout)).context("creating terminal failed")
-}
-
-/// Restore the terminal. This is where you disable raw mode, leave the alternate screen, and show
-/// the cursor.
-fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
-    disable_raw_mode().context("failed to disable raw mode")?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)
-        .context("unable to switch to main screen")?;
-    terminal.show_cursor().context("unable to show cursor")
+    let backend = CrosstermBackend::on_stdout()?;
+    let mut terminal = Terminal::new(backend)?;
+    run(&mut terminal)
 }
 
 /// Run the application loop. This is where you would handle events and update the application
 /// state. This example exits when the user presses 'q'. Other styles of application loops are
 /// possible, for example, you could have multiple application states and switch between them based
 /// on events, or you could have a single application state and update it based on events.
-fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+fn run<B: Backend>(terminal: &mut Terminal<B>) -> Result<()> {
     loop {
         terminal.draw(crate::render_app)?;
         if should_quit()? {
@@ -61,7 +34,7 @@ fn run(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
 
 /// Render the application. This is where you would draw the application UI. This example just
 /// draws a greeting.
-fn render_app(frame: &mut ratatui::Frame<CrosstermBackend<Stdout>>) {
+fn render_app<B: Backend>(frame: &mut ratatui::Frame<B>) {
     let greeting = Paragraph::new("Hello World! (press 'q' to quit)");
     frame.render_widget(greeting, frame.size());
 }

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::{BTreeMap, VecDeque},
-    error::Error,
-    io,
+    io::stdout,
     sync::mpsc,
     thread,
     time::{Duration, Instant},
 };
 
+use anyhow::Result;
 use rand::distributions::{Distribution, Uniform};
 use ratatui::{prelude::*, widgets::*};
 
@@ -63,10 +63,8 @@ struct Worker {
     tx: mpsc::Sender<Download>,
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    crossterm::terminal::enable_raw_mode()?;
-    let stdout = io::stdout();
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::new(stdout()).with_raw_mode()?;
     let mut terminal = Terminal::with_options(
         backend,
         TerminalOptions {
@@ -86,9 +84,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     run_app(&mut terminal, workers, downloads, rx)?;
 
-    crossterm::terminal::disable_raw_mode()?;
     terminal.clear()?;
-
     Ok(())
 }
 
@@ -160,7 +156,7 @@ fn run_app<B: Backend>(
     workers: Vec<Worker>,
     mut downloads: Downloads,
     rx: mpsc::Receiver<Event>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let mut redraw = true;
     loop {
         if redraw {

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,13 +1,11 @@
-use std::{error::Error, io};
-
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode};
 use itertools::Itertools;
 use ratatui::{layout::Constraint::*, prelude::*, widgets::*};
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
+
     loop {
         terminal.draw(|f| ui(f))?;
         if let Event::Key(key) = event::read()? {

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,44 +1,15 @@
 use std::{error::Error, io};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use itertools::Itertools;
 use ratatui::{layout::Constraint::*, prelude::*, widgets::*};
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
-
-    // create app and run it
-    let res = run_app(&mut terminal);
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f))?;
-
         if let Event::Key(key) = event::read()? {
             if let KeyCode::Char('q') = key.code {
                 return Ok(());

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,14 +1,7 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
 struct StatefulList<T> {
@@ -137,40 +130,12 @@ impl<'a> App<'a> {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
     let tick_rate = Duration::from_millis(250);
-    let app = App::new();
-    let res = run_app(&mut terminal, app, tick_rate);
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
+    let mut app = App::new();
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui(f, &mut app))?;

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -131,8 +131,7 @@ impl<'a> App<'a> {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let tick_rate = Duration::from_millis(250);
     let mut app = App::new();

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -20,10 +20,11 @@ struct App {
 
 impl App {
     fn chain_hook(&mut self) {
+        better_panic::install();
         let original_hook = std::panic::take_hook();
 
         std::panic::set_hook(Box::new(move |panic| {
-            let mut backend = CrosstermBackend::on_stdout().unwrap();
+            let mut backend = CrosstermBackend::on_stdout();
             backend.leave_alternate_screen().unwrap();
             backend.disable_raw_mode().unwrap();
             original_hook(panic);
@@ -34,8 +35,7 @@ impl App {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let mut app = App::default();
     run_tui(&mut terminal, &mut app)

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -1,14 +1,7 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, widgets::*};
 
 struct App {
@@ -26,40 +19,13 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
     let tick_rate = Duration::from_millis(250);
-    let app = App::new();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui(f, &app))?;

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -20,8 +20,7 @@ impl App {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let tick_rate = Duration::from_millis(250);
     let mut app = App::new();

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -13,8 +13,7 @@ impl App {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     // create app and run it
     let mut app = App::new();

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -1,10 +1,5 @@
-use std::{error::Error, io};
-
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
 struct App {
@@ -17,35 +12,13 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
     // create app and run it
-    let app = App::new();
-    let res = run_app(&mut terminal, app);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, &app))?;
 

--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -13,8 +13,7 @@ struct App {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let tick_rate = Duration::from_millis(250);
     let mut app = App::default();

--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -1,14 +1,7 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use ratatui::{prelude::*, symbols::scrollbar, widgets::*};
 
 #[derive(Default)]
@@ -19,40 +12,13 @@ struct App {
     pub horizontal_scroll: usize,
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
     let tick_rate = Duration::from_millis(250);
-    let app = App::default();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::default();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui(f, &mut app))?;

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -65,8 +65,7 @@ impl App {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let tick_rate = Duration::from_millis(250);
     let mut app = App::new();

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -1,14 +1,7 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
 use rand::{
     distributions::{Distribution, Uniform},
     rngs::ThreadRng,
@@ -71,40 +64,13 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
     let tick_rate = Duration::from_millis(250);
-    let app = App::new();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|f| ui(f, &app))?;

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -1,10 +1,5 @@
-use std::{error::Error, io};
-
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
 struct App<'a> {
@@ -68,35 +63,12 @@ impl<'a> App<'a> {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
-    let app = App::new();
-    let res = run_app(&mut terminal, app);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, &mut app))?;
 

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -64,8 +64,7 @@ impl<'a> App<'a> {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let mut app = App::new();
 

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -29,8 +29,7 @@ impl<'a> App<'a> {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 
     let mut app = App::new();
 

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -1,10 +1,5 @@
-use std::{error::Error, io};
-
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
 struct App<'a> {
@@ -33,35 +28,12 @@ impl<'a> App<'a> {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
 
-    // create app and run it
-    let app = App::new();
-    let res = run_app(&mut terminal, app);
+    let mut app = App::new();
 
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, &app))?;
 

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -1,5 +1,3 @@
-use std::{error::Error, io};
-
 /// A simple example demonstrating how to handle user input. This is
 /// a bit out of the scope of the library as it does not provide any
 /// input handling out of the box. However, it may helps some to get
@@ -14,11 +12,8 @@ use std::{error::Error, io};
 ///   messages.
 /// **Note: ** as this is a relatively simple example unicode characters are unsupported and
 /// their use will result in undefined behaviour.
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
 enum InputMode {
@@ -103,35 +98,11 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+fn main() -> Result<()> {
+    let backend = CrosstermBackend::on_stdout()?;
     let mut terminal = Terminal::new(backend)?;
+    let mut app = App::default();
 
-    // create app and run it
-    let app = App::default();
-    let res = run_app(&mut terminal, app);
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, &app))?;
 

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -99,8 +99,8 @@ impl App {
 }
 
 fn main() -> Result<()> {
-    let backend = CrosstermBackend::on_stdout()?;
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
+
     let mut app = App::default();
 
     loop {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,7 +15,7 @@
 //! ```rust,no_run
 //! use ratatui::backend::{Backend, CrosstermBackend};
 //!
-//! let mut backend = CrosstermBackend::on_stdout()?;
+//! let mut backend = CrosstermBackend::on_stdout();
 //! backend.clear()?;
 //! # std::io::Result::Ok(())
 //! ```
@@ -209,7 +209,7 @@ pub trait Backend {
     ///
     /// ```rust,no_run
     /// # use ratatui::backend::{Backend, CrosstermBackend};
-    /// let mut backend = CrosstermBackend::on_stdout()?;
+    /// let mut backend = CrosstermBackend::on_stdout();
     /// backend.clear()?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -230,7 +230,7 @@ pub trait Backend {
     /// ```rust,no_run
     /// use ratatui::backend::{Backend, CrosstermBackend, ClearType};
     ///
-    /// let mut backend = CrosstermBackend::on_stdout()?;
+    /// let mut backend = CrosstermBackend::on_stdout();
     /// backend.clear_region(ClearType::All)?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -262,7 +262,7 @@ pub trait Backend {
     ///
     /// ```rust,no_run
     /// # use ratatui::backend::{Backend, CrosstermBackend};
-    /// let mut backend = CrosstermBackend::on_stdout()?;
+    /// let mut backend = CrosstermBackend::on_stdout();
     /// let size = backend.size()?;
     /// # std::io::Result::Ok(())
     /// ```

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -42,37 +42,6 @@ pub struct TermwizBackend {
     buffered_terminal: BufferedTerminal<SystemTerminal>,
 }
 
-impl Default for TermwizBackend {
-    /// Creates a new Termwiz backend instance with the default configuration.
-    ///
-    /// Note that this function will panic if it is unable to query the terminal capabilities, or
-    /// if it is unable to create the system or buffered terminal.
-    ///
-    /// See [`TermwizBackend::new`] for a version of this function that returns an error instead of
-    /// panicking.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use ratatui::backend::{Backend, TermwizBackend};
-    /// let backend = TermwizBackend::default();
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if it is unable to query the terminal capabilities, or if it is
-    /// unable to create the system or buffered terminal.
-    fn default() -> Self {
-        let caps = Capabilities::new_from_env().expect("unable to query capabilities");
-        let terminal = SystemTerminal::new(caps).expect("unable to create terminal");
-        let terminal = BufferedTerminal::new(terminal).expect("failed to create buffered terminal");
-        Self {
-            buffered_terminal: terminal,
-        }
-    }
-}
-
 impl TermwizBackend {
     /// Creates a new Termwiz backend instance.
     ///

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -14,7 +14,8 @@ use crate::{
     layout::Rect,
 };
 
-/// A backend used for the integration tests.
+/// A [`Backend`] implementation used for integration testing that that renders to an in memory
+/// buffer.
 ///
 /// # Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,11 +73,10 @@
 //! such as clearing the screen, hiding the cursor, etc.
 //!
 //! ```rust,no_run
-//! use ratatui::{backend::CrosstermBackend, Terminal};
+//! use ratatui::TerminalBuilder;
 //!
 //! fn main() -> std::io::Result<()> {
-//!     let backend = CrosstermBackend::on_stdout()?;
-//!     let mut terminal = Terminal::new(backend)?;
+//!     let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 //!     Ok(())
 //! }
 //! ```
@@ -107,8 +106,7 @@
 //! };
 //!
 //! fn main() -> io::Result<()> {
-//!     let backend = CrosstermBackend::on_stdout()?;
-//!     let mut terminal = Terminal::new(backend)?;
+//!     let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 //!
 //!     terminal.draw(|frame| {
 //!         let size = frame.size();
@@ -208,6 +206,7 @@ pub mod layout;
 pub mod style;
 pub mod symbols;
 pub mod terminal;
+mod terminal_builder;
 pub mod text;
 pub mod widgets;
 
@@ -215,3 +214,5 @@ pub mod prelude;
 
 #[doc(inline)]
 pub use self::terminal::{CompletedFrame, Frame, Terminal, TerminalOptions, Viewport};
+#[doc(inline)]
+pub use self::terminal_builder::{AlternateScreenMode, MouseCapture, RawMode, TerminalBuilder};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,4 +32,5 @@ pub use crate::{
     symbols::{self, Marker},
     terminal::{self, Frame, Terminal, TerminalOptions, Viewport},
     text::{self, Line, Masked, Span, Text},
+    AlternateScreenMode, MouseCapture, RawMode, TerminalBuilder,
 };

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -12,11 +12,10 @@
 //! # Examples
 //!
 //! ```no_run
-//! use ratatui::{Terminal, backend::CrosstermBackend};
+//! use ratatui::TerminalBuilder;
 //! # use crossterm::event::{read, Event, KeyCode};
 //!
-//! let backend = CrosstermBackend::on_stdout()?;
-//! let mut terminal = Terminal::new(backend)?;
+//! let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 //!
 //! terminal.draw(|frame| {
 //!    // Draw things here
@@ -106,17 +105,16 @@ pub struct TerminalOptions {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ratatui::{Terminal, backend::CrosstermBackend, widgets::Paragraph};
+/// use ratatui::{TerminalBuilder, widgets::Paragraph};
 ///
-/// let backend = CrosstermBackend::on_stdout()?;
-/// let mut terminal = Terminal::new(backend)?;
+/// let mut terminal = TerminalBuilder::crossterm_on_stdout().build()?;
 ///
 /// terminal.draw(|frame| {
 ///     frame.render_widget(Paragraph::new("Hello World!"), frame.size());
 /// })?;
 /// # std::io::Result::Ok(())
 /// ```
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Terminal<B>
 where
     B: Backend,
@@ -622,10 +620,7 @@ fn compute_inline_size<B: Backend>(
 
 #[cfg(test)]
 mod tests {
-    use std::io::Stdout;
-
     use super::*;
-    use crate::prelude::*;
 
     #[test]
     fn viewport_to_string() {
@@ -635,17 +630,5 @@ mod tests {
             Viewport::Fixed(Rect::new(0, 0, 5, 5)).to_string(),
             "Fixed(5x5+0+0)"
         );
-    }
-
-    #[test]
-    #[cfg(feature = "crossterm")]
-    fn crossterm_default() {
-        let _terminal = Terminal::<CrosstermBackend<Stdout>>::default();
-    }
-
-    #[test]
-    #[cfg(feature = "termion")]
-    fn termion_default() {
-        let _terminal = Terminal::<TermionBackend<Stdout>>::default();
     }
 }

--- a/src/terminal_builder.rs
+++ b/src/terminal_builder.rs
@@ -1,0 +1,386 @@
+#[allow(unused_imports)]
+use std::io::{self, stderr, stdout, Stderr, Stdout, Write};
+
+use crate::{
+    backend::{self},
+    Terminal,
+};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum RawMode {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum AlternateScreenMode {
+    #[default]
+    EnterAlternateScreen,
+    MainScreen,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MouseCapture {
+    Captured,
+    #[default]
+    NotCaptured,
+}
+
+#[derive(Debug)]
+pub struct TerminalBuilder;
+
+impl TerminalBuilder {
+    #[cfg(feature = "crossterm")]
+    pub fn crossterm_on_stdout() -> crossterm::TerminalBuilder<Stdout> {
+        Self::crossterm(stdout())
+    }
+
+    #[cfg(feature = "crossterm")]
+    pub fn crossterm_on_stderr() -> crossterm::TerminalBuilder<Stderr> {
+        Self::crossterm(stderr())
+    }
+
+    #[cfg(feature = "crossterm")]
+    pub fn crossterm<W: Write>(writer: W) -> crossterm::TerminalBuilder<W> {
+        crossterm::TerminalBuilder::new(writer)
+    }
+
+    #[cfg(feature = "termion")]
+    pub fn termion_on_stdout() -> termion::TerminalBuilder<Stdout> {
+        Self::termion(stdout())
+    }
+
+    #[cfg(feature = "termion")]
+    pub fn termion_on_stderr() -> termion::TerminalBuilder<Stderr> {
+        Self::termion(stderr())
+    }
+
+    #[cfg(feature = "termion")]
+    pub fn termion<W: Write>(writer: W) -> termion::TerminalBuilder<W> {
+        termion::TerminalBuilder::new(writer)
+    }
+
+    #[cfg(feature = "termwiz")]
+    pub fn termwiz_on_stdout() -> termwiz::TerminalBuilder {
+        termwiz::TerminalBuilder::new()
+    }
+}
+
+#[cfg(feature = "crossterm")]
+mod crossterm {
+    use super::*;
+    use crate::backend::CrosstermBackend;
+
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    pub struct TerminalBuilder<W: Write> {
+        writer: W,
+        raw_mode: RawMode,
+        alternate_screen: AlternateScreenMode,
+        mouse_capture: MouseCapture,
+    }
+
+    impl<W: Write> TerminalBuilder<W> {
+        pub fn new(writer: W) -> Self {
+            TerminalBuilder::<W> {
+                writer,
+                raw_mode: RawMode::default(),
+                alternate_screen: AlternateScreenMode::default(),
+                mouse_capture: MouseCapture::default(),
+            }
+        }
+
+        pub fn raw_mode(self, raw_mode: RawMode) -> Self {
+            TerminalBuilder::<W> { raw_mode, ..self }
+        }
+
+        pub fn alternate_screen(self, alternate_screen: AlternateScreenMode) -> Self {
+            TerminalBuilder::<W> {
+                alternate_screen,
+                ..self
+            }
+        }
+
+        pub fn mouse_capture(self, mouse_capture: MouseCapture) -> Self {
+            TerminalBuilder::<W> {
+                mouse_capture,
+                ..self
+            }
+        }
+
+        pub fn build(self) -> io::Result<Terminal<CrosstermBackend<W>>> {
+            let backend = backend::CrosstermBackend::new(self.writer);
+            let backend = match self.raw_mode {
+                RawMode::Enabled => backend.with_raw_mode()?,
+                RawMode::Disabled => backend,
+            };
+            let backend = match self.alternate_screen {
+                AlternateScreenMode::EnterAlternateScreen => backend.with_alternate_screen()?,
+                AlternateScreenMode::MainScreen => backend,
+            };
+            let backend = match self.mouse_capture {
+                MouseCapture::Captured => backend.with_mouse_capture()?,
+                MouseCapture::NotCaptured => backend,
+            };
+            Terminal::new(backend)
+        }
+    }
+}
+
+#[cfg(feature = "termion")]
+mod termion {
+    use ::termion::{
+        raw::{IntoRawMode, RawTerminal},
+        screen::{AlternateScreen, IntoAlternateScreen, ToMainScreen},
+    };
+    use backend::TermionBackend;
+
+    use super::*;
+
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    pub struct TerminalBuilder<W: Write> {
+        writer: W,
+        raw_mode: RawMode,
+        alternate_screen: AlternateScreenMode,
+        mouse_capture: MouseCapture,
+    }
+
+    impl<W: Write> TerminalBuilder<W> {
+        pub fn new(writer: W) -> Self {
+            TerminalBuilder::<W> {
+                writer,
+                raw_mode: RawMode::default(),
+                alternate_screen: AlternateScreenMode::default(),
+                mouse_capture: MouseCapture::default(),
+            }
+        }
+
+        pub fn raw_mode(self, raw_mode: RawMode) -> TerminalBuilder<W> {
+            TerminalBuilder::<W> { raw_mode, ..self }
+        }
+
+        pub fn alternate_screen(self, alternate_screen: AlternateScreenMode) -> Self {
+            TerminalBuilder::<W> {
+                alternate_screen,
+                ..self
+            }
+        }
+
+        pub fn mouse_capture(self, mouse_capture: MouseCapture) -> Self {
+            TerminalBuilder::<W> {
+                mouse_capture,
+                ..self
+            }
+        }
+
+        const DISABLE_MOUSE_CAPTURE: &'static str = "\x1B[?1006l\x1b[?1015l\x1b[?1002l\x1b[?1000l";
+
+        pub fn build(
+            self,
+        ) -> io::Result<Terminal<TermionBackend<AlternateScreen<RawTerminal<W>>>>> {
+            let writer = self.writer.into_raw_mode()?;
+            if self.raw_mode == RawMode::Disabled {
+                writer.suspend_raw_mode()?;
+            }
+            let mut writer = writer.into_alternate_screen()?;
+            if self.alternate_screen == AlternateScreenMode::MainScreen {
+                write!(writer, "{}", ToMainScreen)?;
+            }
+            if self.mouse_capture == MouseCapture::NotCaptured {
+                write!(writer, "{}", Self::DISABLE_MOUSE_CAPTURE)?;
+            }
+            let backend = TermionBackend::new(writer);
+            Terminal::new(backend)
+        }
+    }
+}
+
+#[cfg(feature = "termwiz")]
+mod termwiz {
+    use std::error::Error;
+
+    use backend::TermwizBackend;
+
+    use super::*;
+
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    pub struct TerminalBuilder {
+        raw_mode: RawMode,
+        alternate_screen: AlternateScreenMode,
+    }
+
+    impl TerminalBuilder {
+        pub fn new() -> Self {
+            TerminalBuilder::default()
+        }
+
+        pub fn raw_mode(self, raw_mode: RawMode) -> Self {
+            TerminalBuilder { raw_mode, ..self }
+        }
+
+        pub fn alternate_screen(self, alternate_screen: AlternateScreenMode) -> Self {
+            TerminalBuilder {
+                alternate_screen,
+                ..self
+            }
+        }
+
+        pub fn build(self) -> Result<Terminal<TermwizBackend>, Box<dyn Error>> {
+            let mut backend = TermwizBackend::new()?;
+            match self.raw_mode {
+                RawMode::Enabled => backend.enable_raw_mode()?,
+                RawMode::Disabled => backend.disable_raw_mode()?,
+            };
+            match self.alternate_screen {
+                AlternateScreenMode::EnterAlternateScreen => backend.enter_alternate_screen()?,
+                AlternateScreenMode::MainScreen => backend.leave_alternate_screen()?,
+            };
+            let terminal = Terminal::new(backend)?;
+            Ok(terminal)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    // the tests cannot run in parallel as the terminal is a global resource
+    use serial_test::serial;
+
+    use super::*;
+
+    #[test]
+    #[serial]
+    #[cfg(feature = "crossterm")]
+    fn crossterm() {
+        struct Expected<W: Write> {
+            writer: W,
+            raw_mode_enabled: bool,
+            alternate_screen_entered: bool,
+            mouse_capture_enabled: bool,
+        }
+        #[track_caller]
+        fn test<W: Write + Debug>(
+            terminal_builder: crossterm::TerminalBuilder<W>,
+            expected: Expected<W>,
+        ) {
+            let terminal = terminal_builder.build().unwrap();
+            let backend = terminal.backend();
+            assert_eq!(
+                format!("{backend:?}"),
+                format!(
+                    "CrosstermBackend {{ writer: {:?}, raw_mode_enabled: {}, \
+                    alternate_screen_entered: {}, mouse_capture_enabled: {} }}",
+                    expected.writer,
+                    expected.raw_mode_enabled,
+                    expected.alternate_screen_entered,
+                    expected.mouse_capture_enabled
+                )
+            );
+        }
+
+        test(
+            TerminalBuilder::crossterm(stdout()),
+            Expected {
+                writer: stdout(),
+                raw_mode_enabled: true,
+                alternate_screen_entered: true,
+                mouse_capture_enabled: false,
+            },
+        );
+        test(
+            TerminalBuilder::crossterm(stderr()),
+            Expected {
+                writer: stderr(),
+                raw_mode_enabled: true,
+                alternate_screen_entered: true,
+                mouse_capture_enabled: false,
+            },
+        );
+        test(
+            TerminalBuilder::crossterm_on_stdout(),
+            Expected {
+                writer: stdout(),
+                raw_mode_enabled: true,
+                alternate_screen_entered: true,
+                mouse_capture_enabled: false,
+            },
+        );
+        test(
+            TerminalBuilder::crossterm_on_stderr(),
+            Expected {
+                writer: stderr(),
+                raw_mode_enabled: true,
+                alternate_screen_entered: true,
+                mouse_capture_enabled: false,
+            },
+        );
+        test(
+            TerminalBuilder::crossterm_on_stdout()
+                .raw_mode(RawMode::Enabled)
+                .alternate_screen(AlternateScreenMode::EnterAlternateScreen)
+                .mouse_capture(MouseCapture::Captured),
+            Expected {
+                writer: stdout(),
+                raw_mode_enabled: true,
+                alternate_screen_entered: true,
+                mouse_capture_enabled: true,
+            },
+        );
+        test(
+            TerminalBuilder::crossterm_on_stderr()
+                .raw_mode(RawMode::Disabled)
+                .alternate_screen(AlternateScreenMode::MainScreen)
+                .mouse_capture(MouseCapture::NotCaptured),
+            Expected {
+                writer: stderr(),
+                raw_mode_enabled: false,
+                alternate_screen_entered: false,
+                mouse_capture_enabled: false,
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(feature = "termion")]
+    fn termion() -> io::Result<()> {
+        // due to the way termion works, we cannot test the actual terminal, but we can check that
+        // this compiles and runs without errors
+        let _ = TerminalBuilder::termion(stdout()).build()?;
+        let _ = TerminalBuilder::termion(stderr()).build()?;
+        let _ = TerminalBuilder::termion_on_stdout().build()?;
+        let _ = TerminalBuilder::termion_on_stderr().build()?;
+        let _ = TerminalBuilder::termion_on_stdout()
+            .raw_mode(RawMode::Enabled)
+            .alternate_screen(AlternateScreenMode::EnterAlternateScreen)
+            .mouse_capture(MouseCapture::Captured)
+            .build()?;
+        let _ = TerminalBuilder::termion_on_stderr()
+            .raw_mode(RawMode::Disabled)
+            .alternate_screen(AlternateScreenMode::MainScreen)
+            .mouse_capture(MouseCapture::NotCaptured)
+            .build()?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(feature = "termwiz")]
+    fn termwiz() -> Result<(), Box<dyn std::error::Error>> {
+        // due to the way termwiz works, we cannot test the actual terminal, but we can check that
+        // this compiles and runs without errors
+        let _ = TerminalBuilder::termwiz_on_stdout().build()?;
+        let _ = TerminalBuilder::termwiz_on_stdout()
+            .raw_mode(RawMode::Enabled)
+            .alternate_screen(AlternateScreenMode::EnterAlternateScreen)
+            .build()?;
+        let _ = TerminalBuilder::termwiz_on_stdout()
+            .raw_mode(RawMode::Disabled)
+            .alternate_screen(AlternateScreenMode::MainScreen)
+            .build()?;
+        Ok(())
+    }
+}

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -264,7 +264,7 @@ impl<'a> Block<'a> {
     ///
     /// ```
     /// // Draw a block nested within another block
-    /// use ratatui::{backend::TestBackend, buffer::Buffer, terminal::Terminal, widgets::{Block, Borders}};
+    /// use ratatui::{backend::TestBackend, buffer::Buffer, Terminal, widgets::{Block, Borders}};
     /// let backend = TestBackend::new(15, 5);
     /// let mut terminal = Terminal::new(backend).unwrap();
     /// let outer_block = Block::default()


### PR DESCRIPTION
This PR simplifies the creation of backends and terminals by
implementing `Default` for the backends and adding builder style
methods to the terminal.

For example, the following code now creates a terminal that enters the
alternate screen and enables raw mode and cleans up after itself when
dropped.

```rust
use anyhow::{Context, Result};
use crossterm::event::{self, Event, KeyCode};
use ratatui::{prelude::*};

fn main() -> Result<()> {
    run()?;
    println!("This is on the main screen!");
    Ok(())
}

fn run() -> Result() {
    let backend = CrosstermBackend::on_stdout()?; 
    let mut terminal = Terminal::new(backend)?; 
    loop { 
        terminal.draw(|frame| {
            frame.render_widget(
                Paragraph::new("this is on the alternate screen"),
                frame.size(),
            );
        })?; 
        if let Event::Key(key) = event::read()? { 
            if let KeyCode::Char('q') = key.code { 
                return Ok(()); 
            } 
        } 
    } 
}
```

CrosstermBackend and TermionBackend both gain `on_stdout()` and
`on_stderr()` methods which enable raw mode and switch to the alternate
screen before returning, and builder style methods to enable or disable
raw mode and the alternate screen.

This commit implements `Drop` for the CrosstermBackend which will
disable raw mode and switch back to the main screen. This ensures the
terminal is left in a usable state if the application panics. The
underlying Termion and Termwiz code both already implement `Drop` so no
changes are required to them.

This commit adds a Deref implementation to terminal to allow the backend
to be accessed directly.

The README and library, terminal, backends, types, traits and modules
docs are all updated to reflect these changes and to add some missing
documentation and examples.

Fixes https://github.com/ratatui-org/ratatui/issues/261

## PR Review notes

This PR consists of 2 commits, the first makes the changes which should be backwards
compatible with all existing code. The second updates the examples to use the new
methods.

To make it easier to review this, I'd recommend looking at each commit (there is no overlap in the code):

- Code and docs: https://github.com/ratatui-org/ratatui/pull/280/commits/2498f7bba6387055698c65edb97a0f0d7e2654f8
The change is large (1206 insertions, 212 deletions), but a large chunk is comments (468 lines)
- Examples: https://github.com/ratatui-org/ratatui/pull/280/commits/85fe06606a185fff99f73c6ed82125426cdf4039

Note that https://github.com/ratatui-org/ratatui/pull/280#issuecomment-1657115361 explains a few choices that might not be obvious.

I'd recommend generating the docs locally and viewing the main library doc, backend and terminal module docs, Terminal type, Backend trait, and each Backend type.
```
cargo +nightly doc -Zunstable-options -Zrustdoc-scrape-examples --all-features --open
```

I'm seeking feedback on anything that's missing in the docs, anything that's not where you'd expect it to be, anything that's not idiomatic (taking into account Ratatui's general builder pattern as well as Rust norms), and any problems this new code might cause for app / library builders. Thoughts on how to communicate these changes to users would be appreciated as well.