### PR TITLE
fix(chart): fix chart row style being incorrect when using Axis::title

### DIFF
--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -560,7 +560,7 @@ impl<'a> Widget for Chart<'a> {
 
         if let Some((x, y)) = layout.title_x {
             let title = self.x_axis.title.unwrap();
-            let width = graph_area.right().saturating_sub(x);
+            let width = title.width() as u16;
             buf.set_style(
                 Rect {
                     x,
@@ -575,7 +575,7 @@ impl<'a> Widget for Chart<'a> {
 
         if let Some((x, y)) = layout.title_y {
             let title = self.y_axis.title.unwrap();
-            let width = graph_area.right().saturating_sub(x);
+            let width = title.width() as u16;
             buf.set_style(
                 Rect {
                     x,
@@ -717,5 +717,16 @@ mod tests {
         assert_eq!("Scatter".parse::<GraphType>(), Ok(GraphType::Scatter));
         assert_eq!("Line".parse::<GraphType>(), Ok(GraphType::Line));
         assert_eq!("".parse::<GraphType>(), Err(ParseError::VariantNotFound));
+    }
+
+    #[test]
+    fn it_does_not_panic_if_title_is_wider_than_buffer() {
+        let widget = Chart::default()
+            .y_axis(Axis::default().title("xxxxxxxxxxxxxxxx"))
+            .x_axis(Axis::default().title("xxxxxxxxxxxxxxxx"));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 4));
+        widget.render(buffer.area, &mut buffer);
+
+        assert_eq!(buffer, Buffer::with_lines(vec![" ".repeat(8); 4]))
     }
 }

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -618,3 +618,41 @@ fn widgets_chart_can_have_a_legend() {
 
     terminal.backend().assert_buffer(&expected);
 }
+
+#[test]
+fn widgets_chart_top_line_styling_is_correct() {
+    let backend = TestBackend::new(9, 5);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let title_style = Style::default().fg(Color::Red).bg(Color::LightRed);
+    let data_style = Style::default().fg(Color::Blue);
+
+    terminal
+        .draw(|f| {
+            let data: [(f64, f64); 2] = [(0.0, 1.0), (1.0, 1.0)];
+            let widget = Chart::new(vec![Dataset::default()
+                .data(&data)
+                .graph_type(ratatui::widgets::GraphType::Line)
+                .style(data_style)])
+            .y_axis(
+                Axis::default()
+                    .title(Span::styled("abc", title_style))
+                    .bounds([0.0, 1.0])
+                    .labels(create_labels(&["a", "b"])),
+            )
+            .x_axis(Axis::default().bounds([0.0, 1.0]));
+            f.render_widget(widget, f.size());
+        })
+        .unwrap();
+
+    let mut expected = Buffer::with_lines(vec![
+        "b│abc••••",
+        " │       ",
+        " │       ",
+        " │       ",
+        "a│       ",
+    ]);
+    expected.set_style(Rect::new(2, 0, 3, 1), title_style);
+    expected.set_style(Rect::new(5, 0, 4, 1), data_style);
+    terminal.backend().assert_buffer(&expected);
+}


### PR DESCRIPTION
Fixes: #379



old behavior
![image](https://github.com/ratatui-org/ratatui/assets/60185743/2dc68680-aee9-40f3-8099-4f83d3c17d11)

new fixed
![image](https://github.com/ratatui-org/ratatui/assets/60185743/be4319d0-9d3a-44a8-a5b5-97ac0fbfe0eb)

