### PR TITLE
chore(changelog): ignore alpha tags

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -98,7 +98,7 @@ tag_pattern = "v[0-9]*"
 # regex for skipping tags
 skip_tags = "v0.1.0-rc.1"
 # regex for ignoring tags
-ignore_tags = ""
+ignore_tags = "alpha"
 # sort the tags topologically
 topo_order = false
 # sort the commits inside sections by oldest/newest order


### PR DESCRIPTION
With this change, all the changes from alpha releases will be incorporated in the stable release changelog. Also, we will have all the entries in the latest alpha release instead of separating the changelog. For example, `alpha.2` changelog will contain changes from `alpha.1` and `alpha.0`. If we do not want to do that, I can tweak the release workflow accordingly.