### PR TITLE
test(sparkline): added benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,11 +58,15 @@ itertools = "0.10"
 rand = "0.8"
 
 [[bench]]
+name = "block"
+harness = false
+
+[[bench]]
 name = "paragraph"
 harness = false
 
 [[bench]]
-name = "block"
+name = "sparkline"
 harness = false
 
 

--- a/benches/sparkline.rs
+++ b/benches/sparkline.rs
@@ -1,0 +1,45 @@
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
+use rand::Rng;
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    widgets::{Sparkline, Widget},
+};
+
+/// Benchmark for rendering a sparkline.
+pub fn sparkline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparkline");
+    let mut rng = rand::thread_rng();
+
+    for data_count in [64, 256, 2048] {
+        let data: Vec<u64> = (0..data_count)
+            .map(|_| rng.gen_range(0..data_count))
+            .collect();
+
+        // Render a basic sparkline
+        group.bench_with_input(
+            BenchmarkId::new("render", data_count),
+            &Sparkline::default().data(&data),
+            render,
+        );
+    }
+
+    group.finish();
+}
+
+/// render the block into a buffer of the given `size`
+fn render(bencher: &mut Bencher, sparkline: &Sparkline) {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 200, 50));
+    // We use `iter_batched` to clone the value in the setup function.
+    // See https://github.com/ratatui-org/ratatui/pull/377.
+    bencher.iter_batched(
+        || sparkline.clone(),
+        |bench_sparkline| {
+            bench_sparkline.render(buffer.area, &mut buffer);
+        },
+        criterion::BatchSize::LargeInput,
+    )
+}
+
+criterion_group!(benches, sparkline);
+criterion_main!(benches);


### PR DESCRIPTION
# Description

This PR adds benchmark for the `sparkline` widget testing a basic render with different amounts of data.

# Reports
The `sparkline` renders only the values that can fit in the buffer width (200 for this test), above that amount, there is almost no difference in the performance.

![image](https://github.com/ratatui-org/ratatui/assets/36198422/fb52d3b9-1629-4864-a76a-d7ac04fe7650)
