### PR TITLE
chore(changelog): make the scopes lowercase in the changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -22,7 +22,7 @@ body = """
 
 {% macro commit(commit) -%}
 - [{{ commit.id | truncate(length=7, end="") }}]({{ "https://github.com/ratatui-org/ratatui/commit/" ~ commit.id }})
-  *({{commit.scope | default(value = "uncategorized")}})* {{ commit.message | upper_first }}
+  *({{commit.scope | default(value = "uncategorized") | lower }})* {{ commit.message | upper_first }}
 {%- if commit.breaking %} [**breaking**]{% endif %}
 {%- if commit.body %}
 


### PR DESCRIPTION
Before:

```md
### Documentation

- [0c68ebe](https://github.com/ratatui-org/ratatui/commit/0c68ebed4f63a595811006e0af221b11a83780cf)
  *(Block)* Add documentation to Block ([#469](https://github.com/ratatui-org/ratatui/issues/469))
```

After:

```md
### Documentation

- [0c68ebe](https://github.com/ratatui-org/ratatui/commit/0c68ebed4f63a595811006e0af221b11a83780cf)
  *(block)* Add documentation to Block ([#469](https://github.com/ratatui-org/ratatui/issues/469))
```