### PR TITLE
feat: Add `buffer_mut` method on `Frame`

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -650,6 +650,11 @@ impl Frame<'_> {
     pub fn set_cursor(&mut self, x: u16, y: u16) {
         self.cursor_position = Some((x, y));
     }
+
+    /// Gets the buffer that this `Frame` draws into as a mutable reference.
+    pub fn buffer_mut(&mut self) -> &mut Buffer {
+        self.buffer
+    }
 }
 
 /// `CompletedFrame` represents the state of the terminal after all changes performed in the last


### PR DESCRIPTION
`current_buffer_mut` already exists on `Terminal`. It would be nice to expose the same thing to `Frame` as well.
