### PR TITLE
docs(terminal): add docs for terminal module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ pub mod terminal;
 pub mod text;
 pub mod widgets;
 
-pub use self::terminal::{Frame, Terminal, TerminalOptions, Viewport};
+#[doc(inline)]
+pub use self::terminal::{CompletedFrame, Frame, Terminal, TerminalOptions, Viewport};
 
 pub mod prelude;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,6 +29,6 @@ pub use crate::{
     layout::{self, Alignment, Constraint, Corner, Direction, Layout, Margin, Rect},
     style::{self, Color, Modifier, Style, Styled, Stylize},
     symbols::{self, Marker},
-    terminal::{self, Frame, Terminal, TerminalOptions, Viewport},
+    terminal::{CompletedFrame, Frame, Terminal, TerminalOptions, Viewport},
     text::{self, Line, Masked, Span, Text},
 };


### PR DESCRIPTION
- moves the impl Terminal block up to be closer to the type definition

Pulls in doc changes from #280 in an attempt to simplify that PR (more to come for other types).
