### PR TITLE
ci: put commit id first in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -21,8 +21,8 @@ body = """
 {% endif -%}
 
 {% macro commit(commit) -%}
-- *({{commit.scope | default(value = "uncategorized")}})* {{ commit.message | upper_first }}
-([{{ commit.id | truncate(length=7, end="") }}]({{ "https://github.com/ratatui-org/ratatui/commit/" ~ commit.id }}))
+- [{{ commit.id | truncate(length=7, end="") }}]({{ "https://github.com/ratatui-org/ratatui/commit/" ~ commit.id }})
+  *({{commit.scope | default(value = "uncategorized")}})* {{ commit.message | upper_first }}
 {%- if commit.breaking %} [**breaking**]{% endif %}
 {%- if commit.body %}
 


### PR DESCRIPTION
```shell
git cliff --unreleased
```
[CHANGELOG.md](https://github.com/ratatui-org/ratatui/files/12503810/CHANGELOG.md)

<img width="1016" alt="image" src="https://github.com/ratatui-org/ratatui/assets/381361/b9969fdc-0306-441d-ae30-ea0bc4155421">
