### PR TITLE
chore(widgets): Implement `Debug & Default` common traits

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -42,6 +42,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug, Default)]
 pub struct CrosstermBackend<W: Write> {
     buffer: W,
 }
@@ -212,7 +213,7 @@ impl From<Color> for CColor {
 /// The `ModifierDiff` struct is used to calculate the difference between two `Modifier`
 /// values. This is useful when updating the terminal display, as it allows for more
 /// efficient updates by only sending the necessary changes.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct ModifierDiff {
     pub from: Modifier,
     pub to: Modifier,

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -31,6 +31,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug, Default)]
 pub struct TermionBackend<W>
 where
     W: Write,
@@ -163,14 +164,16 @@ where
         self.stdout.flush()
     }
 }
-
+#[derive(Debug, Default)]
 struct Fg(Color);
 
+#[derive(Debug, Default)]
 struct Bg(Color);
 
 /// The `ModifierDiff` struct is used to calculate the difference between two `Modifier`
 /// values. This is useful when updating the terminal display, as it allows for more
 /// efficient updates by only sending the necessary changes.
+#[derive(Debug, Default)]
 struct ModifierDiff {
     from: Modifier,
     to: Modifier,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// A buffer cell
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cell {
     pub symbol: String,
     pub fg: Color,
@@ -135,7 +135,7 @@ impl Default for Cell {
 /// buf.get_mut(5, 0).set_char('x');
 /// assert_eq!(buf.get(5, 0).symbol, "x");
 /// ```
-#[derive(Clone, PartialEq, Eq, Default)]
+#[derive(Default, Clone, Eq, PartialEq)]
 pub struct Buffer {
     /// The area represented by this buffer
     pub area: Rect,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -11,27 +11,35 @@ use cassowary::{
     WeightedRelation::{EQ, GE, LE},
 };
 
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Hash, Clone, Copy, PartialEq, Eq)]
 pub enum Corner {
+    #[default]
     TopLeft,
     TopRight,
     BottomRight,
     BottomLeft,
 }
 
-#[derive(Debug, Hash, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
 pub enum Direction {
     Horizontal,
+    #[default]
     Vertical,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Constraint {
     Percentage(u16),
     Ratio(u32, u32),
     Length(u16),
     Max(u16),
     Min(u16),
+}
+
+impl Default for Constraint {
+    fn default() -> Self {
+        Constraint::Percentage(100)
+    }
 }
 
 impl Constraint {
@@ -56,14 +64,15 @@ impl Constraint {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct Margin {
     pub vertical: u16,
     pub horizontal: u16,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Alignment {
+    #[default]
     Left,
     Center,
     Right,
@@ -359,6 +368,7 @@ fn split(area: Rect, layout: &Layout) -> Rc<[Rect]> {
 }
 
 /// A container used by the solver inside split
+#[derive(Debug)]
 struct Element {
     x: Variable,
     y: Variable,
@@ -395,7 +405,7 @@ impl Element {
 
 /// A simple rectangle used in the computation of the layout and to give widgets a hint about the
 /// area they are supposed to render to.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct Rect {
     pub x: u16,
     pub y: u16,

--- a/src/style.rs
+++ b/src/style.rs
@@ -89,10 +89,11 @@ pub use stylize::{Styled, Stylize};
 /// assert_eq!("white".parse(), Ok(Color::White));
 /// assert_eq!("bright white".parse(), Ok(Color::White));
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Color {
     /// Resets the foreground or background color
+    #[default]
     Reset,
     /// ANSI Color: Black. Foreground: 30, Background: 40
     Black,
@@ -150,7 +151,7 @@ bitflags! {
     /// let m = Modifier::BOLD | Modifier::ITALIC;
     /// ```
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[derive(Clone, Copy, PartialEq, Eq)]
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
     pub struct Modifier: u16 {
         const BOLD              = 0b0000_0000_0001;
         const DIM               = 0b0000_0000_0010;
@@ -247,7 +248,7 @@ impl fmt::Debug for Modifier {
 ///     buffer.get(0, 0).style(),
 /// );
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Style {
     pub fg: Option<Color>,

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -21,6 +21,12 @@ pub mod block {
         pub empty: &'static str,
     }
 
+    impl Default for Set {
+        fn default() -> Self {
+            NINE_LEVELS
+        }
+    }
+
     pub const THREE_LEVELS: Set = Set {
         full: FULL,
         seven_eighths: FULL,
@@ -67,6 +73,12 @@ pub mod bar {
         pub one_quarter: &'static str,
         pub one_eighth: &'static str,
         pub empty: &'static str,
+    }
+
+    impl Default for Set {
+        fn default() -> Self {
+            NINE_LEVELS
+        }
     }
 
     pub const THREE_LEVELS: Set = Set {
@@ -158,6 +170,12 @@ pub mod line {
         pub cross: &'static str,
     }
 
+    impl Default for Set {
+        fn default() -> Self {
+            NORMAL
+        }
+    }
+
     pub const NORMAL: Set = Set {
         vertical: VERTICAL,
         horizontal: HORIZONTAL,
@@ -222,9 +240,10 @@ pub mod braille {
 }
 
 /// Marker to use when plotting data points
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum Marker {
     /// One point per cell in shape of dot
+    #[default]
     Dot,
     /// One point per cell in shape of a block
     Block,
@@ -246,7 +265,7 @@ pub mod scrollbar {
     /// │  └──────── thumb
     /// └─────────── begin
     /// ```
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Default, Clone)]
     pub struct Set {
         pub track: &'static str,
         pub thumb: &'static str,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -7,22 +7,23 @@ use crate::{
     widgets::{StatefulWidget, Widget},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub enum Viewport {
+    #[default]
     Fullscreen,
     Inline(u16),
     Fixed(Rect),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Options to pass to [`Terminal::with_options`]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct TerminalOptions {
     /// Viewport used to draw to the terminal
     pub viewport: Viewport,
 }
 
 /// Interface to the terminal backed by Termion
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Terminal<B>
 where
     B: Backend,
@@ -46,6 +47,7 @@ where
 }
 
 /// Represents a consistent terminal interface for rendering.
+#[derive(Debug)]
 pub struct Frame<'a, B: 'a>
 where
     B: Backend,
@@ -137,6 +139,7 @@ where
 /// `CompletedFrame` represents the state of the terminal after all changes performed in the last
 /// [`Terminal::draw`] call have been applied. Therefore, it is only valid until the next call to
 /// [`Terminal::draw`].
+#[derive(Debug)]
 pub struct CompletedFrame<'a> {
     pub buffer: &'a Buffer,
     pub area: Rect,

--- a/src/text/grapheme.rs
+++ b/src/text/grapheme.rs
@@ -5,7 +5,7 @@ use crate::style::{Style, Styled};
 /// it actually is not a member of the text type hierarchy (`Text` -> `Line` -> `Span`).
 /// It is a separate type used mostly for rendering purposes. A `Span` consists of components that
 /// can be split into `StyledGrapheme`s, but it does not contain a collection of `StyledGrapheme`s.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct StyledGrapheme<'a> {
     pub symbol: &'a str,
     pub style: Style,

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use super::{Span, Spans, Style, StyledGrapheme};
 use crate::layout::Alignment;
 
-#[derive(Debug, Clone, PartialEq, Default, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Line<'a> {
     pub spans: Vec<Span<'a>>,
     pub alignment: Option<Alignment>,

--- a/src/text/masked.rs
+++ b/src/text/masked.rs
@@ -21,7 +21,7 @@ use super::Text;
 /// Paragraph::new(password).render(buffer.area, &mut buffer);
 /// assert_eq!(buffer, Buffer::with_lines(vec!["xxxxx"]));
 /// ```
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
 pub struct Masked<'a> {
     inner: Cow<'a, str>,
     mask_char: char,

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -7,7 +7,7 @@ use super::StyledGrapheme;
 use crate::style::{Style, Styled};
 
 /// A string where all graphemes have the same style.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Span<'a> {
     pub content: Cow<'a, str>,
     pub style: Style,

--- a/src/text/spans.rs
+++ b/src/text/spans.rs
@@ -9,7 +9,7 @@ use crate::{layout::Alignment, text::Line};
 /// future. All methods that accept Spans have been replaced with methods that
 /// accept Into<Line<'a>> (which is implemented on `Spans`) to allow users of
 /// this crate to gradually transition to Line.
-#[derive(Debug, Clone, PartialEq, Default, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 #[deprecated(note = "Use `ratatui::text::Line` instead")]
 pub struct Spans<'a>(pub Vec<Span<'a>>);
 

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -28,7 +28,7 @@ use crate::style::Style;
 /// text.extend(Text::styled("Some more lines\nnow with more style!", style));
 /// assert_eq!(6, text.height());
 /// ```
-#[derive(Debug, Clone, PartialEq, Default, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Text<'a> {
     pub lines: Vec<Line<'a>>,
 }

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,6 +1,6 @@
 use crate::{layout::Alignment, text::Line};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Title<'a> {
     pub content: Line<'a>,
     /// Defaults to Left if unset
@@ -43,15 +43,5 @@ where
 {
     fn from(value: T) -> Self {
         Self::default().content(value.into())
-    }
-}
-
-impl<'a> Default for Title<'a> {
-    fn default() -> Self {
-        Self {
-            content: Line::from(""),
-            alignment: None,
-            position: None,
-        }
     }
 }

--- a/src/widgets/barchart/bar.rs
+++ b/src/widgets/barchart/bar.rs
@@ -15,7 +15,7 @@ use crate::{buffer::Buffer, style::Style, text::Line};
 ///     .value_style(Style::default().bg(Color::Red).fg(Color::White))
 ///     .text_value("10°C".to_string());
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Bar<'a> {
     /// Value to display on the bar (computed when the data is passed to the widget)
     pub(super) value: u64,

--- a/src/widgets/barchart/bar_group.rs
+++ b/src/widgets/barchart/bar_group.rs
@@ -10,7 +10,7 @@ use crate::text::Line;
 ///     .label("Group 1".into())
 ///     .bars(&[Bar::default().value(200), Bar::default().value(150)]);
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct BarGroup<'a> {
     /// label of the group. It will be printed centered under this group of bars
     pub(super) label: Option<Line<'a>>,

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -10,8 +10,9 @@ use crate::{
     widgets::{Borders, Widget},
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub enum BorderType {
+    #[default]
     Plain,
     Rounded,
     Double,
@@ -29,7 +30,7 @@ impl BorderType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Padding {
     pub left: u16,
     pub right: u16,
@@ -112,7 +113,7 @@ impl Padding {
 ///     .border_type(BorderType::Rounded)
 ///     .style(Style::default().bg(Color::Black));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Block<'a> {
     /// List of titles
     titles: Vec<Title<'a>>,
@@ -135,12 +136,6 @@ pub struct Block<'a> {
     style: Style,
     /// Block padding
     padding: Padding,
-}
-
-impl<'a> Default for Block<'a> {
-    fn default() -> Block<'a> {
-        Block::new()
-    }
 }
 
 impl<'a> Block<'a> {

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 /// Display a month calendar for the month containing `display_date`
+#[derive(Debug)]
 pub struct Monthly<'a, S: DateStyler> {
     display_date: Date,
     events: S,
@@ -172,6 +173,7 @@ pub trait DateStyler {
 }
 
 /// A simple `DateStyler` based on a [`HashMap`]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct CalendarEventStore(pub HashMap<Date, Style>);
 
 impl CalendarEventStore {

--- a/src/widgets/canvas/circle.rs
+++ b/src/widgets/canvas/circle.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Shape to draw a circle with a given center and radius and with the given color
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Circle {
     pub x: f64,
     pub y: f64,

--- a/src/widgets/canvas/line.rs
+++ b/src/widgets/canvas/line.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Shape to draw a line from (x1, y1) to (x2, y2) with the given color
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Line {
     pub x1: f64,
     pub y1: f64,

--- a/src/widgets/canvas/map.rs
+++ b/src/widgets/canvas/map.rs
@@ -6,8 +6,9 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum MapResolution {
+    #[default]
     Low,
     High,
 }
@@ -22,19 +23,10 @@ impl MapResolution {
 }
 
 /// Shape to draw a world map with the given resolution and color
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Map {
     pub resolution: MapResolution,
     pub color: Color,
-}
-
-impl Default for Map {
-    fn default() -> Map {
-        Map {
-            resolution: MapResolution::Low,
-            color: Color::Reset,
-        }
-    }
 }
 
 impl Shape for Map {

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -29,14 +29,14 @@ pub trait Shape {
 }
 
 /// Label to draw some text on the canvas
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Label<'a> {
     x: f64,
     y: f64,
     line: TextLine<'a>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 struct Layer {
     string: String,
     colors: Vec<Color>,
@@ -51,7 +51,7 @@ trait Grid: Debug {
     fn reset(&mut self);
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 struct BrailleGrid {
     width: u16,
     height: u16,
@@ -114,7 +114,7 @@ impl Grid for BrailleGrid {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 struct CharGrid {
     width: u16,
     height: u16,
@@ -355,6 +355,7 @@ impl<'a> Context<'a> {
 ///         });
 ///     });
 /// ```
+#[derive(Debug)]
 pub struct Canvas<'a, F>
 where
     F: Fn(&mut Context),

--- a/src/widgets/canvas/points.rs
+++ b/src/widgets/canvas/points.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A shape to draw a group of points with the given color
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Points<'a> {
     pub coords: &'a [(f64, f64)],
     pub color: Color,
@@ -16,15 +16,6 @@ impl<'a> Shape for Points<'a> {
             if let Some((x, y)) = painter.get_point(*x, *y) {
                 painter.paint(x, y, self.color);
             }
-        }
-    }
-}
-
-impl<'a> Default for Points<'a> {
-    fn default() -> Points<'a> {
-        Points {
-            coords: &[],
-            color: Color::Reset,
         }
     }
 }

--- a/src/widgets/canvas/rectangle.rs
+++ b/src/widgets/canvas/rectangle.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Shape to draw a rectangle from a `Rect` with the given color
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Rectangle {
     pub x: f64,
     pub y: f64,

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// An X or Y axis for the chart widget
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Axis<'a> {
     /// Title displayed next to axis end
     title: Option<TextLine<'a>>,
@@ -27,18 +27,6 @@ pub struct Axis<'a> {
     style: Style,
     /// The alignment of the labels of the Axis
     labels_alignment: Alignment,
-}
-
-impl<'a> Default for Axis<'a> {
-    fn default() -> Axis<'a> {
-        Axis {
-            title: None,
-            bounds: [0.0, 0.0],
-            labels: None,
-            style: Style::default(),
-            labels_alignment: Alignment::Left,
-        }
-    }
 }
 
 impl<'a> Axis<'a> {
@@ -88,16 +76,17 @@ impl<'a> Axis<'a> {
 }
 
 /// Used to determine which style of graphing to use
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum GraphType {
     /// Draw each point
+    #[default]
     Scatter,
     /// Draw each point and lines between each point using the same marker
     Line,
 }
 
 /// A group of data points
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Dataset<'a> {
     /// Name of the dataset (used in the legend if shown)
     name: Cow<'a, str>,
@@ -109,18 +98,6 @@ pub struct Dataset<'a> {
     graph_type: GraphType,
     /// Style used to plot this dataset
     style: Style,
-}
-
-impl<'a> Default for Dataset<'a> {
-    fn default() -> Dataset<'a> {
-        Dataset {
-            name: Cow::from(""),
-            data: &[],
-            marker: symbols::Marker::Dot,
-            graph_type: GraphType::Scatter,
-            style: Style::default(),
-        }
-    }
 }
 
 impl<'a> Dataset<'a> {
@@ -155,7 +132,7 @@ impl<'a> Dataset<'a> {
 
 /// A container that holds all the infos about where to display each elements of the chart (axis,
 /// labels, legend, ...).
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Default, Clone, PartialEq)]
 struct ChartLayout {
     /// Location of the title of the x axis
     title_x: Option<(u16, u16)>,
@@ -211,7 +188,7 @@ struct ChartLayout {
 ///         .bounds([0.0, 10.0])
 ///         .labels(["0.0", "5.0", "10.0"].iter().cloned().map(Span::from).collect()));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Chart<'a> {
     /// A block to display around the widget eventually
     block: Option<Block<'a>>,

--- a/src/widgets/clear.rs
+++ b/src/widgets/clear.rs
@@ -23,7 +23,7 @@ use crate::{buffer::Buffer, layout::Rect, widgets::Widget};
 ///
 /// For a more complete example how to utilize `Clear` to realize popups see
 /// the example `examples/popup.rs`
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Clear;
 
 impl Widget for Clear {

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -179,6 +179,7 @@ fn get_unicode_block<'a>(frac: f64) -> &'a str {
 ///     .line_set(symbols::line::THICK)
 ///     .ratio(0.4);
 /// ```
+#[derive(Debug, Default)]
 pub struct LineGauge<'a> {
     block: Option<Block<'a>>,
     ratio: f64,
@@ -186,19 +187,6 @@ pub struct LineGauge<'a> {
     line_set: symbols::line::Set,
     style: Style,
     gauge_style: Style,
-}
-
-impl<'a> Default for LineGauge<'a> {
-    fn default() -> Self {
-        Self {
-            block: None,
-            ratio: 0.0,
-            label: None,
-            style: Style::default(),
-            line_set: symbols::line::NORMAL,
-            gauge_style: Style::default(),
-        }
-    }
 }
 
 impl<'a> LineGauge<'a> {
@@ -374,5 +362,26 @@ mod tests {
                 .add_modifier(Modifier::BOLD)
                 .remove_modifier(Modifier::DIM)
         )
+    }
+
+    #[test]
+    fn line_gauge_default() {
+        // TODO: replace to `assert_eq!(LineGauge::default(), LineGauge::default())`
+        // when `Eq` or `PartialEq` is implemented for `LineGauge`.
+        assert_eq!(
+            format!("{:?}", LineGauge::default()),
+            format!(
+                "{:?}",
+                LineGauge {
+                    block: None,
+                    ratio: 0.0,
+                    label: None,
+                    style: Style::default(),
+                    line_set: symbols::line::NORMAL,
+                    gauge_style: Style::default(),
+                }
+            ),
+            "LineGauge::default() should have correct default values."
+        );
     }
 }

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -8,7 +8,7 @@ use crate::{
     widgets::{Block, StatefulWidget, Widget},
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ListState {
     offset: usize,
     selected: Option<usize>,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -53,7 +53,7 @@ use crate::{buffer::Buffer, layout::Rect};
 
 bitflags! {
     /// Bitflags that can be composed to set the visible borders essentially on the block widget.
-    #[derive(Clone, Copy, Default, PartialEq, Eq)]
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
     pub struct Borders: u8 {
         /// Show no border (default)
         const NONE   = 0b0000;

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -42,7 +42,7 @@ fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) 
 ///     .alignment(Alignment::Center)
 ///     .wrap(Wrap { trim: true });
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Paragraph<'a> {
     /// A block to wrap the widget in
     block: Option<Block<'a>>,
@@ -85,7 +85,7 @@ pub struct Paragraph<'a> {
 /// //     - Here is another point
 /// // that is long enough to wrap
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Wrap {
     /// Should leading whitespace be trimmed
     pub trim: bool,

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -15,6 +15,7 @@ pub trait LineComposer<'a> {
 }
 
 /// A state machine that wraps lines on word boundaries.
+#[derive(Debug, Default, Clone)]
 pub struct WordWrapper<'a, O, I>
 where
     // Outer iterator providing the individual lines
@@ -207,6 +208,7 @@ where
 }
 
 /// A state machine that truncates overhanging lines.
+#[derive(Debug, Default)]
 pub struct LineTruncator<'a, O, I>
 where
     // Outer iterator providing the individual lines

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -35,7 +35,7 @@ pub enum ScrollDirection {
 ///
 /// If you don't have multi-line content, you can leave the `viewport_content_length` set to the
 /// default of 0 and it'll use the track size as a `viewport_content_length`.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct ScrollbarState {
     // The current position within the scrollable content.
     position: u16,
@@ -101,7 +101,7 @@ impl ScrollbarState {
 }
 
 /// Scrollbar Orientation
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub enum ScrollbarOrientation {
     #[default]
     VerticalRight,

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -38,8 +38,9 @@ pub struct Sparkline<'a> {
     direction: RenderDirection,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum RenderDirection {
+    #[default]
     LeftToRight,
     RightToLeft,
 }

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -32,7 +32,7 @@ use crate::{
 ///
 /// You can apply a [`Style`] on the entire [`Cell`] using [`Cell::style`] or rely on the styling
 /// capabilities of [`Text`].
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Cell<'a> {
     content: Text<'a>,
     style: Style,
@@ -99,7 +99,7 @@ impl<'a> Styled for Cell<'a> {
 /// ```
 ///
 /// By default, a row has a height of 1 but you can change this using [`Row::height`].
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Row<'a> {
     cells: Vec<Cell<'a>>,
     height: u16,
@@ -211,7 +211,7 @@ impl<'a> Styled for Row<'a> {
 /// // ...and potentially show a symbol in front of the selection.
 /// .highlight_symbol(">>");
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Table<'a> {
     /// A block to wrap the widget in
     block: Option<Block<'a>>,
@@ -372,7 +372,7 @@ impl<'a> Styled for Table<'a> {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct TableState {
     offset: usize,
     selected: Option<usize>,

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -23,7 +23,7 @@ use crate::{
 ///     .highlight_style(Style::default().fg(Color::Yellow))
 ///     .divider(DOT);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Tabs<'a> {
     /// A block to wrap this widget in if necessary
     block: Option<Block<'a>>,


### PR DESCRIPTION
Implement `Debug & Default` common traits for most structs in src.

Reorder the derive fields to be more consistent:

    Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash

see: https://github.com/ratatui-org/ratatui/issues/307