### PR TITLE
chore: implement `Clone & Copy` common traits

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -42,7 +42,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct CrosstermBackend<W: Write> {
     buffer: W,
 }
@@ -213,7 +213,7 @@ impl From<Color> for CColor {
 /// The `ModifierDiff` struct is used to calculate the difference between two `Modifier`
 /// values. This is useful when updating the terminal display, as it allows for more
 /// efficient updates by only sending the necessary changes.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 struct ModifierDiff {
     pub from: Modifier,
     pub to: Modifier,

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -31,7 +31,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct TermionBackend<W>
 where
     W: Write,
@@ -164,16 +164,16 @@ where
         self.stdout.flush()
     }
 }
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 struct Fg(Color);
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 struct Bg(Color);
 
 /// The `ModifierDiff` struct is used to calculate the difference between two `Modifier`
 /// values. This is useful when updating the terminal display, as it allows for more
 /// efficient updates by only sending the necessary changes.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 struct ModifierDiff {
     from: Modifier,
     to: Modifier,

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -28,7 +28,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TestBackend {
     width: u16,
     buffer: Buffer,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -20,7 +20,7 @@ pub enum Corner {
     BottomLeft,
 }
 
-#[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Direction {
     Horizontal,
     #[default]
@@ -64,7 +64,7 @@ impl Constraint {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct Margin {
     pub vertical: u16,
     pub horizontal: u16,
@@ -368,7 +368,7 @@ fn split(area: Rect, layout: &Layout) -> Rc<[Rect]> {
 }
 
 /// A container used by the solver inside split
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 struct Element {
     x: Variable,
     y: Variable,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -23,7 +23,7 @@ pub struct TerminalOptions {
 }
 
 /// Interface to the terminal backed by Termion
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Terminal<B>
 where
     B: Backend,
@@ -139,7 +139,7 @@ where
 /// `CompletedFrame` represents the state of the terminal after all changes performed in the last
 /// [`Terminal::draw`] call have been applied. Therefore, it is only valid until the next call to
 /// [`Terminal::draw`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CompletedFrame<'a> {
     pub buffer: &'a Buffer,
     pub area: Rect,

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -10,7 +10,7 @@ use crate::{
     widgets::{Borders, Widget},
 };
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum BorderType {
     #[default]
     Plain,
@@ -30,7 +30,7 @@ impl BorderType {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Padding {
     pub left: u16,
     pub right: u16,

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// Display a month calendar for the month containing `display_date`
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Monthly<'a, S: DateStyler> {
     display_date: Date,
     events: S,
@@ -173,7 +173,7 @@ pub trait DateStyler {
 }
 
 /// A simple `DateStyler` based on a [`HashMap`]
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CalendarEventStore(pub HashMap<Date, Style>);
 
 impl CalendarEventStore {

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -355,7 +355,7 @@ impl<'a> Context<'a> {
 ///         });
 ///     });
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Canvas<'a, F>
 where
     F: Fn(&mut Context),

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -179,7 +179,7 @@ fn get_unicode_block<'a>(frac: f64) -> &'a str {
 ///     .line_set(symbols::line::THICK)
 ///     .ratio(0.4);
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct LineGauge<'a> {
     block: Option<Block<'a>>,
     ratio: f64,

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -208,7 +208,7 @@ where
 }
 
 /// A state machine that truncates overhanging lines.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct LineTruncator<'a, O, I>
 where
     // Outer iterator providing the individual lines

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// An enum representing the direction of scrolling in a Scrollbar widget.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum ScrollDirection {
     /// Forward scroll direction, usually corresponds to scrolling downwards or rightwards.
     #[default]


### PR DESCRIPTION
Implement `Clone & Copy` common traits for most structs in src.

Only implement `Copy` for structs that are simple and trivial to copy.

Reorder the derive fields to be more consistent:

    Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash

see: https://github.com/ratatui-org/ratatui/issues/307
