### PR TITLE
Create rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
This PR adds a `rust-toolchain.toml` to guarantee developers use a stable version of rust. 
