### PR TITLE
refactor(layout): simplify and doc split()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 fakeit = "1.1"
 itertools = "0.10"
 rand = "0.8"
+pretty_assertions = "1.4.0"
 
 [[bench]]
 name = "block"

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -93,6 +93,7 @@ impl TestBackend {
     /// Asserts that the TestBackend's buffer is equal to the expected buffer.
     /// If the buffers are not equal, a panic occurs with a detailed error message
     /// showing the differences between the expected and actual buffers.
+    #[track_caller]
     pub fn assert_buffer(&self, expected: &Buffer) {
         assert_eq!(expected.area, self.buffer.area);
         let diff = expected.diff(&self.buffer);

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use cassowary::{
-    strength::{MEDIUM, REQUIRED, WEAK},
-    Constraint as CassowaryConstraint, Expression, Solver, Variable,
+    strength::{REQUIRED, STRONG, WEAK},
+    AddConstraintError, Expression, Solver, Variable,
     WeightedRelation::{EQ, GE, LE},
 };
 
@@ -132,6 +132,106 @@ pub enum Alignment {
     Right,
 }
 
+/// A simple rectangle used in the computation of the layout and to give widgets a hint about the
+/// area they are supposed to render to.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Rect {
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+impl Rect {
+    /// Creates a new rect, with width and height limited to keep the area under max u16.
+    /// If clipped, aspect ratio will be preserved.
+    pub fn new(x: u16, y: u16, width: u16, height: u16) -> Rect {
+        let max_area = u16::max_value();
+        let (clipped_width, clipped_height) =
+            if u32::from(width) * u32::from(height) > u32::from(max_area) {
+                let aspect_ratio = f64::from(width) / f64::from(height);
+                let max_area_f = f64::from(max_area);
+                let height_f = (max_area_f / aspect_ratio).sqrt();
+                let width_f = height_f * aspect_ratio;
+                (width_f as u16, height_f as u16)
+            } else {
+                (width, height)
+            };
+        Rect {
+            x,
+            y,
+            width: clipped_width,
+            height: clipped_height,
+        }
+    }
+
+    pub const fn area(self) -> u16 {
+        self.width * self.height
+    }
+
+    pub const fn left(self) -> u16 {
+        self.x
+    }
+
+    pub const fn right(self) -> u16 {
+        self.x.saturating_add(self.width)
+    }
+
+    pub const fn top(self) -> u16 {
+        self.y
+    }
+
+    pub const fn bottom(self) -> u16 {
+        self.y.saturating_add(self.height)
+    }
+
+    pub fn inner(self, margin: &Margin) -> Rect {
+        if self.width < 2 * margin.horizontal || self.height < 2 * margin.vertical {
+            Rect::default()
+        } else {
+            Rect {
+                x: self.x + margin.horizontal,
+                y: self.y + margin.vertical,
+                width: self.width - 2 * margin.horizontal,
+                height: self.height - 2 * margin.vertical,
+            }
+        }
+    }
+
+    pub fn union(self, other: Rect) -> Rect {
+        let x1 = min(self.x, other.x);
+        let y1 = min(self.y, other.y);
+        let x2 = max(self.x + self.width, other.x + other.width);
+        let y2 = max(self.y + self.height, other.y + other.height);
+        Rect {
+            x: x1,
+            y: y1,
+            width: x2 - x1,
+            height: y2 - y1,
+        }
+    }
+
+    pub fn intersection(self, other: Rect) -> Rect {
+        let x1 = max(self.x, other.x);
+        let y1 = max(self.y, other.y);
+        let x2 = min(self.x + self.width, other.x + other.width);
+        let y2 = min(self.y + self.height, other.y + other.height);
+        Rect {
+            x: x1,
+            y: y1,
+            width: x2 - x1,
+            height: y2 - y1,
+        }
+    }
+
+    pub const fn intersects(self, other: Rect) -> bool {
+        self.x < other.x + other.width
+            && self.x + self.width > other.x
+            && self.y < other.y + other.height
+            && self.y + self.height > other.y
+    }
+}
+
 /// A layout is a set of constraints that can be applied to a given area to split it into smaller
 /// ones.
 ///
@@ -184,12 +284,6 @@ pub struct Layout {
     /// Whether the last chunk of the computed layout should be expanded to fill the available
     /// space.
     expand_to_fill: bool,
-}
-
-type Cache = HashMap<(Rect, Layout), Rc<[Rect]>>;
-thread_local! {
-    // TODO: Maybe use a fixed size cache https://github.com/ratatui-org/ratatui/issues/402
-    static LAYOUT_CACHE: RefCell<Cache> = RefCell::new(HashMap::new());
 }
 
 impl Default for Layout {
@@ -365,263 +459,155 @@ impl Layout {
     }
 }
 
+type Cache = HashMap<(Rect, Layout), Rc<[Rect]>>;
+thread_local! {
+    // TODO: Maybe use a fixed size cache https://github.com/ratatui-org/ratatui/issues/402
+    static LAYOUT_CACHE: RefCell<Cache> = RefCell::new(HashMap::new());
+}
+
+/// A container used by the solver inside split
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+struct Element {
+    start: Variable,
+    end: Variable,
+}
+
+impl Element {
+    fn new() -> Element {
+        Element {
+            start: Variable::new(),
+            end: Variable::new(),
+        }
+    }
+
+    fn size(&self) -> Expression {
+        self.end - self.start
+    }
+}
+
 fn split(area: Rect, layout: &Layout) -> Rc<[Rect]> {
+    try_split(area, layout).expect("failed to split")
+}
+
+fn try_split(area: Rect, layout: &Layout) -> Result<Rc<[Rect]>, AddConstraintError> {
     let mut solver = Solver::new();
+    let inner = area.inner(&layout.margin);
+
+    let (start, end) = match layout.direction {
+        Direction::Horizontal => (inner.x, inner.right()),
+        Direction::Vertical => (inner.y, inner.bottom()),
+    };
+
+    // setup the bounds of the area
+    let area = Element::new();
+    solver.add_constraints(&[
+        area.start | EQ(REQUIRED) | f64::from(start),
+        area.end | EQ(REQUIRED) | f64::from(end),
+    ])?;
+
+    // create an element for each constraint that needs to be applied. Each element defines the
+    // variables that will be used to compute the layout.
     let elements = layout
         .constraints
         .iter()
         .map(|_| Element::new())
         .collect::<Vec<Element>>();
 
-    let dest_area = area.inner(&layout.margin);
-    let mut ccs: Vec<CassowaryConstraint> =
-        Vec::with_capacity(elements.len() * 4 + layout.constraints.len() * 6);
-    for elt in &elements {
-        ccs.push(elt.width | GE(REQUIRED) | 0f64);
-        ccs.push(elt.height | GE(REQUIRED) | 0f64);
-        ccs.push(elt.left() | GE(REQUIRED) | f64::from(dest_area.left()));
-        ccs.push(elt.top() | GE(REQUIRED) | f64::from(dest_area.top()));
-        ccs.push(elt.right() | LE(REQUIRED) | f64::from(dest_area.right()));
-        ccs.push(elt.bottom() | LE(REQUIRED) | f64::from(dest_area.bottom()));
+    // ensure that all the elements are inside the area
+    for element in &elements {
+        solver.add_constraints(&[
+            element.start | GE(REQUIRED) | area.start,
+            element.end | LE(REQUIRED) | area.end,
+        ])?;
     }
+    // ensure there are no gaps between the elements
+    for pair in elements.windows(2) {
+        solver.add_constraint(pair[0].end | EQ(REQUIRED) | pair[1].start)?;
+    }
+    // ensure the first element touches the left/top edge of the area
     if let Some(first) = elements.first() {
-        ccs.push(match layout.direction {
-            Direction::Horizontal => first.left() | EQ(REQUIRED) | f64::from(dest_area.left()),
-            Direction::Vertical => first.top() | EQ(REQUIRED) | f64::from(dest_area.top()),
-        });
+        solver.add_constraint(first.start | EQ(REQUIRED) | area.start)?;
     }
+    // ensure the last element touches the right/bottom edge of the area
     if layout.expand_to_fill {
         if let Some(last) = elements.last() {
-            ccs.push(match layout.direction {
-                Direction::Horizontal => last.right() | EQ(REQUIRED) | f64::from(dest_area.right()),
-                Direction::Vertical => last.bottom() | EQ(REQUIRED) | f64::from(dest_area.bottom()),
-            });
+            solver.add_constraint(last.end | EQ(REQUIRED) | area.end)?;
         }
     }
-    match layout.direction {
-        Direction::Horizontal => {
-            for pair in elements.windows(2) {
-                ccs.push((pair[0].x + pair[0].width) | EQ(REQUIRED) | pair[1].x);
+    // apply the constraints
+    for (&constraint, &element) in layout.constraints.iter().zip(elements.iter()) {
+        match constraint {
+            Constraint::Percentage(p) => {
+                let percent = f64::from(p) / 100.00;
+                solver.add_constraint(element.size() | EQ(STRONG) | (area.size() * percent))?;
             }
-            for (i, size) in layout.constraints.iter().enumerate() {
-                ccs.push(elements[i].y | EQ(REQUIRED) | f64::from(dest_area.y));
-                ccs.push(elements[i].height | EQ(REQUIRED) | f64::from(dest_area.height));
-                ccs.push(match *size {
-                    Constraint::Length(v) => elements[i].width | EQ(MEDIUM) | f64::from(v),
-                    Constraint::Percentage(v) => {
-                        elements[i].width | EQ(MEDIUM) | (f64::from(v * dest_area.width) / 100.0)
-                    }
-                    Constraint::Ratio(n, d) => {
-                        elements[i].width
-                            | EQ(MEDIUM)
-                            | (f64::from(dest_area.width) * f64::from(n) / f64::from(d))
-                    }
-                    Constraint::Min(v) => elements[i].width | GE(MEDIUM) | f64::from(v),
-                    Constraint::Max(v) => elements[i].width | LE(MEDIUM) | f64::from(v),
-                });
-
-                match *size {
-                    Constraint::Min(v) | Constraint::Max(v) => {
-                        ccs.push(elements[i].width | EQ(WEAK) | f64::from(v));
-                    }
-                    _ => {}
-                }
+            Constraint::Ratio(n, d) => {
+                // avoid division by zero by using 1 when denominator is 0
+                let ratio = f64::from(n) / f64::from(d.max(1));
+                solver.add_constraint(element.size() | EQ(STRONG) | (area.size() * ratio))?;
             }
-        }
-        Direction::Vertical => {
-            for pair in elements.windows(2) {
-                ccs.push((pair[0].y + pair[0].height) | EQ(REQUIRED) | pair[1].y);
+            Constraint::Length(l) => {
+                solver.add_constraint(element.size() | EQ(STRONG) | f64::from(l))?
             }
-            for (i, size) in layout.constraints.iter().enumerate() {
-                ccs.push(elements[i].x | EQ(REQUIRED) | f64::from(dest_area.x));
-                ccs.push(elements[i].width | EQ(REQUIRED) | f64::from(dest_area.width));
-                ccs.push(match *size {
-                    Constraint::Length(v) => elements[i].height | EQ(MEDIUM) | f64::from(v),
-                    Constraint::Percentage(v) => {
-                        elements[i].height | EQ(MEDIUM) | (f64::from(v * dest_area.height) / 100.0)
-                    }
-                    Constraint::Ratio(n, d) => {
-                        elements[i].height
-                            | EQ(MEDIUM)
-                            | (f64::from(dest_area.height) * f64::from(n) / f64::from(d))
-                    }
-                    Constraint::Min(v) => elements[i].height | GE(MEDIUM) | f64::from(v),
-                    Constraint::Max(v) => elements[i].height | LE(MEDIUM) | f64::from(v),
-                });
-
-                match *size {
-                    Constraint::Min(v) | Constraint::Max(v) => {
-                        ccs.push(elements[i].height | EQ(WEAK) | f64::from(v));
-                    }
-                    _ => {}
-                }
+            Constraint::Max(m) => {
+                solver.add_constraints(&[
+                    element.size() | LE(STRONG) | f64::from(m),
+                    element.size() | EQ(WEAK) | f64::from(m),
+                ])?;
+            }
+            Constraint::Min(m) => {
+                solver.add_constraints(&[
+                    element.size() | GE(STRONG) | f64::from(m),
+                    element.size() | EQ(WEAK) | f64::from(m),
+                ])?;
             }
         }
     }
-    solver.add_constraints(&ccs).unwrap();
+
     let changes: HashMap<Variable, f64> = solver.fetch_changes().iter().copied().collect();
+
+    // convert to Rects
     let mut results = elements
         .iter()
-        .map(|element| Rect {
-            x: changes.get(&element.x).map(|&v| v as u16).unwrap_or(0),
-            y: changes.get(&element.y).map(|&v| v as u16).unwrap_or(0),
-            width: changes.get(&element.width).map(|&v| v as u16).unwrap_or(0),
-            height: changes.get(&element.height).map(|&v| v as u16).unwrap_or(0),
+        .map(|element| {
+            let start = *changes.get(&element.start).unwrap_or(&0.0);
+            let end = *changes.get(&element.end).unwrap_or(&0.0);
+            match layout.direction {
+                Direction::Horizontal => Rect {
+                    x: start as u16,
+                    y: inner.y,
+                    width: (end - start) as u16,
+                    height: inner.height,
+                },
+                Direction::Vertical => Rect {
+                    x: inner.x,
+                    y: start as u16,
+                    width: inner.width,
+                    height: (end - start) as u16,
+                },
+            }
         })
         .collect::<Rc<[Rect]>>();
 
     if layout.expand_to_fill {
-        // Fix imprecision by extending the last item a bit if necessary
-        // "unwrap" is safe, because the Rc at this point has no shared references
+        // Because it's not always possible to satisfy all constraints, the last item might be
+        // slightly smaller than the available space. E.g. when the available space is 10, and the
+        // constraints are [Length(5), Max(4)], the last item will be 4 wide instead of 5. Fix this
+        // by extending the last item a bit if necessary. (`unwrap()` is safe here, because results
+        // has no shared references right now).
         if let Some(last) = Rc::get_mut(&mut results).unwrap().last_mut() {
             match layout.direction {
-                Direction::Vertical => {
-                    last.height = dest_area.bottom() - last.y;
-                }
                 Direction::Horizontal => {
-                    last.width = dest_area.right() - last.x;
+                    last.width = inner.right() - last.x;
+                }
+                Direction::Vertical => {
+                    last.height = inner.bottom() - last.y;
                 }
             }
         }
     }
 
-    results
-}
-
-/// A container used by the solver inside split
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-struct Element {
-    x: Variable,
-    y: Variable,
-    width: Variable,
-    height: Variable,
-}
-
-impl Element {
-    fn new() -> Element {
-        Element {
-            x: Variable::new(),
-            y: Variable::new(),
-            width: Variable::new(),
-            height: Variable::new(),
-        }
-    }
-
-    fn left(&self) -> Variable {
-        self.x
-    }
-
-    fn top(&self) -> Variable {
-        self.y
-    }
-
-    fn right(&self) -> Expression {
-        self.x + self.width
-    }
-
-    fn bottom(&self) -> Expression {
-        self.y + self.height
-    }
-}
-
-/// A simple rectangle used in the computation of the layout and to give widgets a hint about the
-/// area they are supposed to render to.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
-pub struct Rect {
-    pub x: u16,
-    pub y: u16,
-    pub width: u16,
-    pub height: u16,
-}
-
-impl Rect {
-    /// Creates a new rect, with width and height limited to keep the area under max u16.
-    /// If clipped, aspect ratio will be preserved.
-    pub fn new(x: u16, y: u16, width: u16, height: u16) -> Rect {
-        let max_area = u16::max_value();
-        let (clipped_width, clipped_height) =
-            if u32::from(width) * u32::from(height) > u32::from(max_area) {
-                let aspect_ratio = f64::from(width) / f64::from(height);
-                let max_area_f = f64::from(max_area);
-                let height_f = (max_area_f / aspect_ratio).sqrt();
-                let width_f = height_f * aspect_ratio;
-                (width_f as u16, height_f as u16)
-            } else {
-                (width, height)
-            };
-        Rect {
-            x,
-            y,
-            width: clipped_width,
-            height: clipped_height,
-        }
-    }
-
-    pub const fn area(self) -> u16 {
-        self.width * self.height
-    }
-
-    pub const fn left(self) -> u16 {
-        self.x
-    }
-
-    pub const fn right(self) -> u16 {
-        self.x.saturating_add(self.width)
-    }
-
-    pub const fn top(self) -> u16 {
-        self.y
-    }
-
-    pub const fn bottom(self) -> u16 {
-        self.y.saturating_add(self.height)
-    }
-
-    pub fn inner(self, margin: &Margin) -> Rect {
-        if self.width < 2 * margin.horizontal || self.height < 2 * margin.vertical {
-            Rect::default()
-        } else {
-            Rect {
-                x: self.x + margin.horizontal,
-                y: self.y + margin.vertical,
-                width: self.width - 2 * margin.horizontal,
-                height: self.height - 2 * margin.vertical,
-            }
-        }
-    }
-
-    pub fn union(self, other: Rect) -> Rect {
-        let x1 = min(self.x, other.x);
-        let y1 = min(self.y, other.y);
-        let x2 = max(self.x + self.width, other.x + other.width);
-        let y2 = max(self.y + self.height, other.y + other.height);
-        Rect {
-            x: x1,
-            y: y1,
-            width: x2 - x1,
-            height: y2 - y1,
-        }
-    }
-
-    pub fn intersection(self, other: Rect) -> Rect {
-        let x1 = max(self.x, other.x);
-        let y1 = max(self.y, other.y);
-        let x2 = min(self.x + self.width, other.x + other.width);
-        let y2 = min(self.y + self.height, other.y + other.height);
-        Rect {
-            x: x1,
-            y: y1,
-            width: x2 - x1,
-            height: y2 - y1,
-        }
-    }
-
-    pub const fn intersects(self, other: Rect) -> bool {
-        self.x < other.x + other.width
-            && self.x + self.width > other.x
-            && self.y < other.y + other.height
-            && self.y + self.height > other.y
-    }
+    Ok(results)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is mainly a reduction in density of the code with a goal of
improving mainatainability so that the algorithm is clear.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

(Testing - the layout example renders the same)