### PR TITLE
Add weak constraints to make rects closer to each other in size 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ bitflags = "2.3"
 cassowary = "0.3"
 crossterm = { version = "0.27", optional = true }
 indoc = "2.0"
+itertools = "0.11"
 paste = "1.0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
 termion = { version = "2.0", optional = true }
@@ -56,7 +57,6 @@ cargo-husky = { version = "1.5.0", default-features = false, features = [
 ] }
 criterion = { version = "0.5", features = ["html_reports"] }
 fakeit = "1.1"
-itertools = "0.10"
 rand = "0.8"
 pretty_assertions = "1.4.0"
 

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -2,7 +2,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     buffer::Buffer,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect, SegmentSize},
     style::{Style, Styled},
     text::Text,
     widgets::{Block, StatefulWidget, Widget},
@@ -350,7 +350,7 @@ impl<'a> Table<'a> {
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(constraints)
-            .expand_to_fill(false)
+            .segment_size(SegmentSize::None)
             .split(Rect {
                 x: 0,
                 y: 0,


### PR DESCRIPTION
This PR introduces a `SegmentSize` `enum` that will allow adding the following constraints optionally:


```rust

        for i in 0..elements.len() {
            for j in (i + 1)..elements.len() {
                solver.add_constraint(elements[j].size() | EQ(WEAK) | (elements[i].size()))?;
            }
        }

```

This makes chunks similar in size to each other if other constraints are satisfied.

This PR also changes the implementation of `Max` and `Min` by adding a `MEDIUM` equality constraint instead of a `WEAK` equality constraint. 

```diff
     Constraint::Max(m) => {
         solver.add_constraints(&[                           
             element.size() | LE(STRONG) | f64::from(m),     
-            element.size() | EQ(WEAK) | f64::from(m),
+            element.size() | EQ(MEDIUM) | f64::from(m),
         ])?;                                                
     }                                                       
     Constraint::Min(m) => {                                 
         solver.add_constraints(&[                           
             element.size() | GE(STRONG) | f64::from(m),     
-            element.size() | EQ(WEAK) | f64::from(m),
+            element.size() | EQ(MEDIUM) | f64::from(m),
         ])?;                                                
     }                                                       
```

It should result in the same layouts for us though, because there were no other `MEDIUM` constraints used.