### PR TITLE
fix(scrollbar)!: move symbols and set to symbols module

### DIFF
--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -9,7 +9,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{prelude::*, symbols::scrollbar, widgets::*};
 
 #[derive(Default)]
 struct App {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -233,3 +233,52 @@ pub enum Marker {
     /// Up to 8 points per cell
     Braille,
 }
+
+pub mod scrollbar {
+    use super::{block, line};
+
+    /// Scrollbar Set
+    /// ```text
+    /// <--▮------->
+    /// ^  ^   ^   ^
+    /// │  │   │   └ end
+    /// │  │   └──── track
+    /// │  └──────── thumb
+    /// └─────────── begin
+    /// ```
+    #[derive(Debug, Clone)]
+    pub struct Set {
+        pub track: &'static str,
+        pub thumb: &'static str,
+        pub begin: &'static str,
+        pub end: &'static str,
+    }
+
+    pub const DOUBLE_VERTICAL: Set = Set {
+        track: line::DOUBLE_VERTICAL,
+        thumb: block::FULL,
+        begin: "▲",
+        end: "▼",
+    };
+
+    pub const DOUBLE_HORIZONTAL: Set = Set {
+        track: line::DOUBLE_HORIZONTAL,
+        thumb: block::FULL,
+        begin: "◄",
+        end: "►",
+    };
+
+    pub const VERTICAL: Set = Set {
+        track: line::VERTICAL,
+        thumb: block::FULL,
+        begin: "↑",
+        end: "↓",
+    };
+
+    pub const HORIZONTAL: Set = Set {
+        track: line::HORIZONTAL,
+        thumb: block::FULL,
+        begin: "←",
+        end: "→",
+    };
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -27,7 +27,7 @@ mod gauge;
 mod list;
 mod paragraph;
 mod reflow;
-pub mod scrollbar;
+mod scrollbar;
 mod sparkline;
 mod table;
 mod tabs;

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -3,52 +3,7 @@ use crate::{
     buffer::Buffer,
     layout::Rect,
     style::Style,
-    symbols::{block::FULL, line},
-};
-
-/// Scrollbar Set
-/// ```text
-/// <--▮------->
-/// ^  ^   ^   ^
-/// │  │   │   └ end
-/// │  │   └──── track
-/// │  └──────── thumb
-/// └─────────── begin
-/// ```
-#[derive(Debug, Clone)]
-pub struct Set {
-    pub track: &'static str,
-    pub thumb: &'static str,
-    pub begin: &'static str,
-    pub end: &'static str,
-}
-
-pub const DOUBLE_VERTICAL: Set = Set {
-    track: line::DOUBLE_VERTICAL,
-    thumb: FULL,
-    begin: "▲",
-    end: "▼",
-};
-
-pub const DOUBLE_HORIZONTAL: Set = Set {
-    track: line::DOUBLE_HORIZONTAL,
-    thumb: FULL,
-    begin: "◄",
-    end: "►",
-};
-
-pub const VERTICAL: Set = Set {
-    track: line::VERTICAL,
-    thumb: FULL,
-    begin: "↑",
-    end: "↓",
-};
-
-pub const HORIZONTAL: Set = Set {
-    track: line::HORIZONTAL,
-    thumb: FULL,
-    begin: "←",
-    end: "→",
+    symbols::scrollbar::{Set, DOUBLE_HORIZONTAL, DOUBLE_VERTICAL},
 };
 
 /// An enum representing the direction of scrolling in a Scrollbar widget.
@@ -502,7 +457,10 @@ impl<'a> StatefulWidget for Scrollbar<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_buffer_eq;
+    use crate::{
+        assert_buffer_eq,
+        symbols::scrollbar::{HORIZONTAL, VERTICAL},
+    };
 
     #[test]
     fn test_no_render_when_area_zero() {


### PR DESCRIPTION
This makes it consistent with the other symbol sets

BREAKING CHANGE: The symbols are now in the `symbols` module. To update
your code, add an import for `ratatui::symbols::scrollbar::*` (or the
specific symbols you need).

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
