### PR TITLE
chore: check documentation lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         uses: taiki-e/install-action@cargo-make
       - name: Check formatting
         run: cargo make fmt
+      - name: Check documentation
+        run: cargo make check-doc
 
   clippy:
     runs-on: ubuntu-latest

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,7 +21,7 @@ dependencies = [
 
 [tasks.style-check]
 description = "Check code style"
-dependencies = ["fmt", "typos"]
+dependencies = ["fmt", "typos", "check-doc"]
 
 [tasks.fmt]
 description = "Format source code"
@@ -33,6 +33,19 @@ args = ["fmt", "--all", "--check"]
 description = "Run typo checks"
 install_crate = { crate_name = "typos-cli", binary = "typos", test_arg = "--version" }
 command = "typos"
+
+[tasks.check-doc]
+description = "Check documentation for errors and warnings"
+toolchain = "nightly"
+command = "cargo"
+args = [
+  "rustdoc",
+  "--all-features",
+  "--",
+  "-Zunstable-options",
+  "--check",
+  "-Dwarnings"
+]
 
 [tasks.check]
 description = "Check code for errors and warnings"


### PR DESCRIPTION
# Description

Adds a `check-doc` job to the Makefile. This job checks for errors and warnings in the doc-comments.

# Makefile structure

~I've added a meta-job `check` that runs `check-code` and `check-doc`.~
~The `check` job is run in CI so now the pipelines would check for code and documentation.~

~`check-code` replaces the old `check` job.~

~For me this is not a breaking change as it concerns tooling and not public APIs. I've also checked every place the `cargo check` job could have been referenced.~

# Job implementation

I've used an unstable Rustdoc flag: `--check`, [see here](https://doc.rust-lang.org/rustdoc/unstable-features.html#--check-only-checks-the-documentation). Here is the [tracking issue](https://github.com/rust-lang/cargo/issues/10025).

I've used [`cargo rustdoc`](https://doc.rust-lang.org/cargo/commands/cargo-rustdoc.html) instead of `cargo doc` to pass flags down to `rustdoc`.
I didn't use the env variable `RUSTDOCFLAGS` because `cargo-make` [doesn't cleanup task scoped env after execution](https://github.com/sagiegurari/cargo-make#task), so it would interfere with other jobs.

---

Fixes #451 