### PR TITLE
Support for Test-Driven Development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ rand = "0.8"
 pretty_assertions = "1.4.0"
 
 [features]
-default = ["crossterm"]
+default = ["crossterm", "unstable-testing-mode"]
 #! The following optional features are available for all backends:
 ## enables serialization and deserialization of style and color types using the [Serde crate].
 ## This is useful if you want to save themes to a file.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ all-widgets = ["widget-calendar"]
 ## enables the [`calendar`] widget module and adds a dependency on the [Time crate].
 widget-calendar = ["dep:time"]
 
+## Adds a unstable API for unit testing ratatui. THIS MAY BREAK AT ANY TIME!
+unstable-testing-mode = []
+
 [package.metadata.docs.rs]
 all-features = true
 # see https://doc.rust-lang.org/nightly/rustdoc/scraped-examples.html

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -149,6 +149,11 @@ impl<'a> Line<'a> {
             ..self
         }
     }
+    
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_spans(&self) -> Vec<Span>{
+        self.spans.clone()
+    }
 }
 
 impl<'a> From<String> for Line<'a> {

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -156,6 +156,14 @@ impl<'a> Line<'a> {
     }
 }
 
+impl<'a> ToString for Line<'a> {
+    fn to_string(&self) -> String {
+        self.spans.iter().fold("".to_string(), |acc, span: &Span| {
+            acc + &span.content
+        })
+    }
+}
+
 impl<'a> From<String> for Line<'a> {
     fn from(s: String) -> Self {
         Self::from(vec![Span::from(s)])

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -167,6 +167,12 @@ impl<'a> Span<'a> {
     pub fn reset_style(&mut self) {
         self.patch_style(Style::reset());
     }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_content(&self) -> String{
+        self.content.to_string()
+    }
+
 }
 
 impl<'a, T> From<T> for Span<'a>

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -147,6 +147,15 @@ impl<'a> Text<'a> {
             line.reset_style();
         }
     }
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_text_content(&self) -> String{
+        self.lines.iter().flat_map(|line: &Line| {
+            let lines: Vec<String> = line.get_spans().iter().map(|span: &Span| {
+                span.get_content()
+            }).collect();
+            lines
+        }).collect()
+    }
 }
 
 impl<'a> From<String> for Text<'a> {

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -147,8 +147,13 @@ impl<'a> Text<'a> {
             line.reset_style();
         }
     }
