### PR TITLE
chore: Add a check for if breaking change label should be added 

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -19,5 +19,50 @@ jobs:
       - name: Check PR title
         if: github.event_name == 'pull_request_target'
         uses: amannn/action-semantic-pull-request@v5
+        id: check_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Add comment indicating we require pull request titles to follow conventional commits specification
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && (steps.check_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            > ${{ steps.check_pr_title.outputs.error_message }}
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.check_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true
+
+  check-breaking-change-label:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check breaking change label
+      run: |
+        title="${{ github.event.pull_request.title }}"
+        if ! echo "$title" | grep -qE '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?!: '; then
+          echo "::set-output name=breaking_change::true"
+        else
+          echo "::set-output name=breaking_change::false"
+        fi
+
+    - name: Add label
+      if: steps.check.outputs.breaking_change == 'true'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['breaking change']
+          })


### PR DESCRIPTION
This PR will do 3 things

1. Add a comment if the title is not in conventional commit specification, urging the PR submitter to change it
2. Remove the comment if the title is updated
3. Add a `breaking change` label if the title has a `!:` in it and follows the conventional commit specification.