### PR TITLE
fix(release): set the correct permissions for creating alpha releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,8 @@ jobs:
   publish-alpha:
     name: Create an alpha release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ !startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
The latest [alpha release job](https://github.com/ratatui-org/ratatui/actions/runs/5838396596) failed due to this.
