### PR TITLE
docs(table): add documentation for `block` and `header` methods of the `Table` widget

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -90,6 +90,7 @@
 //! understand how it implements mouse capture.
 //!
 //! [`Terminal`]: crate::terminal::Terminal
+//! [`TermionBackend`]: termion/struct.TermionBackend.html
 //! [Crossterm]: https://crates.io/crates/crossterm
 //! [Termion]: https://crates.io/crates/termion
 //! [Termwiz]: https://crates.io/crates/termwiz

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -304,11 +304,52 @@ impl<'a> Table<'a> {
         }
     }
 
+    /// Creates a custom block around a [`Table`] widget.
+    ///
+    /// The `block` parameter is of type [`Block`]. This holds the specified block to be 
+    /// created around the [`Table`]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::{prelude::*, widgets::*};
+    /// let table = Table::new(vec![
+    ///     Row::new(vec![
+    ///         Cell::from("Cell1"),
+    ///         Cell::from("Cell2")
+    ///     ]),
+    ///     Row::new(vec![
+    ///         Cell::from("Cell3"),
+    ///         Cell::from("Cell4")
+    ///     ]),
+    /// ]).block(Block::default().title("Table"));
+    /// ```
     pub fn block(mut self, block: Block<'a>) -> Self {
         self.block = Some(block);
         self
     }
 
+    /// Creates a header for a [`Table`] widget.
+    ///
+    /// The `header` parameter is of type [`Row`] and this holds the cells to be displayed at the
+    /// top of the [`Table`]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::{prelude::*, widgets::*};
+    /// let table = Table::new(vec![
+    ///     Row::new(vec![
+    ///         Cell::from("Cell1"),
+    ///         Cell::from("Cell2")
+    ///     ])
+    /// ]).header(
+    ///     Row::new(vec![
+    ///         Cell::from("Header Cell 1"),
+    ///         Cell::from("Header Cell 2")
+    ///     ])
+    /// );
+    /// ```
     pub fn header(mut self, header: Row<'a>) -> Self {
         self.header = Some(header);
         self

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -306,7 +306,7 @@ impl<'a> Table<'a> {
 
     /// Creates a custom block around a [`Table`] widget.
     ///
-    /// The `block` parameter is of type [`Block`]. This holds the specified block to be 
+    /// The `block` parameter is of type [`Block`]. This holds the specified block to be
     /// created around the [`Table`]
     ///
     /// # Examples


### PR DESCRIPTION
Additionally, add `fix(docs): don't fail rustdoc due to termion`
