### PR TITLE
fix(release): fix the last tag retrieval for alpha releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Calculate the next release
         run: |
           suffix="alpha"
-          last_tag="$(git describe --abbrev=0 --tags `git rev-list --tags --max-count=1`)"
+          last_tag="$(git tag --sort=committerdate | tail -1)"
           if [[ "${last_tag}" = *"-${suffix}"* ]]; then
             # increment the alpha version
             # e.g. v0.22.1-alpha.12 -> v0.22.1-alpha.13


### PR DESCRIPTION
There are 2 tags (`alpha.0`, `alpha.1`) associated with the same commit and the previous `git` command was failing to retrieve the _latest_ tag.

This PR fixes https://github.com/ratatui-org/ratatui/actions/runs/5908461923/job/16027928791
