### PR TITLE
chore: only run check pr action on pull_request_target events

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -6,9 +6,9 @@ on:
       - opened
       - edited
       - synchronize
+      - labeled
+      - unlabeled
   merge_group:
-  pull_request:
-    types: [synchronize, opened, reopened, labeled, unlabeled]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
From the documentation: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.