### PR TITLE
fix(table): fix unit tests broken due to rounding

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -561,6 +561,17 @@ fn try_split(area: Rect, layout: &Layout) -> Result<Rc<[Rect]>, AddConstraintErr
 
     let changes: HashMap<Variable, f64> = solver.fetch_changes().iter().copied().collect();
 
+    // please leave this comment here as it's useful for debugging unit tests when we make any
+    // changes to layout code - we should replace this with tracing in the future.
+    // let ends = format!(
+    //     "{:?}",
+    //     elements
+    //         .iter()
+    //         .map(|e| changes.get(&e.end).unwrap_or(&0.0))
+    //         .collect::<Vec<&f64>>()
+    // );
+    // dbg!(ends);
+
     // convert to Rects
     let results = elements
         .iter()


### PR DESCRIPTION
The merge of the table unit tests after the rounding layout fix was not
rebased correctly, this addresses the broken tests, makes them more
concise while adding comments to help clarify that the rounding behavior
is working as expected.

Fixes the issue mentioned in https://github.com/ratatui-org/ratatui/pull/395#discussion_r1299220841
