### PR TITLE
fix(docs): don't fail rustdoc due to termion

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -89,6 +89,7 @@
 //! backend being used, and developers should consult the specific backend's documentation to
 //! understand how it implements mouse capture.
 //!
+//! [`TermionBackend`]: termion/struct.TermionBackend.html
 //! [`Terminal`]: crate::terminal::Terminal
 //! [Crossterm]: https://crates.io/crates/crossterm
 //! [Termion]: https://crates.io/crates/termion


### PR DESCRIPTION
Windows cannot compile termion, so it is not included in the docs.
Rustdoc will fail if it cannot find a link, so the docs fail to build
on windows.

This replaces the link to TermionBackend with one that does not fail
during checks.

Fixes https://github.com/ratatui-org/ratatui/issues/498

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
