### PR TITLE
chore(docs): fix doc comment

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -32,7 +32,7 @@ pub struct TerminalOptions {
     pub viewport: Viewport,
 }
 
-/// Interface to the terminal backed by Termion
+/// Interface to the terminal backed by a [`Backend`].
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Terminal<B>
 where


### PR DESCRIPTION
The current doc comment makes it seem as if `Termion` was the only supported backend. 
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
