### PR TITLE
docs: fix documentation lint warnings

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -67,7 +67,7 @@ pub struct WindowSize {
     /// Size in pixel width,height.
     ///
     /// The `pixels` fields may not be implemented by all terminals and return `0,0`.
-    /// See https://man7.org/linux/man-pages/man4/tty_ioctl.4.html under section
+    /// See <https://man7.org/linux/man-pages/man4/tty_ioctl.4.html> under section
     /// "Get and set window size" / TIOCGWINSZ where the fields are commented as "unused".
     pub pixels: Size,
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -440,7 +440,7 @@ impl std::error::Error for ParseColorError {}
 /// `Color` variant. It supports named colors, RGB values, and indexed colors. If the string cannot
 /// be parsed, a `ParseColorError` is returned.
 ///
-/// See the [`Color`](Color) documentation for more information on the supported color names.
+/// See the [`Color`] documentation for more information on the supported color names.
 ///
 /// # Examples
 ///

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -72,7 +72,7 @@ impl<'a, S: DateStyler> Monthly<'a, S> {
         self
     }
 
-    /// Render the calendar within a [Block](crate::widgets::Block)
+    /// Render the calendar within a [Block]
     pub fn block(mut self, b: Block<'a>) -> Self {
         self.block = Some(b);
         self


### PR DESCRIPTION
I just fixed some doc lint warning that were annoying while documenting as they prevented the switch to the `doc` job.

I don't see any documentation **build** test in `cargo make ci`, we probably should add it to avoid documentation mistakes?

<details><summary>Lint errors for `doc-open` job</summary>
<p>

![image](https://github.com/ratatui-org/ratatui/assets/36198422/1c4a8695-317a-4a05-b5ed-6bd8ad3bac2a)

</p>
</details> 