-    #[cfg(feature = "unstable-testing-mode")]
-    pub fn get_text_content(&self) -> String{
+    
+    
+}
+
+#[cfg(feature = "unstable-testing-mode")]
+impl<'a> ToString for Text<'a> {
+    fn to_string(&self) -> String{
         self.lines.iter().flat_map(|line: &Line| {
             let lines: Vec<String> = line.get_spans().iter().map(|span: &Span| {
                 span.get_content()

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -154,12 +154,9 @@ impl<'a> Text<'a> {
 #[cfg(feature = "unstable-testing-mode")]
 impl<'a> ToString for Text<'a> {
     fn to_string(&self) -> String{
-        self.lines.iter().flat_map(|line: &Line| {
-            let lines: Vec<String> = line.get_spans().iter().map(|span: &Span| {
-                span.get_content()
-            }).collect();
-            lines
-        }).collect()
+        self.lines.iter().fold("".to_string(), |acc: String, line: &Line| {
+            acc + &line.to_string()
+        })
     }
 }
 

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -502,6 +502,51 @@ impl<'a> Block<'a> {
         self.render_title_position(Position::Top, area, buf);
         self.render_title_position(Position::Bottom, area, buf);
     }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_titles(&self) -> Vec<Title> {
+        self.titles.clone()
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_titles_style(&self) -> Style {
+        self.titles_style
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_titles_alignment(&self) -> Alignment {
+        self.titles_alignment
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_titles_position(&self) -> Position {
+        self.titles_position
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_borders(&self) -> Borders{
+        self.borders
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_border_style(&self) -> Style{
+        self.border_style
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_border_type(&self) -> BorderType{
+        self.border_type
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_style(&self) -> Style {
+        self.style
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_padding(&self) -> Padding{
+        self.padding
+    }
 }
 
 impl<'a> Widget for Block<'a> {

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -209,16 +209,16 @@ impl<'a> List<'a> {
     }
 
     #[cfg(feature = "unstable-testing-mode")]
-    pub fn get_block(&self) -> &Option<Block> {
-        &self.block
+    pub fn get_block(&self) -> Option<Block> {
+        self.block.clone()
     }
     #[cfg(feature = "unstable-testing-mode")]
     pub fn get_style(&self) -> Style {
         self.style
     }
     #[cfg(feature = "unstable-testing-mode")]
-    pub fn get_items(&self) -> &Vec<ListItem<'a>> {
-        return &self.items;
+    pub fn get_items(&self) -> Vec<ListItem> {
+        self.items.clone()
     }
 
     #[cfg(feature = "unstable-testing-mode")]
@@ -242,8 +242,8 @@ impl<'a> List<'a> {
     }
 
     #[cfg(feature = "unstable-testing-mode")]
-    pub fn get_highlight_spacing(&self) -> &HighlightSpacing {
-        &self.highlight_spacing
+    pub fn get_highlight_spacing(&self) -> HighlightSpacing {
+        self.highlight_spacing.clone()
     }
 }
 

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -207,6 +207,44 @@ impl<'a> List<'a> {
         }
         (start, end)
     }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_block(&self) -> &Option<Block> {
+        &self.block
+    }
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_style(&self) -> Style {
+        self.style
+    }
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_items(&self) -> &Vec<ListItem<'a>> {
+        return &self.items;
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_start_corner(&self) -> Corner {
+        self.start_corner
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_highlight_style(&self) -> Style {
+        self.highlight_style
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_highlight_symbol(&self) -> Option<&str> {
+        self.highlight_symbol
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_repeat_highlight_symbol(&self) -> bool {
+        self.repeat_highlight_symbol
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_highlight_spacing(&self) -> &HighlightSpacing {
+        &self.highlight_spacing
+    }
 }
 
 impl<'a> StatefulWidget for List<'a> {

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -201,7 +201,7 @@ impl<'a> Paragraph<'a> {
         self
     }
 
-    #[cfg(feature = "unstable-testing-mode")]
+    #[cfg(test)]
     pub fn get_block(&self) -> &Option<Block> {
         &self.block
     }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -201,7 +201,7 @@ impl<'a> Paragraph<'a> {
         self
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "unstable-testing-mode")]
     pub fn get_block(&self) -> &Option<Block> {
         &self.block
     }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -202,8 +202,8 @@ impl<'a> Paragraph<'a> {
     }
 
     #[cfg(feature = "unstable-testing-mode")]
-    pub fn get_block(&self) -> &Option<Block> {
-        &self.block
+    pub fn get_block(&self) -> Option<Block> {
+        self.block.clone()
     }
 
     #[cfg(feature = "unstable-testing-mode")]
@@ -217,8 +217,8 @@ impl<'a> Paragraph<'a> {
     }
 
     #[cfg(feature = "unstable-testing-mode")]
-    pub fn get_text(&self) -> &Text {
-        &self.text
+    pub fn get_text(&self) -> Text {
+        self.text.clone()
     } 
 
     #[cfg(feature = "unstable-testing-mode")]

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -200,6 +200,36 @@ impl<'a> Paragraph<'a> {
         self.alignment = alignment;
         self
     }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_block(&self) -> &Option<Block> {
+        &self.block
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_style(&self) -> Style {
+        self.style
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_wrap(&self) -> Option<Wrap> {
+        self.wrap
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_text(&self) -> &Text {
+        &self.text
+    } 
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_scroll(&self) -> (u16, u16) {
+        self.scroll
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_alignment(&self) -> Alignment {
+        self.alignment
+    }
 }
 
 impl<'a> Widget for Paragraph<'a> {

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -81,6 +81,36 @@ impl<'a> Tabs<'a> {
         self.divider = divider.into();
         self
     }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_block(&self) -> Option<Block> {
+        self.block.clone()
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_titles(&self) -> Vec<Line> {
+        self.titles.clone()
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_selected(&self) -> usize  {
+        self.selected
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_style(&self) -> Style{
+        self.style
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_highlight_style(&self) -> Style{
+        self.highlight_style
+    }
+
+    #[cfg(feature = "unstable-testing-mode")]
+    pub fn get_divider(&self) -> Span{
+        self.divider.clone()
+    }
 }
 
 impl<'a> Styled for Tabs<'a> {


### PR DESCRIPTION
Test-Driven Development (TDD) is widely recognized as a good way to develop software. 

Sadly, using TDD with this library has been impossible, because there is no good way to assert on the state of the UI.
To fix this, I started work on some getters that return the current state of some widgets and help with creating small and maintainable unit tests.

(See also this discussion I started a while back: https://github.com/ratatui-org/ratatui/discussions/78)

I hid these changes behind a feature flag called "unstable-testing-mode", because I'm not quite certain if this is the best way to implement this feature.  

This feature is also by no means complete yet. It's just here to gather feedback and to (maybe) get some help implementing it.