### PR TITLE
chore(codecov): fix yaml syntax

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-	- "examples"
+  - "examples"


### PR DESCRIPTION
a yaml file cannot contain tabs outside of strings

was added by #373, i dont know why codecov is in a state of "working" or "not working"
![Screenshot 2023-08-16 at 12-18-55 Code coverage done right](https://github.com/ratatui-org/ratatui/assets/10911626/989a7b16-a351-4187-891e-454e9e19bdfc)
