### PR TITLE
test(block): add benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,11 @@ rand = "0.8"
 name = "paragraph"
 harness = false
 
+[[bench]]
+name = "block"
+harness = false
+
+
 [[example]]
 name = "barchart"
 required-features = ["crossterm"]

--- a/benches/block.rs
+++ b/benches/block.rs
@@ -1,0 +1,58 @@
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    prelude::Alignment,
+    widgets::{
+        block::{Position, Title},
+        Block, Borders, Padding, Widget,
+    },
+};
+
+/// Benchmark for rendering a block.
+pub fn block(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block");
+
+    for buffer_size in &[
+        Rect::new(0, 0, 100, 50),  // vertically split screen
+        Rect::new(0, 0, 200, 50),  // 1080p fullscreen with medium font
+        Rect::new(0, 0, 256, 256), // Max sized area
+    ] {
+        let buffer_area = buffer_size.area();
+
+        // Render an empty block
+        group.bench_with_input(
+            BenchmarkId::new("render_empty", buffer_area),
+            &Block::new(),
+            |b, block| render(b, block, buffer_size),
+        );
+
+        // Render with all features
+        group.bench_with_input(
+            BenchmarkId::new("render_all_feature", buffer_area),
+            &Block::new()
+                .borders(Borders::ALL)
+                .title("test title")
+                .title(
+                    Title::from("bottom left title")
+                        .alignment(Alignment::Right)
+                        .position(Position::Bottom),
+                )
+                .padding(Padding::new(5, 5, 2, 2)),
+            |b, block| render(b, block, buffer_size),
+        );
+    }
+
+    group.finish();
+}
+
+/// render the block into a buffer of the given `size`
+fn render(bencher: &mut Bencher, block: &Block, size: &Rect) {
+    let mut buffer = Buffer::empty(*size);
+    bencher.iter(|| {
+        block.clone().render(buffer.area, &mut buffer);
+    })
+}
+
+criterion_group!(benches, block);
+criterion_main!(benches);


### PR DESCRIPTION
# Description

I added benchmarks to the `block` widget to uncover eventual performance issues.  
I tried to cover common (creation, render) or expensive (inner area) calculations. I also ran the benchmark with three different common buffer sizes.  
From what I can see it doesn't seem to have any bottleneck here.

What is covered by the benches :

- `Block` creation
- Render with different parameters (empty, titles, borders, padding)
- Computing inner area

# Details

- This PR adds benchmarks only for `block`. I think it's a better idea to split the work on benchmarks to add them incrementally.

- I'm not sure the `black_box` is really necessary for the `block` creation bench. Otherwise the compiler advises to put the `new` function reference as parameter (see below). I'm afraid this is less legible and might not work as expected.
```rust
group.bench_function("new", |b| b.iter(Block::new));
```

- Lastly, I have a small concern about my benches reports not looking the same as the `paragraph` ones : 
![image](https://github.com/ratatui-org/ratatui/assets/36198422/94c9b2cb-c2d5-4fcc-86fb-f4f8e82f8fcb)
I based myself off of this bench (the `paragraph` one), so I'm not sure this is the expected behavior (works in the terminal and results are correct once clicked on though).

---
This PR relates to #137.

Thank you for your review and your work.