### PR TITLE
feat(widgets::table): add option to always allocate the "selection" constraint

### DIFF
--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -46,7 +46,7 @@ pub use self::{
     paragraph::{Paragraph, Wrap},
     scrollbar::{ScrollDirection, Scrollbar, ScrollbarOrientation, ScrollbarState},
     sparkline::{RenderDirection, Sparkline},
-    table::{Cell, Row, Table, TableState},
+    table::{Cell, HighlightSpacing, Row, Table, TableState},
     tabs::Tabs,
 };
 use crate::{buffer::Buffer, layout::Rect};

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -160,23 +160,24 @@ impl<'a> Styled for Row<'a> {
     }
 }
 
-/// This option allows to configure the behavior of the "highlight symbol" column width allocation
+/// This option allows the user to configure the "highlight symbol" column width spacing
 #[derive(Debug, PartialEq, Eq, Clone, Default, Hash)]
 pub enum HighlightSpacing {
-    /// Always add spacing for the row selection symbol
+    /// Always add spacing for the selection symbol column
     ///
     /// With this variant, the column for the selection symbol will always be allocated, and so the
     /// table will never change size, regardless of if a row is selected or not
     Always,
-    /// Only add spacing for the row selection symbol, if a row is selected
+    /// Only add spacing for the selection symbol column if a row is selected
     ///
     /// With this variant, the column for the selection symbol will only be allocated if there is a
     /// selection, causing the table to shift if selected / unselected
     #[default]
     WhenSelected,
-    /// Never add spacing selection symbol spacing, regardless of if something is selected or not
+    /// Never add spacing to the selection symbol column, regardless of whether something is
+    /// selected or not
     ///
-    /// This effectively changes that the highlight symbol will never be drawn
+    /// This means that the highlight symbol will never be drawn
     Never,
 }
 
@@ -323,7 +324,7 @@ impl<'a> Table<'a> {
 
     /// Set when to show the highlight spacing
     ///
-    /// see [HighlightSpacing] about which variant affects spacing in which way
+    /// See [HighlightSpacing] about which variant affects spacing in which way
     pub fn highlight_spacing(mut self, value: HighlightSpacing) -> Self {
         self.highlight_spacing = value;
         self

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -321,8 +321,10 @@ impl<'a> Table<'a> {
         self
     }
 
-    /// Set which style of selection space allocation to use
-    pub fn highlight_set_selection_space(mut self, value: HighlightSpacing) -> Self {
+    /// Set when to show the highlight spacing
+    ///
+    /// see [HighlightSpacing] about which variant affects spacing in which way
+    pub fn highlight_spacing(mut self, value: HighlightSpacing) -> Self {
         self.highlight_spacing = value;
         self
     }

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -628,7 +628,7 @@ fn widgets_table_enable_always_highlight_spacing() {
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
                 .block(Block::default().borders(Borders::ALL))
                 .highlight_symbol(">> ")
-                .highlight_set_selection_space(space)
+                .highlight_spacing(space)
                 .widths(&[
                     Constraint::Length(5),
                     Constraint::Length(5),


### PR DESCRIPTION
This PR adds a option for `Table` to always allocate the "selection column", regardless of if something is selected, this way there is less "moving around" of the layout.

The default is still `false` (only allocated if something is selected), but it can both be enabled or disabled in a builder function.

Note: also renamed some internal variables to better reflect on what they do / track