### PR TITLE
chore(ci): update the name of the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Continuous Integration
 
 on:
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
For the sake of consistency with:

https://github.com/ratatui-org/ratatui/blob/d2429bc3e44a34197511192dbd215dd32fdf2d9c/.github/workflows/cd.yml#L1
