### PR TITLE
fix(Layout): layout cache does not grow without bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-width = "0.1"
 document-features = { version = "0.2.7", optional = true }
+lru = "0.11.1"
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -340,7 +340,7 @@ impl Default for Layout {
 }
 
 impl Layout {
-    const DEFAULT_CACHE_SIZE: usize = 16;
+    pub const DEFAULT_CACHE_SIZE: usize = 16;
     /// Creates a new layout with default values.
     ///
     /// - direction: [Direction::Vertical]
@@ -368,7 +368,8 @@ impl Layout {
     /// has set this value or that the cache size is already initialized.
     ///
     /// Note that a custom cache size will be set only if this function:
-    /// * is called before [Layout::split()] otherwise, the cache size is `DEFAULT_CACHE_SIZE`.
+    /// * is called before [Layout::split()] otherwise, the cache size is
+    ///   [`Self::DEFAULT_CACHE_SIZE`].
     /// * is called for the first time, subsequent calls do not modify the cache size.
     pub fn init_cache(cache_size: usize) -> bool {
         LAYOUT_CACHE
@@ -499,8 +500,8 @@ impl Layout {
     ///
     /// This method stores the result of the computation in a thread-local cache keyed on the layout
     /// and area, so that subsequent calls with the same parameters are faster. The cache is a
-    /// LruCache, and grows until `DEFAULT_CACHE_SIZE` is reached by default, if the cache is
-    /// initialized with the [Layout::init_cache()] grows until the initialized cache size.
+    /// LruCache, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default, if the cache
+    /// is initialized with the [Layout::init_cache()] grows until the initialized cache size.
     ///
     /// # Examples
     ///

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -14,9 +14,8 @@ use cassowary::{
     WeightedRelation::{EQ, GE, LE},
 };
 use itertools::Itertools;
-use strum::{Display, EnumString};
-
 use lru::LruCache;
+use strum::{Display, EnumString};
 
 #[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Corner {


### PR DESCRIPTION
This pull request avoids the growth of Layout cache without any bounds.
The Layout cache is now using an LruCache ([doc](https://docs.rs/lru/latest/lru/)).
The current default cache size is set to 16. It seems reasonable for me to keep this value low.
A user can set the cache size during the Layout instantiation.

fix #402