### PR TITLE
chore: implement `Eq & PartialEq` common traits

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -42,7 +42,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct CrosstermBackend<W: Write> {
     buffer: W,
 }
@@ -213,7 +213,7 @@ impl From<Color> for CColor {
 /// The `ModifierDiff` struct is used to calculate the difference between two `Modifier`
 /// values. This is useful when updating the terminal display, as it allows for more
 /// efficient updates by only sending the necessary changes.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 struct ModifierDiff {
     pub from: Modifier,
     pub to: Modifier,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -49,7 +49,7 @@ pub use self::test::TestBackend;
 
 /// Enum representing the different types of clearing operations that can be performed
 /// on the terminal screen.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ClearType {
     All,
     AfterCursor,

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -31,7 +31,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct TermionBackend<W>
 where
     W: Write,
@@ -164,16 +164,16 @@ where
         self.stdout.flush()
     }
 }
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 struct Fg(Color);
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 struct Bg(Color);
 
 /// The `ModifierDiff` struct is used to calculate the difference between two `Modifier`
 /// values. This is useful when updating the terminal display, as it allows for more
 /// efficient updates by only sending the necessary changes.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 struct ModifierDiff {
     from: Modifier,
     to: Modifier,

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -28,7 +28,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TestBackend {
     width: u16,
     buffer: Buffer,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -11,7 +11,7 @@ use cassowary::{
     WeightedRelation::{EQ, GE, LE},
 };
 
-#[derive(Debug, Default, Hash, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Corner {
     #[default]
     TopLeft,
@@ -70,7 +70,7 @@ pub struct Margin {
     pub horizontal: u16,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Alignment {
     #[default]
     Left,
@@ -78,7 +78,7 @@ pub enum Alignment {
     Right,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Layout {
     direction: Direction,
     margin: Margin,
@@ -368,7 +368,7 @@ fn split(area: Rect, layout: &Layout) -> Rc<[Rect]> {
 }
 
 /// A container used by the solver inside split
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct Element {
     x: Variable,
     y: Variable,

--- a/src/style.rs
+++ b/src/style.rs
@@ -151,7 +151,7 @@ bitflags! {
     /// let m = Modifier::BOLD | Modifier::ITALIC;
     /// ```
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    #[derive(Default, Clone, Copy, Eq, PartialEq)]
     pub struct Modifier: u16 {
         const BOLD              = 0b0000_0000_0001;
         const DIM               = 0b0000_0000_0010;
@@ -423,7 +423,7 @@ impl Style {
 }
 
 /// Error type indicating a failure to parse a color string.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct ParseColorError;
 
 impl std::fmt::Display for ParseColorError {

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -8,7 +8,7 @@ pub mod block {
     pub const ONE_QUARTER: &str = "▎";
     pub const ONE_EIGHTH: &str = "▏";
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Eq, PartialEq)]
     pub struct Set {
         pub full: &'static str,
         pub seven_eighths: &'static str,
@@ -62,7 +62,7 @@ pub mod bar {
     pub const ONE_QUARTER: &str = "▂";
     pub const ONE_EIGHTH: &str = "▁";
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Eq, PartialEq)]
     pub struct Set {
         pub full: &'static str,
         pub seven_eighths: &'static str,
@@ -155,7 +155,7 @@ pub mod line {
     pub const DOUBLE_CROSS: &str = "╬";
     pub const THICK_CROSS: &str = "╋";
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Eq, PartialEq)]
     pub struct Set {
         pub vertical: &'static str,
         pub horizontal: &'static str,
@@ -240,7 +240,7 @@ pub mod braille {
 }
 
 /// Marker to use when plotting data points
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum Marker {
     /// One point per cell in shape of dot
     #[default]
@@ -265,7 +265,7 @@ pub mod scrollbar {
     /// │  └──────── thumb
     /// └─────────── begin
     /// ```
-    #[derive(Debug, Default, Clone)]
+    #[derive(Debug, Default, Clone, Eq, PartialEq)]
     pub struct Set {
         pub track: &'static str,
         pub thumb: &'static str,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -23,7 +23,7 @@ pub struct TerminalOptions {
 }
 
 /// Interface to the terminal backed by Termion
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Terminal<B>
 where
     B: Backend,
@@ -139,7 +139,7 @@ where
 /// `CompletedFrame` represents the state of the terminal after all changes performed in the last
 /// [`Terminal::draw`] call have been applied. Therefore, it is only valid until the next call to
 /// [`Terminal::draw`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CompletedFrame<'a> {
     pub buffer: &'a Buffer,
     pub area: Rect,

--- a/src/text/grapheme.rs
+++ b/src/text/grapheme.rs
@@ -5,7 +5,7 @@ use crate::style::{Style, Styled};
 /// it actually is not a member of the text type hierarchy (`Text` -> `Line` -> `Span`).
 /// It is a separate type used mostly for rendering purposes. A `Span` consists of components that
 /// can be split into `StyledGrapheme`s, but it does not contain a collection of `StyledGrapheme`s.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct StyledGrapheme<'a> {
     pub symbol: &'a str,
     pub style: Style,

--- a/src/widgets/barchart/bar.rs
+++ b/src/widgets/barchart/bar.rs
@@ -15,7 +15,7 @@ use crate::{buffer::Buffer, style::Style, text::Line};
 ///     .value_style(Style::default().bg(Color::Red).fg(Color::White))
 ///     .text_value("10°C".to_string());
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Bar<'a> {
     /// Value to display on the bar (computed when the data is passed to the widget)
     pub(super) value: u64,

--- a/src/widgets/barchart/bar_group.rs
+++ b/src/widgets/barchart/bar_group.rs
@@ -10,7 +10,7 @@ use crate::text::Line;
 ///     .label("Group 1".into())
 ///     .bars(&[Bar::default().value(200), Bar::default().value(150)]);
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct BarGroup<'a> {
     /// label of the group. It will be printed centered under this group of bars
     pub(super) label: Option<Line<'a>>,

--- a/src/widgets/barchart/mod.rs
+++ b/src/widgets/barchart/mod.rs
@@ -28,7 +28,7 @@ use super::{Block, Widget};
 ///     .data(BarGroup::default().bars(&[Bar::default().value(10), Bar::default().value(20)]))
 ///     .max(4);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BarChart<'a> {
     /// Block to wrap the widget in
     block: Option<Block<'a>>,

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -10,7 +10,7 @@ use crate::{
     widgets::{Borders, Widget},
 };
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum BorderType {
     #[default]
     Plain,

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// Display a month calendar for the month containing `display_date`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Monthly<'a, S: DateStyler> {
     display_date: Date,
     events: S,

--- a/src/widgets/canvas/circle.rs
+++ b/src/widgets/canvas/circle.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Shape to draw a circle with a given center and radius and with the given color
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Circle {
     pub x: f64,
     pub y: f64,

--- a/src/widgets/canvas/line.rs
+++ b/src/widgets/canvas/line.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Shape to draw a line from (x1, y1) to (x2, y2) with the given color
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Line {
     pub x1: f64,
     pub y1: f64,

--- a/src/widgets/canvas/map.rs
+++ b/src/widgets/canvas/map.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum MapResolution {
     #[default]
     Low,
@@ -23,7 +23,7 @@ impl MapResolution {
 }
 
 /// Shape to draw a world map with the given resolution and color
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Map {
     pub resolution: MapResolution,
     pub color: Color,

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -29,14 +29,14 @@ pub trait Shape {
 }
 
 /// Label to draw some text on the canvas
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Label<'a> {
     x: f64,
     y: f64,
     line: TextLine<'a>,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 struct Layer {
     string: String,
     colors: Vec<Color>,
@@ -51,7 +51,7 @@ trait Grid: Debug {
     fn reset(&mut self);
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 struct BrailleGrid {
     width: u16,
     height: u16,
@@ -114,7 +114,7 @@ impl Grid for BrailleGrid {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 struct CharGrid {
     width: u16,
     height: u16,
@@ -355,7 +355,7 @@ impl<'a> Context<'a> {
 ///         });
 ///     });
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Canvas<'a, F>
 where
     F: Fn(&mut Context),

--- a/src/widgets/canvas/points.rs
+++ b/src/widgets/canvas/points.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A shape to draw a group of points with the given color
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Points<'a> {
     pub coords: &'a [(f64, f64)],
     pub color: Color,

--- a/src/widgets/canvas/rectangle.rs
+++ b/src/widgets/canvas/rectangle.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// Shape to draw a rectangle from a `Rect` with the given color
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Rectangle {
     pub x: f64,
     pub y: f64,

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// An X or Y axis for the chart widget
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Axis<'a> {
     /// Title displayed next to axis end
     title: Option<TextLine<'a>>,
@@ -76,7 +76,7 @@ impl<'a> Axis<'a> {
 }
 
 /// Used to determine which style of graphing to use
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum GraphType {
     /// Draw each point
     #[default]
@@ -86,7 +86,7 @@ pub enum GraphType {
 }
 
 /// A group of data points
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Dataset<'a> {
     /// Name of the dataset (used in the legend if shown)
     name: Cow<'a, str>,
@@ -132,7 +132,7 @@ impl<'a> Dataset<'a> {
 
 /// A container that holds all the infos about where to display each elements of the chart (axis,
 /// labels, legend, ...).
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 struct ChartLayout {
     /// Location of the title of the x axis
     title_x: Option<(u16, u16)>,
@@ -188,7 +188,7 @@ struct ChartLayout {
 ///         .bounds([0.0, 10.0])
 ///         .labels(["0.0", "5.0", "10.0"].iter().cloned().map(Span::from).collect()));
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Chart<'a> {
     /// A block to display around the widget eventually
     block: Option<Block<'a>>,

--- a/src/widgets/clear.rs
+++ b/src/widgets/clear.rs
@@ -23,7 +23,7 @@ use crate::{buffer::Buffer, layout::Rect, widgets::Widget};
 ///
 /// For a more complete example how to utilize `Clear` to realize popups see
 /// the example `examples/popup.rs`
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Clear;
 
 impl Widget for Clear {

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -19,7 +19,7 @@ use crate::{
 ///     .gauge_style(Style::default().fg(Color::White).bg(Color::Black).add_modifier(Modifier::ITALIC))
 ///     .percent(20);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Gauge<'a> {
     block: Option<Block<'a>>,
     ratio: f64,
@@ -179,7 +179,7 @@ fn get_unicode_block<'a>(frac: f64) -> &'a str {
 ///     .line_set(symbols::line::THICK)
 ///     .ratio(0.4);
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct LineGauge<'a> {
     block: Option<Block<'a>>,
     ratio: f64,

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -8,7 +8,7 @@ use crate::{
     widgets::{Block, StatefulWidget, Widget},
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct ListState {
     offset: usize,
     selected: Option<usize>,
@@ -45,7 +45,7 @@ impl ListState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ListItem<'a> {
     content: Text<'a>,
     style: Style,
@@ -90,7 +90,7 @@ impl<'a> ListItem<'a> {
 ///     .highlight_style(Style::default().add_modifier(Modifier::ITALIC))
 ///     .highlight_symbol(">>");
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct List<'a> {
     block: Option<Block<'a>>,
     items: Vec<ListItem<'a>>,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -53,7 +53,7 @@ use crate::{buffer::Buffer, layout::Rect};
 
 bitflags! {
     /// Bitflags that can be composed to set the visible borders essentially on the block widget.
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    #[derive(Default, Clone, Copy, Eq, PartialEq)]
     pub struct Borders: u8 {
         /// Show no border (default)
         const NONE   = 0b0000;

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -42,7 +42,7 @@ fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) 
 ///     .alignment(Alignment::Center)
 ///     .wrap(Wrap { trim: true });
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Paragraph<'a> {
     /// A block to wrap the widget in
     block: Option<Block<'a>>,
@@ -85,7 +85,7 @@ pub struct Paragraph<'a> {
 /// //     - Here is another point
 /// // that is long enough to wrap
 /// ```
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct Wrap {
     /// Should leading whitespace be trimmed
     pub trim: bool,

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -35,7 +35,7 @@ pub enum ScrollDirection {
 ///
 /// If you don't have multi-line content, you can leave the `viewport_content_length` set to the
 /// default of 0 and it'll use the track size as a `viewport_content_length`.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct ScrollbarState {
     // The current position within the scrollable content.
     position: u16,
@@ -101,7 +101,7 @@ impl ScrollbarState {
 }
 
 /// Scrollbar Orientation
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub enum ScrollbarOrientation {
     #[default]
     VerticalRight,

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -21,7 +21,7 @@ use crate::{
 ///     .max(5)
 ///     .style(Style::default().fg(Color::Red).bg(Color::White));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Sparkline<'a> {
     /// A block to wrap the widget in
     block: Option<Block<'a>>,
@@ -38,7 +38,7 @@ pub struct Sparkline<'a> {
     direction: RenderDirection,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum RenderDirection {
     #[default]
     LeftToRight,

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -32,7 +32,7 @@ use crate::{
 ///
 /// You can apply a [`Style`] on the entire [`Cell`] using [`Cell::style`] or rely on the styling
 /// capabilities of [`Text`].
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Cell<'a> {
     content: Text<'a>,
     style: Style,
@@ -99,7 +99,7 @@ impl<'a> Styled for Cell<'a> {
 /// ```
 ///
 /// By default, a row has a height of 1 but you can change this using [`Row::height`].
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Row<'a> {
     cells: Vec<Cell<'a>>,
     height: u16,
@@ -372,7 +372,7 @@ impl<'a> Styled for Table<'a> {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct TableState {
     offset: usize,
     selected: Option<usize>,

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -23,7 +23,7 @@ use crate::{
 ///     .highlight_style(Style::default().fg(Color::Yellow))
 ///     .divider(DOT);
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Tabs<'a> {
     /// A block to wrap this widget in if necessary
     block: Option<Block<'a>>,


### PR DESCRIPTION
Also reorder some derive fields to be more consistent:

    Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash

see: https://github.com/ratatui-org/ratatui/issues/307