### PR TITLE
chore(toolchain)!: bump msrv to 1.67

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        toolchain: [ "1.65.0", "stable" ]
+        toolchain: [ "1.67.0", "stable" ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -130,7 +130,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        toolchain: [ "1.65.0", "stable" ]
+        toolchain: [ "1.67.0", "stable" ]
         backend: [ crossterm, termion, termwiz ]
         exclude:
           # termion is not supported on windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 autoexamples = true
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 
 [badges]
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ you are interested in working on a PR or issue opened in the previous repository
 
 ## Rust version requirements
 
-Since version 0.21.0, The Minimum Supported Rust Version (MSRV) of `ratatui` is 1.65.0.
+Since version 0.21.0, The Minimum Supported Rust Version (MSRV) of `ratatui` is 1.67.0.
 
 ## Documentation
 


### PR DESCRIPTION
This updates the msrv to  `1.67`.

Because an optional dependency of ratatui requires it.

Alternatives: Choose to not bump the versions for optional dependencies, or pin the time version to the latest version that supports `1.65`


<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
