### PR TITLE
chore(rustfmt): Make empty items not single line

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,3 +3,4 @@ group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
 wrap_comments = true
 comment_width = 100
+empty_item_single_line = false


### PR DESCRIPTION
I have format on save enabled. During prototyping, if I type the following:

```rust
impl<'a> Widget for Histogram<'a> {
    fn render(mut self, area: Rect, buf: &mut Buffer) {
    }
}
```

and hit save, it gets formatted to this:

```rust
impl<'a> Widget for Histogram<'a> {
    fn render(mut self, area: Rect, buf: &mut Buffer) {}
}
```

It would be nice if we can disable this.