### PR TITLE
Fix layout gap

### DIFF
--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -107,7 +107,7 @@ fn render_fg_named_colors<B: Backend>(frame: &mut Frame<B>, bg: Color, area: Rec
         .flat_map(|area| {
             Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints(vec![Constraint::Percentage(13); 8])
+                .constraints(vec![Constraint::Ratio(1, 8); 8])
                 .split(*area)
                 .to_vec()
         })
@@ -132,7 +132,7 @@ fn render_bg_named_colors<B: Backend>(frame: &mut Frame<B>, fg: Color, area: Rec
         .flat_map(|area| {
             Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints(vec![Constraint::Percentage(13); 8])
+                .constraints(vec![Constraint::Ratio(1, 8); 8])
                 .split(*area)
                 .to_vec()
         })

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -304,7 +304,8 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
 
 #[test]
 fn widgets_table_columns_widths_can_use_mixed_constraints() {
-    let test_case = |widths, expected| {
+    #[track_caller]
+    fn test_case(widths: &[Constraint], expected: Buffer) {
         let backend = TestBackend::new(30, 10);
         let mut terminal = Terminal::new(backend).unwrap();
 
@@ -324,7 +325,7 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
-    };
+    }
 
     // columns of zero width show nothing
     test_case(
@@ -356,12 +357,12 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
-            "│Hea Head2                He │",
+            "│Hea Head2                Hea│",
             "│                            │",
-            "│Row Row12                Ro │",
-            "│Row Row22                Ro │",
-            "│Row Row32                Ro │",
-            "│Row Row42                Ro │",
+            "│Row Row12                Row│",
+            "│Row Row22                Row│",
+            "│Row Row32                Row│",
+            "│Row Row42                Row│",
             "│                            │",
             "│                            │",
             "└────────────────────────────┘",
@@ -398,12 +399,12 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
-            "│Head1            Head2      │",
+            "│Head1             Head2     │",
             "│                            │",
-            "│Row11            Row12      │",
-            "│Row21            Row22      │",
-            "│Row31            Row32      │",
-            "│Row41            Row42      │",
+            "│Row11             Row12     │",
+            "│Row21             Row22     │",
+            "│Row31             Row32     │",
+            "│Row41             Row42     │",
             "│                            │",
             "│                            │",
             "└────────────────────────────┘",
@@ -413,7 +414,8 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
 
 #[test]
 fn widgets_table_columns_widths_can_use_ratio_constraints() {
-    let test_case = |widths, expected| {
+    #[track_caller]
+    fn test_case(widths: &[Constraint], expected: Buffer) {
         let backend = TestBackend::new(30, 10);
         let mut terminal = Terminal::new(backend).unwrap();
 
@@ -434,7 +436,7 @@ fn widgets_table_columns_widths_can_use_ratio_constraints() {
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
-    };
+    }
 
     // columns of zero width show nothing
     test_case(
@@ -487,12 +489,12 @@ fn widgets_table_columns_widths_can_use_ratio_constraints() {
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
-            "│Head1    Head2    Head3     │",
+            "│Head1    Head2     Head3    │",
             "│                            │",
-            "│Row11    Row12    Row13     │",
-            "│Row21    Row22    Row23     │",
-            "│Row31    Row32    Row33     │",
-            "│Row41    Row42    Row43     │",
+            "│Row11    Row12     Row13    │",
+            "│Row21    Row22     Row23    │",
+            "│Row31    Row32     Row33    │",
+            "│Row41    Row42     Row43    │",
             "│                            │",
             "│                            │",
             "└────────────────────────────┘",


### PR DESCRIPTION
Fixes https://github.com/ratatui-org/ratatui/issues/367

~~Note: this builds on #405, so it has the commits for that here.~~ Look at just the last commit in this PR to understand it. The relevant change is just the addition of `round()`:
https://github.com/ratatui-org/ratatui/blob/2364d9b3098024459c4360900228e2b3e79fb848/src/layout.rs#L453-L454

Note each of the test changes is a subjectively better rendering choice. I'm not 100% sure if there are some tests that would make it easier to see this change's effect rather than those that are already changed.

I updated the colors example to use a ratio instead of a percentage as this now renders correctly without gaps.

Before (using `constraint: vec![Ratio(1,8); 8]` )

<img width="857" alt="image" src="https://github.com/ratatui-org/ratatui/assets/381361/59b5cbae-738c-40e3-90b6-55afe33de493">

After:

<img width="859" alt="image" src="https://github.com/ratatui-org/ratatui/assets/381361/2a7f4129-6873-4de8-9898-51abcaf6ea6a">
