### PR TITLE
Update README to use ratatui 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,6 @@ Or modify your `Cargo.toml`
 ratatui = { version = "0.23.0", features = ["all-widgets"]}
 ```
 
-Ratatui is mostly backwards compatible with `tui-rs`. To migrate an existing project, it may be
-easier to rename the ratatui dependency to `tui` rather than updating every usage of the crate.
-E.g.:
-
-```toml
-[dependencies]
-tui = { package = "ratatui", version = "0.23.0", features = ["all-widgets"]}
-```
-
 ## Introduction
 
 `ratatui` is a terminal UI library that supports multiple backends:
@@ -217,9 +208,9 @@ be installed with `cargo install cargo-make`).
 ### Third-party libraries, bootstrapping templates and widgets
 
 * [ansi-to-tui](https://github.com/uttarayan21/ansi-to-tui) — Convert ansi colored text to
-  `tui::text::Text`
+  `ratatui::text::Text`
 * [color-to-tui](https://github.com/uttarayan21/color-to-tui) — Parse hex colors to
-  `tui::style::Color`
+  `ratatui::style::Color`
 * [rust-tui-template](https://github.com/ratatui-org/rust-tui-template) — A template for bootstrapping a
   Rust TUI application with Tui-rs & crossterm
 * [simple-tui-rs](https://github.com/pmsanford/simple-tui-rs) — A simple example tui-rs app


### PR DESCRIPTION
In my opinion, this change in the docs will be a better user experience for most people, for the following reasons:

- With breaking changes users can't just do this to upgrade from `tui`:

```toml
[dependencies]
tui = { package = "ratatui", version = "0.23.0", features = ["all-widgets"]} # will cause errors because of breaking changes going forward
```

At best, we should only recommend this:

```toml
[dependencies]
tui = { package = "ratatui", version = "0.19.0", features = ["all-widgets"]}
```

But I think we should save that for the docs or the ratatui-book; and the README should have one obvious way for newcomers to add the `ratatui` crate to their project.

- Third party crates linked have migrated from `tui` to `ratatui`.

- If users use `ratatui` explicitly in the code, it'll will allow for searching for `ratatui` on github / gitlab etc to be easier going forward.