### PR TITLE
style(paragraph): add documentation for "scroll"'s "offset"

### DIFF
--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -91,6 +91,9 @@ pub struct Wrap {
     pub trim: bool,
 }
 
+type Horizontal = u16;
+type Vertical = u16;
+
 impl<'a> Paragraph<'a> {
     pub fn new<T>(text: T) -> Paragraph<'a>
     where
@@ -121,7 +124,8 @@ impl<'a> Paragraph<'a> {
         self
     }
 
-    pub fn scroll(mut self, offset: (u16, u16)) -> Paragraph<'a> {
+    /// Offset values: (Vertical, Horizontal)
+    pub fn scroll(mut self, offset: (Vertical, Horizontal)) -> Paragraph<'a> {
         self.scroll = offset;
         self
     }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -124,7 +124,12 @@ impl<'a> Paragraph<'a> {
         self
     }
 
-    /// Offset values: (Vertical, Horizontal)
+    /// Set the scroll offset for the given paragraph
+    ///
+    /// Scroll works by starting to render at the given offset, which unlike other scroll function
+    /// is (y, x)
+    ///
+    /// There is a RFC for scroll refactoring and unification, see https://github.com/ratatui-org/ratatui/issues/174
     pub fn scroll(mut self, offset: (Vertical, Horizontal)) -> Paragraph<'a> {
         self.scroll = offset;
         self


### PR DESCRIPTION
This PR adds some rustdoc documentation and type helper to clarify what the values in `Paragraph`'s `scroll` are

the `type`s are useful because they are shown in rust-analyzer (though i can remove it if wanted)

Why?
because before it was not clear in what order the values should be