### PR TITLE
feat(release): add automated nightly releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,8 +15,8 @@ defaults:
     shell: bash
 
 jobs:
-  publish-nightly:
-    name: Create a nightly release
+  publish-alpha:
+    name: Create an alpha release
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
@@ -42,7 +42,7 @@ jobs:
           msg="# crate version"
           sed -E -i "s/^version = .* ${msg}$/version = \"${next_tag#v}\" ${msg}/" Cargo.toml
           echo "NEXT_TAG=${next_tag}" >> $GITHUB_ENV
-          echo "Next nightly release: ${next_tag} 🐭"
+          echo "Next alpha release: ${next_tag} 🐭"
 
       - name: Publish on crates.io
         uses: actions-rs/cargo@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,16 +27,20 @@ jobs:
 
       - name: Calculate the next release
         run: |
-          suffix="-alpha"
+          suffix="alpha"
           last_tag="$(git describe --abbrev=0 --tags `git rev-list --tags --max-count=1`)"
-          if [[ "${last_tag}" = *"${suffix}"* ]]; then
+          if [[ "${last_tag}" = *"-${suffix}"* ]]; then
             # increment the alpha version
-            alpha=$(echo "${last_tag}" | grep -oE '([0-9]+)$')
-            next_alpha=$((alpha + 1))
-            next_tag=$(echo "${last_tag}" | sed "s/\.[0-9]\+$/\.${next_alpha}/")
+            # e.g. v0.22.1-alpha.12 -> v0.22.1-alpha.13
+            alpha="${last_tag##*-${suffix}.}"
+            next_alpha="$((alpha + 1))"
+            next_tag="${last_tag/%${alpha}/${next_alpha}}"
           else
-            # start the alpha version from 0
-            next_tag="${last_tag}${suffix}.0"
+            # increment the patch and start the alpha version from 0
+            # e.g. v0.22.0 -> v0.22.1-alpha.0
+            patch="${last_tag##*.}"
+            next_patch="$((patch + 1))"
+            next_tag="${last_tag/%${patch}/${next_patch}}-${suffix}.0"
           fi
           # update the crate version
           msg="# crate version"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,18 +1,79 @@
 name: Continuous Deployment
 
 on:
+  workflow_dispatch:
+  schedule:
+    # At 00:00 on Saturday
+    # https://crontab.guru/#0_0_*_*_6
+    - cron: "0 0 * * 6"
   push:
     tags:
       - "v*.*.*"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  publish:
-    name: Publish on crates.io
+  publish-nightly:
+    name: Create a nightly release
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-      - name: Publish
+        with:
+          fetch-depth: 0
+
+      - name: Calculate the next release
+        run: |
+          suffix="-alpha"
+          last_tag="$(git describe --abbrev=0 --tags `git rev-list --tags --max-count=1`)"
+          if [[ "${last_tag}" = *"${suffix}"* ]]; then
+            # increment the alpha version
+            alpha=$(echo "${last_tag}" | grep -oE '([0-9]+)$')
+            next_alpha=$((alpha + 1))
+            next_tag=$(echo "${last_tag}" | sed "s/\.[0-9]\+$/\.${next_alpha}/")
+          else
+            # start the alpha version from 0
+            next_tag="${last_tag}${suffix}.0"
+          fi
+          # update the crate version
+          msg="# crate version"
+          sed -E -i "s/^version = .* ${msg}$/version = \"${next_tag#v}\" ${msg}/" Cargo.toml
+          echo "NEXT_TAG=${next_tag}" >> $GITHUB_ENV
+          echo "Next nightly release: ${next_tag} 🐭"
+
+      - name: Publish on crates.io
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --allow-dirty --token ${{ secrets.CARGO_TOKEN }}
+
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v2
+        with:
+          config: cliff.toml
+          args: --unreleased --tag ${{ env.NEXT_TAG }} --strip header
+        env:
+          OUTPUT: BODY.md
+
+      - name: Publish on GitHub
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ env.NEXT_TAG }}
+          prerelease: true
+          bodyFile: BODY.md
+
+  publish-stable:
+    name: Create a stable release
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Publish on crates.io
         uses: actions-rs/cargo@v1
         with:
           command: publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui"
-version = "0.22.0"
+version = "0.22.0" # crate version
 authors = ["Florian Dehau <work@fdehau.com>", "The Ratatui Developers"]
 description = "A library to build rich terminal user interfaces or dashboards"
 documentation = "https://docs.rs/ratatui/latest/ratatui/"


### PR DESCRIPTION
As discussed in the [last meeting](https://github.com/ratatui-org/ratatui/discussions/316), this PR updates the release workflow (`cd.yml`) for creating periodic nightly releases.

The version schema is `<version>-alpha.<num>` and `<num>` is increased each time the workflow runs. It is also possible to trigger a nightly release manually via the GitHub interface (see [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow)).

Tested here: https://github.com/orhun/tui-rs-revival/tags

Closes #147
