### PR TITLE
Span tests

### DIFF
--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -132,15 +132,12 @@ impl<'a> Span<'a> {
     }
 }
 
-impl<'a> From<String> for Span<'a> {
-    fn from(s: String) -> Span<'a> {
-        Span::raw(s)
-    }
-}
-
-impl<'a> From<&'a str> for Span<'a> {
-    fn from(s: &'a str) -> Span<'a> {
-        Span::raw(s)
+impl<'a, T> From<T> for Span<'a>
+where
+    T: Into<Cow<'a, str>>,
+{
+    fn from(s: T) -> Self {
+        Span::raw(s.into())
     }
 }
 
@@ -180,6 +177,13 @@ mod tests {
         let content_clone = content.clone();
         let span = Span::from(content);
         assert_eq!(span.content, Cow::Owned::<str>(content_clone));
+    }
+
+    #[test]
+    fn from_ref_string_borrowed_cow() {
+        let content = String::from("some string");
+        let span = Span::from(&content);
+        assert_eq!(span.content, Cow::Borrowed(content.as_str()));
     }
 
     #[test]

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -155,3 +155,58 @@ impl<'a> Styled for Span<'a> {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_ref_str_borrowed_cow() {
+        let content = "some string";
+        let span = Span::from(content);
+        assert_eq!(span.content, Cow::Borrowed(content));
+    }
+
+    #[test]
+    fn from_string_ref_str_borrowed_cow() {
+        let content = String::from("some string");
+        let span = Span::from(content.as_str());
+        assert_eq!(span.content, Cow::Borrowed(content.as_str()));
+    }
+
+    #[test]
+    fn from_string_owned_cow() {
+        let content = String::from("some string");
+        let content_clone = content.clone();
+        let span = Span::from(content);
+        assert_eq!(span.content, Cow::Owned::<str>(content_clone));
+    }
+
+    #[test]
+    fn reset_should_set_style_reset() {
+        let mut span = Span::styled("test", Style::default().fg(crate::style::Color::Green));
+
+        assert_eq!(span.style, Style::default().fg(crate::style::Color::Green));
+
+        span.reset_style();
+
+        assert_eq!(span.style, Style::reset());
+        assert_ne!(span.style, Style::default());
+    }
+
+    #[test]
+    fn patch_style() {
+        let mut span = Span::styled("test", Style::default().bg(crate::style::Color::Cyan));
+
+        assert_eq!(span.style, Style::default().bg(crate::style::Color::Cyan));
+
+        span.patch_style(Style::default().fg(crate::style::Color::Green));
+
+        assert_eq!(
+            span.style,
+            Style::default()
+                .bg(crate::style::Color::Cyan)
+                .fg(crate::style::Color::Green)
+        );
+    }
+}


### PR DESCRIPTION
This PR adds some tests for `widget::Span`, also adding a `From<&String>` implementation

what should be done about the doc-tests, should they stay in-place or should they be refactored?