### PR TITLE
feat(Rect): add `offset` method

### DIFF
--- a/src/layout/rect/offset.rs
+++ b/src/layout/rect/offset.rs
@@ -1,0 +1,12 @@
+/// Amounts by which to move a [`Rect`](super::Rect).
+///
+/// Positive numbers move to the right/bottom and negative to the left/top.
+///
+/// See [`Rect::offset`](super::Rect::offset)
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Offset {
+    /// How much to move on the X axis
+    pub x: i32,
+    /// How much to move on the Y axis
+    pub y: i32,
+}


### PR DESCRIPTION
# Description

As discussed [here](https://github.com/ratatui-org/ratatui/pull/518#discussion_r1333715626). 

Add `inset` and `offset` methods to respectively adjust a `Rect` size and move it.
This is common logic in renders and apps.

# Implementation choices

I used generics to allow direct calculation in the call, like [here](https://github.com/ratatui-org/ratatui/compare/main...Valentin271:ratatui:feat/rect-manipulation-utils?expand=1#diff-7a977f85afc247cf4ed30e8453eb44fd67f06ba2c92115f157c58ebb23d0a3f6R351). This just avoids having to wrap calculations in parenthesis and calling `into()`.
I used two different generics to allow giving different types (e.g. `u16` calculation and `i32` literal).

A signed int allows to move the `Rect` forward or backward.

I used an ~`i64`~ `i32` as parameter to allow moving `x` and `y` from their minimal value to their maximal value (`0` -> `u16::MAX`), even though this is something that very rarely occur (if at all).
An ~`i32`~ `i16` would not be enough ([reference](https://doc.rust-lang.org/reference/types/numeric.html)).

Due to the preceding choice, we're casting an ~`i64`~ `i32` to an `u16`. If the calculation could not be converted back to `u16`, values will wrap around. This is documented, I think this is legitimate since this case should not happen in the first place, we could provide variants later if needed (`saturating_...`, `checked_...`).
Alternatives are:
- saturating (seems good, harder to implement)
- returning `Option` (easy to implement, kind of breaks builder pattern, unpleasant to use)
- panic (easy to implement)

Let me know what you think. IMO, this is basically choosing which behavior should be the default as we could provide variant later.