### PR TITLE
feat(widgets/chart): add option to set the position of legend

### DIFF
--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -249,6 +249,7 @@ fn ui(f: &mut Frame, app: &App) {
                 .style(Style::default().fg(Color::Gray))
                 .bounds([0.0, 5.0])
                 .labels(vec!["0".bold(), "2.5".into(), "5".bold()]),
-        );
+        )
+        .legend_position(Some(LegendPosition::TopLeft));
     f.render_widget(chart, chunks[2]);
 }

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -221,7 +221,8 @@ fn ui(f: &mut Frame, app: &App) {
                 .style(Style::default().fg(Color::Gray))
                 .bounds([0.0, 5.0])
                 .labels(vec!["0".bold(), "2.5".into(), "5.0".bold()]),
-        );
+        )
+        .hidden_legend_constraints((Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)));
     f.render_widget(chart, chunks[1]);
 
     let datasets = vec![Dataset::default()
@@ -250,6 +251,7 @@ fn ui(f: &mut Frame, app: &App) {
                 .bounds([0.0, 5.0])
                 .labels(vec!["0".bold(), "2.5".into(), "5".bold()]),
         )
-        .legend_position(Some(LegendPosition::TopLeft));
+        .legend_position(Some(LegendPosition::TopLeft))
+        .hidden_legend_constraints((Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)));
     f.render_widget(chart, chunks[2]);
 }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -43,7 +43,7 @@ use bitflags::bitflags;
 pub use self::{
     barchart::{Bar, BarChart, BarGroup},
     block::{Block, BorderType, Padding},
-    chart::{Axis, Chart, Dataset, GraphType},
+    chart::{Axis, Chart, Dataset, GraphType, LegendPosition},
     clear::Clear,
     gauge::{Gauge, LineGauge},
     list::{List, ListDirection, ListItem, ListState},

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -317,7 +317,8 @@ pub struct Chart<'a> {
     style: Style,
     /// Constraints used to determine whether the legend should be shown or not
     hidden_legend_constraints: (Constraint, Constraint),
-    /// The position of a legend
+    /// The position detnermine where the legenth is shown or hide regaurdless of
+    /// `hidden_legend_constraints`
     legend_position: Option<LegendPosition>,
 }
 
@@ -330,7 +331,7 @@ impl<'a> Chart<'a> {
             style: Style::default(),
             datasets,
             hidden_legend_constraints: (Constraint::Ratio(1, 4), Constraint::Ratio(1, 4)),
-            legend_position: Some(LegendPosition::TopRight),
+            legend_position: Some(LegendPosition::default()),
         }
     }
 
@@ -379,7 +380,10 @@ impl<'a> Chart<'a> {
         self
     }
 
-    /// Set the position of a legend.
+    /// Set the position of a legend or hide it.
+    ///
+    /// If [`None`], hide the legend even if satisfied with
+    /// [`hidden_legend_constraints`](Self::hidden_legend_constraints)
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Migerated PR from tui-rs is #25

Add option to position the legend at corner. The option uses tui::layout::Corner emum that already made.
If the layout have axis title, the layout draw the legend position above x axis title or under y axis title.

Examples all positions of legend
![ratatui-chart-legend](https://github.com/ratatui-org/ratatui/assets/4014016/02446c18-2184-4cb8-9cec-bb9ad1d71982)

I make 3 tests for each corners of legend based on original test for legend.

