### PR TITLE
docs(lib): extract feature documentation from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,7 @@ termion = { version = "2.0", optional = true }
 ## enables the [`TermwizBackend`] backend and adds a dependency on the [Termwiz crate].
 termwiz = { version = "0.20.0", optional = true }
 
-#! The following optional features are available for all backends:
-## enables serialization and deserialization of style and color types using the [Serde crate].
-## This is useful if you want to save themes to a file.
 serde = { version = "1", optional = true, features = ["derive"] }
-
 bitflags = "2.3"
 cassowary = "0.3"
 indoc = "2.0"
@@ -62,6 +58,9 @@ pretty_assertions = "1.4.0"
 
 [features]
 default = ["crossterm"]
+#! The following optional features are available for all backends:
+## enables serialization and deserialization of style and color types using the [Serde crate].
+## This is useful if you want to save themes to a file.
 serde = ["dep:serde", "bitflags/serde"]
 
 ## enables the [`border!`] macro.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,33 +22,32 @@ rust-version = "1.67.0"
 
 [badges]
 
-[features]
-default = ["crossterm"]
-all-widgets = ["widget-calendar"]
-widget-calendar = ["dep:time"]
-macros = []
-serde = ["dep:serde", "bitflags/serde"]
-
-[package.metadata.docs.rs]
-all-features = true
-# see https://doc.rust-lang.org/nightly/rustdoc/scraped-examples.html
-cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
-rustdoc-args = ["--cfg", "docsrs"]
-
 [dependencies]
+#! The crate provides a set of optional features that can be enabled in your `cargo.toml` file.
+#!
+#! Generally an application will only use one backend, so you should only enable one of the following features:
+## enables the [`CrosstermBackend`] backend and adds a dependency on the [Crossterm crate].
+crossterm = { version = "0.27", optional = true }
+## enables the [`TermionBackend`] backend and adds a dependency on the [Termion crate].
+termion = { version = "2.0", optional = true }
+## enables the [`TermwizBackend`] backend and adds a dependency on the [Termwiz crate].
+termwiz = { version = "0.20.0", optional = true }
+
+#! The following optional features are available for all backends:
+## enables serialization and deserialization of style and color types using the [Serde crate].
+## This is useful if you want to save themes to a file.
+serde = { version = "1", optional = true, features = ["derive"] }
+
 bitflags = "2.3"
 cassowary = "0.3"
-crossterm = { version = "0.27", optional = true }
 indoc = "2.0"
 itertools = "0.11"
 paste = "1.0.2"
-serde = { version = "1", optional = true, features = ["derive"] }
 strum = { version = "0.25", features = ["derive"] }
-termion = { version = "2.0", optional = true }
-termwiz = { version = "0.20.0", optional = true }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-width = "0.1"
+document-features = "0.2.7"
 
 [dev-dependencies]
 anyhow = "1.0.71"
@@ -60,6 +59,27 @@ criterion = { version = "0.5", features = ["html_reports"] }
 fakeit = "1.1"
 rand = "0.8"
 pretty_assertions = "1.4.0"
+
+[features]
+default = ["crossterm"]
+serde = ["dep:serde", "bitflags/serde"]
+
+## enables the [`border!`] macro.
+macros = []
+
+## enables all widgets.
+all-widgets = ["widget-calendar"]
+
+#! Widgets that add dependencies are gated behind feature flags to prevent unused transitive
+#! dependencies. The available features are:
+## enables the [`calendar`] widget module and adds a dependency on the [Time crate].
+widget-calendar = ["dep:time"]
+
+[package.metadata.docs.rs]
+all-features = true
+# see https://doc.rust-lang.org/nightly/rustdoc/scraped-examples.html
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "block"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ strum = { version = "0.25", features = ["derive"] }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-width = "0.1"
-document-features = "0.2.7"
+document-features = { version = "0.2.7", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,31 +169,7 @@
 //! corresponding area.
 //!
 //! # Features
-//!
-//! The crate provides a set of optional features that can be enabled in your `cargo.toml` file.
-//!
-//! Generally an application will only use one backend, so you should only enable one of the
-//! following features:
-//!
-//! - `crossterm` - enables the [`CrosstermBackend`] backend and adds a dependency on the [Crossterm
-//! crate]. Enabled by default.
-//! - `termion` - enables the [`TermionBackend`] backend and adds a dependency on the [Termion
-//!   crate].
-//! - `termwiz` - enables the [`TermwizBackend`] backend and adds a dependency on the [Termwiz
-//!   crate].
-//!
-//! The following optional features are available for all backends:
-//!
-//! - `serde` - enables serialization and deserialization of style and color types using the [Serde
-//! crate]. This is useful if you want to save themes to a file.
-//! - `macros` - enables the [`border!`] macro.
-//! - `all-widgets` - enables all widgets.
-//!
-//! Widgets that add dependencies are gated behind feature flags to prevent unused transitive
-//! dependencies. The available features are:
-//!
-//! - `widget-calendar` - enables the [`calendar`] widget module and adds a dependency on the [Time
-//!   crate].
+#![doc = document_features::document_features!()]
 //!
 //! [`Layout`]: layout::Layout
 //! [`backend`]: backend
@@ -206,7 +182,6 @@
 //! [Termion crate]: https://crates.io/crates/termion
 //! [Termwiz crate]: https://crates.io/crates/termwiz
 //! [Time crate]: https://crates.io/crates/time
-
 // show the feature flags in the generated documentation
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@
 //! corresponding area.
 //!
 //! # Features
-#![doc = document_features::document_features!()]
+#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //!
 //! [`Layout`]: layout::Layout
 //! [`backend`]: backend


### PR DESCRIPTION
Utilize [document-features](https://github.com/slint-ui/document-features) crate to extract the feature documentation from `Cargo.toml`

before / after:

![Screenshot 2023-08-26 at 14-32-26 ratatui - Rust](https://github.com/ratatui-org/ratatui/assets/24392180/0419cd0e-bafa-4a8f-8984-095618ef2fd1)

One thing to note, we can possibly make it an optional dependency: https://github.com/slint-ui/document-features/pull/8

Let me know what you think 🐻 