### PR TITLE
feat(list): add option to always allocate the "selection" column width

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -151,7 +151,7 @@ impl<'a> List<'a> {
 
     /// Set when to show the highlight spacing
     ///
-    /// See [HighlightSpacing] about which variant affects spacing in which way
+    /// See [`HighlightSpacing`] about which variant affects spacing in which way
     pub fn highlight_spacing(mut self, value: HighlightSpacing) -> Self {
         self.highlight_spacing = value;
         self

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -324,7 +324,7 @@ impl<'a> Table<'a> {
 
     /// Set when to show the highlight spacing
     ///
-    /// See [HighlightSpacing] about which variant affects spacing in which way
+    /// See [`HighlightSpacing`] about which variant affects spacing in which way
     pub fn highlight_spacing(mut self, value: HighlightSpacing) -> Self {
         self.highlight_spacing = value;
         self


### PR DESCRIPTION
Before this option was available, selecting a item in a list when nothing was selected previously made the row layout change (the same applies to unselecting) by adding the width of the "highlight symbol" in the front of the list, this option allows to configure this behavior.

re #375

TL;DR: the same as #375, but for `widgets::List`

implementing this for list was easier than `Table` because it already had basically everything in-place