### PR TITLE
refactor(layout): extract common constraints into function

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -323,18 +323,16 @@ fn split(area: Rect, layout: &Layout) -> Rc<[Rect]> {
             for pair in elements.windows(2) {
                 ccs.push((pair[0].x + pair[0].width) | EQ(REQUIRED) | pair[1].x);
             }
-            for (i, size) in layout.constraints.iter().enumerate() {
-                add_constraints_for_constraint(&mut ccs, &elements[i], &dest_area, layout.direction, *size);
-            }
+            
         }
         Direction::Vertical => {
             for pair in elements.windows(2) {
                 ccs.push((pair[0].y + pair[0].height) | EQ(REQUIRED) | pair[1].y);
             }
-            for (i, size) in layout.constraints.iter().enumerate() {
-                add_constraints_for_constraint(&mut ccs, &elements[i], &dest_area, layout.direction, *size);
-            }
         }
+    }
+    for (i, size) in layout.constraints.iter().enumerate() {
+        add_constraints_for_constraint(&mut ccs, &elements[i], &dest_area, layout.direction, *size);
     }
     solver.add_constraints(&ccs).unwrap();
     for &(var, value) in solver.fetch_changes() {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -323,7 +323,6 @@ fn split(area: Rect, layout: &Layout) -> Rc<[Rect]> {
             for pair in elements.windows(2) {
                 ccs.push((pair[0].x + pair[0].width) | EQ(REQUIRED) | pair[1].x);
             }
-            
         }
         Direction::Vertical => {
             for pair in elements.windows(2) {
@@ -391,7 +390,13 @@ struct Helper {
 
 /// Helper function to apply [`cassowary::Constraint`]s for a given [`Constraint`]
 #[inline]
-fn add_constraints_for_constraint(ccs: &mut Vec<cassowary::Constraint>, element: &Element, area: &Rect, direction: Direction, constraint: Constraint) {
+fn add_constraints_for_constraint(
+    ccs: &mut Vec<cassowary::Constraint>,
+    element: &Element,
+    area: &Rect,
+    direction: Direction,
+    constraint: Constraint,
+) {
     let helper = match direction {
         Direction::Horizontal => Helper {
             // area_main_axis: dest_area.x,


### PR DESCRIPTION
This PR refactors some duplicated constraints to be in a single function, reducing duplicate code and reducing possible mismatches

(re https://github.com/ratatui-org/ratatui/pull/395#discussion_r1292008364)

marking this PR as Draft, because i dont think the current struct name and field names are going to stay this way
also because i want to know if this is even a change that is wanted instead of having vertical and horizontal constraints separate, even if they are the same
(also some cleanup would need to be done, like removing commented-out fields)