### PR TITLE
ci(lint): move formatting and doc checks first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Check conventional commits
-        uses: crate-ci/committed@master
-        with:
-          args: "-vv"
-          commits: HEAD
-      - name: Check typos
-        uses: crate-ci/typos@master
-      - name: Lint dependencies
-        uses: EmbarkStudios/cargo-deny-action@v1
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -55,6 +46,15 @@ jobs:
         run: cargo make fmt
       - name: Check documentation
         run: cargo make check-doc
+      - name: Check conventional commits
+        uses: crate-ci/committed@master
+        with:
+          args: "-vv"
+          commits: HEAD
+      - name: Check typos
+        uses: crate-ci/typos@master
+      - name: Lint dependencies
+        uses: EmbarkStudios/cargo-deny-action@v1
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Putting the formatting and doc checks first to ensure that more critical
errors are caught first (e.g. a conventional commit error or typo should
not prevent the formatting and doc checks from running).

See https://github.com/ratatui-org/ratatui/actions/runs/6058985586/job/16441639521?pr=462:

<img width="477" alt="image" src="https://github.com/ratatui-org/ratatui/assets/381361/8a526daf-e938-4008-ac93-939be8aeaab5">

