### PR TITLE
chore(traits): add Display and FromStr traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ indoc = "2.0"
 itertools = "0.11"
 paste = "1.0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 termion = { version = "2.0", optional = true }
 termwiz = { version = "0.20.0", optional = true }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -27,6 +27,8 @@
 
 use std::io;
 
+use strum::{Display, EnumString};
+
 use crate::{buffer::Cell, layout::Rect};
 
 #[cfg(feature = "termion")]
@@ -49,7 +51,7 @@ pub use self::test::TestBackend;
 
 /// Enum representing the different types of clearing operations that can be performed
 /// on the terminal screen.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ClearType {
     All,
     AfterCursor,
@@ -114,4 +116,42 @@ pub trait Backend {
 
     /// Flush any buffered content to the terminal screen.
     fn flush(&mut self) -> Result<(), io::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::ParseError;
+
+    use super::*;
+
+    #[test]
+    fn clear_type_tostring() {
+        assert_eq!(ClearType::All.to_string(), "All");
+        assert_eq!(ClearType::AfterCursor.to_string(), "AfterCursor");
+        assert_eq!(ClearType::BeforeCursor.to_string(), "BeforeCursor");
+        assert_eq!(ClearType::CurrentLine.to_string(), "CurrentLine");
+        assert_eq!(ClearType::UntilNewLine.to_string(), "UntilNewLine");
+    }
+
+    #[test]
+    fn clear_type_from_str() {
+        assert_eq!("All".parse::<ClearType>(), Ok(ClearType::All));
+        assert_eq!(
+            "AfterCursor".parse::<ClearType>(),
+            Ok(ClearType::AfterCursor)
+        );
+        assert_eq!(
+            "BeforeCursor".parse::<ClearType>(),
+            Ok(ClearType::BeforeCursor)
+        );
+        assert_eq!(
+            "CurrentLine".parse::<ClearType>(),
+            Ok(ClearType::CurrentLine)
+        );
+        assert_eq!(
+            "UntilNewLine".parse::<ClearType>(),
+            Ok(ClearType::UntilNewLine)
+        );
+        assert_eq!("".parse::<ClearType>(), Err(ParseError::VariantNotFound));
+    }
 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,3 +1,5 @@
+use strum::{Display, EnumString};
+
 pub mod block {
     pub const FULL: &str = "█";
     pub const SEVEN_EIGHTHS: &str = "▉";
@@ -240,7 +242,7 @@ pub mod braille {
 }
 
 /// Marker to use when plotting data points
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Marker {
     /// One point per cell in shape of dot
     #[default]
@@ -300,4 +302,28 @@ pub mod scrollbar {
         begin: "←",
         end: "→",
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::ParseError;
+
+    use super::*;
+
+    #[test]
+    fn marker_tostring() {
+        assert_eq!(Marker::Dot.to_string(), "Dot");
+        assert_eq!(Marker::Block.to_string(), "Block");
+        assert_eq!(Marker::Bar.to_string(), "Bar");
+        assert_eq!(Marker::Braille.to_string(), "Braille");
+    }
+
+    #[test]
+    fn marker_from_str() {
+        assert_eq!("Dot".parse::<Marker>(), Ok(Marker::Dot));
+        assert_eq!("Block".parse::<Marker>(), Ok(Marker::Block));
+        assert_eq!("Bar".parse::<Marker>(), Ok(Marker::Bar));
+        assert_eq!("Braille".parse::<Marker>(), Ok(Marker::Braille));
+        assert_eq!("".parse::<Marker>(), Err(ParseError::VariantNotFound));
+    }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{fmt, io};
 
 use crate::{
     backend::{Backend, ClearType},
@@ -13,6 +13,16 @@ pub enum Viewport {
     Fullscreen,
     Inline(u16),
     Fixed(Rect),
+}
+
+impl fmt::Display for Viewport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Viewport::Fullscreen => write!(f, "Fullscreen"),
+            Viewport::Inline(height) => write!(f, "Inline({})", height),
+            Viewport::Fixed(area) => write!(f, "Fixed({})", area),
+        }
+    }
 }
 
 /// Options to pass to [`Terminal::with_options`]
@@ -486,4 +496,19 @@ fn compute_inline_size<B: Backend>(
         },
         pos,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn viewport_to_string() {
+        assert_eq!(Viewport::Fullscreen.to_string(), "Fullscreen");
+        assert_eq!(Viewport::Inline(5).to_string(), "Inline(5)");
+        assert_eq!(
+            Viewport::Fixed(Rect::new(0, 0, 5, 5)).to_string(),
+            "Fixed(5x5+0+0)"
+        );
+    }
 }

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,3 +1,5 @@
+use strum::{Display, EnumString};
+
 use crate::{layout::Alignment, text::Line};
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
@@ -10,7 +12,7 @@ pub struct Title<'a> {
     pub position: Option<Position>,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Display, EnumString, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Position {
     #[default]
     Top,
@@ -43,5 +45,25 @@ where
 {
     fn from(value: T) -> Self {
         Self::default().content(value.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::ParseError;
+
+    use super::*;
+
+    #[test]
+    fn position_tostring() {
+        assert_eq!(Position::Top.to_string(), "Top");
+        assert_eq!(Position::Bottom.to_string(), "Bottom");
+    }
+
+    #[test]
+    fn position_from_str() {
+        assert_eq!("Top".parse::<Position>(), Ok(Position::Top));
+        assert_eq!("Bottom".parse::<Position>(), Ok(Position::Bottom));
+        assert_eq!("".parse::<Position>(), Err(ParseError::VariantNotFound));
     }
 }

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -1,6 +1,8 @@
 #[path = "../title.rs"]
 pub mod title;
 
+use strum::{Display, EnumString};
+
 pub use self::title::{Position, Title};
 use crate::{
     buffer::Buffer,
@@ -10,7 +12,7 @@ use crate::{
     widgets::{Borders, Widget},
 };
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum BorderType {
     #[default]
     Plain,
@@ -526,6 +528,8 @@ impl<'a> Styled for Block<'a> {
 
 #[cfg(test)]
 mod tests {
+    use strum::ParseError;
+
     use super::*;
     use crate::{
         assert_buffer_eq,
@@ -984,5 +988,20 @@ mod tests {
 
             assert_buffer_eq!(buffer, expected_buffer);
         }
+    }
+
+    #[test]
+    fn border_type_to_string() {
+        assert_eq!(format!("{}", BorderType::Plain), "Plain");
+        assert_eq!(format!("{}", BorderType::Rounded), "Rounded");
+        assert_eq!(format!("{}", BorderType::Double), "Double");
+    }
+
+    #[test]
+    fn border_type_from_str() {
+        assert_eq!("Plain".parse(), Ok(BorderType::Plain));
+        assert_eq!("Rounded".parse(), Ok(BorderType::Rounded));
+        assert_eq!("Double".parse(), Ok(BorderType::Double));
+        assert_eq!("".parse::<BorderType>(), Err(ParseError::VariantNotFound));
     }
 }

--- a/src/widgets/canvas/map.rs
+++ b/src/widgets/canvas/map.rs
@@ -1,3 +1,5 @@
+use strum::{Display, EnumString};
+
 use crate::{
     style::Color,
     widgets::canvas::{
@@ -6,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum MapResolution {
     #[default]
     Low,
@@ -36,5 +38,28 @@ impl Shape for Map {
                 painter.paint(x, y, self.color);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::ParseError;
+
+    use super::*;
+
+    #[test]
+    fn map_resolution_to_string() {
+        assert_eq!(MapResolution::Low.to_string(), "Low");
+        assert_eq!(MapResolution::High.to_string(), "High");
+    }
+
+    #[test]
+    fn map_resolution_from_str() {
+        assert_eq!("Low".parse(), Ok(MapResolution::Low));
+        assert_eq!("High".parse(), Ok(MapResolution::High));
+        assert_eq!(
+            "".parse::<MapResolution>(),
+            Err(ParseError::VariantNotFound)
+        );
     }
 }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, cmp::max};
 
+use strum::{Display, EnumString};
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
@@ -76,7 +77,7 @@ impl<'a> Axis<'a> {
 }
 
 /// Used to determine which style of graphing to use
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum GraphType {
     /// Draw each point
     #[default]
@@ -627,6 +628,8 @@ impl<'a> Styled for Chart<'a> {
 
 #[cfg(test)]
 mod tests {
+    use strum::ParseError;
+
     use super::*;
     use crate::style::{Modifier, Stylize};
 
@@ -701,5 +704,18 @@ mod tests {
                 .add_modifier(Modifier::BOLD)
                 .remove_modifier(Modifier::DIM)
         )
+    }
+
+    #[test]
+    fn graph_type_to_string() {
+        assert_eq!(GraphType::Scatter.to_string(), "Scatter");
+        assert_eq!(GraphType::Line.to_string(), "Line");
+    }
+
+    #[test]
+    fn graph_type_from_str() {
+        assert_eq!("Scatter".parse::<GraphType>(), Ok(GraphType::Scatter));
+        assert_eq!("Line".parse::<GraphType>(), Ok(GraphType::Line));
+        assert_eq!("".parse::<GraphType>(), Err(ParseError::VariantNotFound));
     }
 }

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -1,3 +1,5 @@
+use strum::{Display, EnumString};
+
 use super::StatefulWidget;
 use crate::{
     buffer::Buffer,
@@ -7,7 +9,7 @@ use crate::{
 };
 
 /// An enum representing the direction of scrolling in a Scrollbar widget.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ScrollDirection {
     /// Forward scroll direction, usually corresponds to scrolling downwards or rightwards.
     #[default]
@@ -101,7 +103,7 @@ impl ScrollbarState {
 }
 
 /// Scrollbar Orientation
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Display, EnumString, Clone, Eq, PartialEq, Hash)]
 pub enum ScrollbarOrientation {
     #[default]
     VerticalRight,
@@ -458,11 +460,79 @@ impl<'a> StatefulWidget for Scrollbar<'a> {
 
 #[cfg(test)]
 mod tests {
+    use strum::ParseError;
+
     use super::*;
     use crate::{
         assert_buffer_eq,
         symbols::scrollbar::{HORIZONTAL, VERTICAL},
     };
+
+    #[test]
+    fn scroll_direction_to_string() {
+        assert_eq!(ScrollDirection::Forward.to_string(), "Forward");
+        assert_eq!(ScrollDirection::Backward.to_string(), "Backward");
+    }
+
+    #[test]
+    fn scroll_direction_from_str() {
+        assert_eq!(
+            "Forward".parse::<ScrollDirection>(),
+            Ok(ScrollDirection::Forward)
+        );
+        assert_eq!(
+            "Backward".parse::<ScrollDirection>(),
+            Ok(ScrollDirection::Backward)
+        );
+        assert_eq!(
+            "".parse::<ScrollDirection>(),
+            Err(ParseError::VariantNotFound)
+        );
+    }
+
+    #[test]
+    fn scrollbar_orientation_to_string() {
+        assert_eq!(
+            ScrollbarOrientation::VerticalRight.to_string(),
+            "VerticalRight"
+        );
+        assert_eq!(
+            ScrollbarOrientation::VerticalLeft.to_string(),
+            "VerticalLeft"
+        );
+        assert_eq!(
+            ScrollbarOrientation::HorizontalBottom.to_string(),
+            "HorizontalBottom"
+        );
+        assert_eq!(
+            ScrollbarOrientation::HorizontalTop.to_string(),
+            "HorizontalTop"
+        );
+    }
+
+    #[test]
+    fn scrollbar_orientation_from_str() {
+        assert_eq!(
+            "VerticalRight".parse::<ScrollbarOrientation>(),
+            Ok(ScrollbarOrientation::VerticalRight)
+        );
+        assert_eq!(
+            "VerticalLeft".parse::<ScrollbarOrientation>(),
+            Ok(ScrollbarOrientation::VerticalLeft)
+        );
+        assert_eq!(
+            "HorizontalBottom".parse::<ScrollbarOrientation>(),
+            Ok(ScrollbarOrientation::HorizontalBottom)
+        );
+        assert_eq!(
+            "HorizontalTop".parse::<ScrollbarOrientation>(),
+            Ok(ScrollbarOrientation::HorizontalTop)
+        );
+        assert_eq!(
+            "".parse::<ScrollbarOrientation>(),
+            Err(ParseError::VariantNotFound)
+        );
+    }
 
     #[test]
     fn test_no_render_when_area_zero() {

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -1,5 +1,7 @@
 use std::cmp::min;
 
+use strum::{Display, EnumString};
+
 use crate::{
     buffer::Buffer,
     layout::Rect,
@@ -38,7 +40,7 @@ pub struct Sparkline<'a> {
     direction: RenderDirection,
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum RenderDirection {
     #[default]
     LeftToRight,
@@ -167,12 +169,36 @@ impl<'a> Widget for Sparkline<'a> {
 
 #[cfg(test)]
 mod tests {
+    use strum::ParseError;
+
     use super::*;
     use crate::{
         assert_buffer_eq,
         buffer::Cell,
         style::{Color, Modifier, Stylize},
     };
+
+    #[test]
+    fn render_direction_to_string() {
+        assert_eq!(RenderDirection::LeftToRight.to_string(), "LeftToRight");
+        assert_eq!(RenderDirection::RightToLeft.to_string(), "RightToLeft");
+    }
+
+    #[test]
+    fn render_direction_from_str() {
+        assert_eq!(
+            "LeftToRight".parse::<RenderDirection>(),
+            Ok(RenderDirection::LeftToRight)
+        );
+        assert_eq!(
+            "RightToLeft".parse::<RenderDirection>(),
+            Ok(RenderDirection::RightToLeft)
+        );
+        assert_eq!(
+            "".parse::<RenderDirection>(),
+            Err(ParseError::VariantNotFound)
+        );
+    }
 
     // Helper function to render a sparkline to a buffer with a given width
     // filled with x symbols to make it easier to assert on the result

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -1,3 +1,4 @@
+use strum::{Display, EnumString};
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
@@ -161,7 +162,7 @@ impl<'a> Styled for Row<'a> {
 }
 
 /// This option allows the user to configure the "highlight symbol" column width spacing
-#[derive(Debug, PartialEq, Eq, Clone, Default, Hash)]
+#[derive(Debug, Display, EnumString, PartialEq, Eq, Clone, Default, Hash)]
 pub enum HighlightSpacing {
     /// Always add spacing for the selection symbol column
     ///
@@ -775,5 +776,35 @@ mod tests {
                 .add_modifier(Modifier::BOLD)
                 .remove_modifier(Modifier::CROSSED_OUT)
         )
+    }
+
+    #[test]
+    fn highlight_spacing_to_string() {
+        assert_eq!(HighlightSpacing::Always.to_string(), "Always".to_string());
+        assert_eq!(
+            HighlightSpacing::WhenSelected.to_string(),
+            "WhenSelected".to_string()
+        );
+        assert_eq!(HighlightSpacing::Never.to_string(), "Never".to_string());
+    }
+
+    #[test]
+    fn highlight_spacing_from_str() {
+        assert_eq!(
+            "Always".parse::<HighlightSpacing>(),
+            Ok(HighlightSpacing::Always)
+        );
+        assert_eq!(
+            "WhenSelected".parse::<HighlightSpacing>(),
+            Ok(HighlightSpacing::WhenSelected)
+        );
+        assert_eq!(
+            "Never".parse::<HighlightSpacing>(),
+            Ok(HighlightSpacing::Never)
+        );
+        assert_eq!(
+            "".parse::<HighlightSpacing>(),
+            Err(strum::ParseError::VariantNotFound)
+        );
     }
 }


### PR DESCRIPTION
Use [strum](https://docs.rs/strum/latest/strum/) for most of these, with a couple of manual implementations, and
related tests

Fixes #307

note: this is mainly the enums, the structs tend not to have obvious display representations.

ping @TieWay59 (due to previous work on trait impls)