### PR TITLE
chore: Check that PR title matches conventional commit guidelines

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,21 @@
+name: Check PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check PR title
+      run: |
+        title="${{ github.event.pull_request.title }}"
+        if ! echo "$title" | grep -qE '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?!?: '; then
+          echo "error: PR title does not follow the Conventional Commits guidelines"
+          exit 1
+        fi


### PR DESCRIPTION
This runs a quick check to see if the PR title matches conventions commit guidelines. This action reruns if the title is edited and modified.