### PR TITLE
ci: don't fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
 
   check:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         toolchain: [ "1.65.0", "stable" ]
@@ -111,6 +112,7 @@ jobs:
 
   test-doc:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
@@ -128,6 +130,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         toolchain: [ "1.65.0", "stable" ]


### PR DESCRIPTION
Run all the tests rather than canceling when one test fails. This allows
us to see all the failures, rather than just the first one if there are
multiple. Specifically this is useful when we have an issue in one
toolchain or backend.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
