### PR TITLE
docs(custom_widget): make button sticky when clicking with mouse

### DIFF
--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -252,8 +252,12 @@ fn handle_mouse_event(
                 _ => 2,
             };
             if old_selected_button != *selected_button {
-                button_states[old_selected_button] = State::Normal;
-                button_states[*selected_button] = State::Selected;
+                if button_states[old_selected_button] != State::Active {
+                    button_states[old_selected_button] = State::Normal;
+                }
+                if button_states[*selected_button] != State::Active {
+                    button_states[*selected_button] = State::Selected;
+                }
             }
         }
         MouseEventKind::Down(MouseButton::Left) => {


### PR DESCRIPTION
Makes the example more intuitive (imo) when trying out the demo with mouse. User can click to make state of the button `Active`, and click again to make it `Normal`. When in `Active` state, hover related changes are ignored.
