### PR TITLE
fix(cargo): adjust minimum paste version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bitflags = "2.3"
 cassowary = "0.3"
 crossterm = { version = "0.26", optional = true }
 indoc = "2.0"
-paste = "1.0"
+paste = "1.0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
 termion = { version = "2.0", optional = true }
 termwiz = { version = "0.20.0", optional = true }


### PR DESCRIPTION
First of all wanted to say that I love ratatui/tui and appreciate the continued maintenance of it :)

I ran into a [CI issue](https://github.com/ndd7xv/heh/actions/runs/5664863950/job/15348805140?pr=75) when trying to release a new version of my [terminal hex editor](https://github.com/ndd7xv/heh) that uses ratatui. The job essentially checks if the minimal versions specified in the `Cargo.toml` are able to compile the rust project. With how this currently works, `-Z minimal-versions` [currently checks transitive dependencies](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#minimal-versions), and I've identified the source of the error to be that the minimum required version of `paste` should actually be `1.0.2` instead of `1.0`.

This isn't really a problem,  considering that the possibility of Cargo using a paste version `1.0.0` or `1.0.1` to build this library on other peoples machines is not that high. Other transitive dependencies that ratatui relies on also have this "problem,"  but for my use case  - since I only use the crossterm feature - makes my job go green.

(In the future, I'll modify my job to run with `-Zdirect-minimal-versions`, which would also make the job go green) 