### PR TITLE
fix: Rewrite the insert_before method on Terminal to fix a bug and remove the height cap

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -228,7 +228,7 @@ pub trait Backend {
     /// [`get_cursor`]: Backend::get_cursor
     fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()>;
 
-    /// Clears the whole terminal scree
+    /// Clears the whole terminal screen
     ///
     /// # Example
     ///

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -363,28 +363,51 @@ mod tests {
 
     #[test]
     fn clear() {
-        let mut backend = TestBackend::new(10, 2);
+        let mut backend = TestBackend::new(10, 4);
         let mut cell = Cell::default();
         cell.set_symbol("a");
         backend.draw([(0, 0, &cell)].into_iter()).unwrap();
         backend.draw([(0, 1, &cell)].into_iter()).unwrap();
         backend.clear().unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec!["          ", "          "]));
+        backend.assert_buffer(&Buffer::with_lines(vec![
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+        ]));
     }
 
     #[test]
     fn clear_region_all() {
-        let mut backend = TestBackend::new(10, 2);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa"]);
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+        ]);
 
         backend.clear_region(ClearType::All).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec!["          ", "          "]));
+        backend.assert_buffer(&Buffer::with_lines(vec![
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+            "          ",
+        ]));
     }
 
     #[test]
     fn clear_region_after_cursor() {
-        let mut backend = TestBackend::new(10, 2);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"]);
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+        ]);
 
         backend.set_cursor(0, 1).unwrap();
         backend.clear_region(ClearType::AfterCursor).unwrap();
@@ -392,13 +415,21 @@ mod tests {
             "aaaaaaaaaa",
             "a         ",
             "          ",
+            "          ",
+            "          ",
         ]));
     }
 
     #[test]
     fn clear_region_before_cursor() {
-        let mut backend = TestBackend::new(10, 2);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"]);
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+        ]);
 
         backend.set_cursor(0, 1).unwrap();
         backend.clear_region(ClearType::BeforeCursor).unwrap();
@@ -406,13 +437,21 @@ mod tests {
             "          ",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
         ]));
     }
 
     #[test]
     fn clear_region_current_line() {
-        let mut backend = TestBackend::new(10, 3);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"]);
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+        ]);
 
         backend.set_cursor(3, 1).unwrap();
         backend.clear_region(ClearType::CurrentLine).unwrap();
@@ -420,82 +459,150 @@ mod tests {
             "aaaaaaaaaa",
             "          ",
             "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
         ]));
     }
 
     #[test]
     fn clear_region_until_new_line() {
-        let mut backend = TestBackend::new(10, 2);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa"]);
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+        ]);
 
         backend.set_cursor(3, 0).unwrap();
         backend.clear_region(ClearType::UntilNewLine).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec!["aaa       ", "aaaaaaaaaa"]));
+        backend.assert_buffer(&Buffer::with_lines(vec![
+            "aaa       ",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+        ]));
     }
 
     #[test]
-    fn append_lines() {
-        let mut backend = TestBackend::new(10, 3);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "bbbbbbbbbb", "cccccccccc"]);
+    fn append_lines_not_at_last_line() {
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "bbbbbbbbbb",
+            "cccccccccc",
+            "dddddddddd",
+            "eeeeeeeeee",
+        ]);
 
         backend.set_cursor(0, 0).unwrap();
+
+        // If the cursor is not at the last line in the terminal the addition of a
+        // newline simply moves the cursor down and to the right
 
         backend.append_lines(1).unwrap();
         assert_eq!(backend.get_cursor().unwrap(), (1, 1));
-        backend.assert_buffer(&Buffer::with_lines(vec![
-            "aaaaaaaaaa",
-            "bbbbbbbbbb",
-            "cccccccccc",
-        ]));
 
         backend.append_lines(1).unwrap();
         assert_eq!(backend.get_cursor().unwrap(), (2, 2));
+
+        backend.append_lines(1).unwrap();
+        assert_eq!(backend.get_cursor().unwrap(), (3, 3));
+
+        backend.append_lines(1).unwrap();
+        assert_eq!(backend.get_cursor().unwrap(), (4, 4));
+
+        // As such the buffer should remain unchanged
         backend.assert_buffer(&Buffer::with_lines(vec![
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
-        ]));
-
-        backend.append_lines(1).unwrap();
-        assert_eq!(backend.get_cursor().unwrap(), (3, 2));
-        backend.assert_buffer(&Buffer::with_lines(vec![
-            "bbbbbbbbbb",
-            "cccccccccc",
-            "          ",
+            "dddddddddd",
+            "eeeeeeeeee",
         ]));
     }
 
     #[test]
-    fn append_lines_multiple() {
-        let mut backend = TestBackend::new(10, 3);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "bbbbbbbbbb", "cccccccccc"]);
+    fn append_lines_at_last_line() {
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "bbbbbbbbbb",
+            "cccccccccc",
+            "dddddddddd",
+            "eeeeeeeeee",
+        ]);
+
+        // If the cursor is at the last line in the terminal the addition of a
+        // newline will scroll the contents of the buffer
+        backend.set_cursor(0, 4).unwrap();
+
+        backend.append_lines(1).unwrap();
+
+        backend.buffer = Buffer::with_lines(vec![
+            "bbbbbbbbbb",
+            "cccccccccc",
+            "dddddddddd",
+            "eeeeeeeeee",
+            "          ",
+        ]);
+
+        // It also moves the cursor to the right, as is common of the behaviour of
+        // terminals in raw-mode
+        assert_eq!(backend.get_cursor().unwrap(), (1, 4));
+    }
+
+    #[test]
+    fn append_multiple_lines_not_at_last_line() {
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "bbbbbbbbbb",
+            "cccccccccc",
+            "dddddddddd",
+            "eeeeeeeeee",
+        ]);
 
         backend.set_cursor(0, 0).unwrap();
 
-        backend.append_lines(2).unwrap();
-        assert_eq!(backend.get_cursor().unwrap(), (1, 2));
+        // If the cursor is not at the last line in the terminal the addition of multiple
+        // newlines simply moves the cursor n lines down and to the right by 1
+
+        backend.append_lines(4).unwrap();
+        assert_eq!(backend.get_cursor().unwrap(), (1, 4));
+
+        // As such the buffer should remain unchanged
         backend.assert_buffer(&Buffer::with_lines(vec![
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
+            "dddddddddd",
+            "eeeeeeeeee",
         ]));
+    }
 
-        backend.set_cursor(0, 1).unwrap();
-
-        backend.append_lines(2).unwrap();
-        assert_eq!(backend.get_cursor().unwrap(), (1, 2));
-        backend.assert_buffer(&Buffer::with_lines(vec![
+    #[test]
+    fn append_multiple_lines_past_last_line() {
+        let mut backend = TestBackend::new(10, 5);
+        backend.buffer = Buffer::with_lines(vec![
+            "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
-            "          ",
-        ]));
+            "dddddddddd",
+            "eeeeeeeeee",
+        ]);
 
-        backend.set_cursor(0, 0).unwrap();
+        backend.set_cursor(0, 3).unwrap();
 
-        backend.append_lines(4).unwrap();
-        assert_eq!(backend.get_cursor().unwrap(), (1, 2));
+        backend.append_lines(3).unwrap();
+        assert_eq!(backend.get_cursor().unwrap(), (1, 4));
+
         backend.assert_buffer(&Buffer::with_lines(vec![
-            "          ",
+            "cccccccccc",
+            "dddddddddd",
+            "eeeeeeeeee",
             "          ",
             "          ",
         ]));

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -421,12 +421,12 @@ mod tests {
             "aaaaaaaaaa",
         ]);
 
-        backend.set_cursor(0, 1).unwrap();
+        backend.set_cursor(3, 2).unwrap();
         backend.clear_region(ClearType::AfterCursor).unwrap();
         backend.assert_buffer(&Buffer::with_lines(vec![
             "aaaaaaaaaa",
-            "a         ",
-            "          ",
+            "aaaaaaaaaa",
+            "aaaa      ",
             "          ",
             "          ",
         ]));
@@ -443,13 +443,13 @@ mod tests {
             "aaaaaaaaaa",
         ]);
 
-        backend.set_cursor(0, 1).unwrap();
+        backend.set_cursor(5, 3).unwrap();
         backend.clear_region(ClearType::BeforeCursor).unwrap();
         backend.assert_buffer(&Buffer::with_lines(vec![
             "          ",
-            "aaaaaaaaaa",
-            "aaaaaaaaaa",
-            "aaaaaaaaaa",
+            "          ",
+            "          ",
+            "     aaaaa",
             "aaaaaaaaaa",
         ]));
     }

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -369,42 +369,50 @@ mod tests {
         backend.draw([(0, 0, &cell)].into_iter()).unwrap();
         backend.draw([(0, 1, &cell)].into_iter()).unwrap();
         backend.clear().unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec!["          "; 2]));
+        backend.assert_buffer(&Buffer::with_lines(vec!["          ", "          "]));
     }
 
     #[test]
     fn clear_region_all() {
         let mut backend = TestBackend::new(10, 2);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa"; 2]);
+        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa"]);
 
         backend.clear_region(ClearType::All).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec!["          "; 2]));
+        backend.assert_buffer(&Buffer::with_lines(vec!["          ", "          "]));
     }
 
     #[test]
     fn clear_region_after_cursor() {
         let mut backend = TestBackend::new(10, 2);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa"; 2]);
+        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"]);
 
         backend.set_cursor(0, 1).unwrap();
         backend.clear_region(ClearType::AfterCursor).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec!["aaaaaaaaaa", "a         "]));
+        backend.assert_buffer(&Buffer::with_lines(vec![
+            "aaaaaaaaaa",
+            "a         ",
+            "          ",
+        ]));
     }
 
     #[test]
     fn clear_region_before_cursor() {
         let mut backend = TestBackend::new(10, 2);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa"; 2]);
+        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"]);
 
         backend.set_cursor(0, 1).unwrap();
         backend.clear_region(ClearType::BeforeCursor).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec!["          ", "aaaaaaaaaa"]));
+        backend.assert_buffer(&Buffer::with_lines(vec![
+            "          ",
+            "aaaaaaaaaa",
+            "aaaaaaaaaa",
+        ]));
     }
 
     #[test]
     fn clear_region_current_line() {
         let mut backend = TestBackend::new(10, 3);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa"; 3]);
+        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"]);
 
         backend.set_cursor(3, 1).unwrap();
         backend.clear_region(ClearType::CurrentLine).unwrap();
@@ -418,7 +426,7 @@ mod tests {
     #[test]
     fn clear_region_until_new_line() {
         let mut backend = TestBackend::new(10, 2);
-        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa"; 2]);
+        backend.buffer = Buffer::with_lines(vec!["aaaaaaaaaa", "aaaaaaaaaa"]);
 
         backend.set_cursor(3, 0).unwrap();
         backend.clear_region(ClearType::UntilNewLine).unwrap();

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -183,65 +183,22 @@ impl Backend for TestBackend {
         match clear_type {
             ClearType::All => self.clear()?,
             ClearType::AfterCursor => {
-                self.buffer.content = self
-                    .buffer
-                    .content()
-                    .iter()
-                    .enumerate()
-                    .map(|(i, c)| {
-                        if i > self.buffer.index_of(self.pos.0, self.pos.1) {
-                            Cell::default()
-                        } else {
-                            c.clone()
-                        }
-                    })
-                    .collect()
+                let index = self.buffer.index_of(self.pos.0, self.pos.1) + 1;
+                self.buffer.content[index..].fill(Cell::default());
             }
             ClearType::BeforeCursor => {
-                self.buffer.content = self
-                    .buffer
-                    .content()
-                    .iter()
-                    .enumerate()
-                    .map(|(i, c)| {
-                        if i < self.buffer.index_of(self.pos.0, self.pos.1) {
-                            Cell::default()
-                        } else {
-                            c.clone()
-                        }
-                    })
-                    .collect()
+                let index = self.buffer.index_of(self.pos.0, self.pos.1);
+                self.buffer.content[..index].fill(Cell::default());
             }
             ClearType::CurrentLine => {
-                self.buffer.content = self
-                    .buffer
-                    .content()
-                    .iter()
-                    .enumerate()
-                    .map(|(i, c)| {
-                        if self.buffer.pos_of(i).1 == self.pos.1 {
-                            Cell::default()
-                        } else {
-                            c.clone()
-                        }
-                    })
-                    .collect()
+                let line_start_index = self.buffer.index_of(0, self.pos.1);
+                let line_end_index = self.buffer.index_of(self.width - 1, self.pos.1);
+                self.buffer.content[line_start_index..=line_end_index].fill(Cell::default());
             }
             ClearType::UntilNewLine => {
-                self.buffer.content = self
-                    .buffer
-                    .content()
-                    .iter()
-                    .enumerate()
-                    .map(|(i, c)| {
-                        let p = self.buffer.pos_of(i);
-                        if p.1 == self.pos.1 && p.0 >= self.pos.0 {
-                            Cell::default()
-                        } else {
-                            c.clone()
-                        }
-                    })
-                    .collect()
+                let index = self.buffer.index_of(self.pos.0, self.pos.1);
+                let line_end_index = self.buffer.index_of(self.width - 1, self.pos.1);
+                self.buffer.content[index..=line_end_index].fill(Cell::default());
             }
         }
         Ok(())

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -207,7 +207,7 @@ impl Backend for TestBackend {
     /// Inserts n line breaks at the current cursor position.
     ///
     /// After the insertion, the cursor x position will be incremented by 1 (unless it's already
-    /// at the end of line).
+    /// at the end of line). This is a common behaviour of terminals in raw mode.
     ///
     /// If the number of lines to append is fewer than the number of lines in the buffer after the
     /// cursor y position then the cursor is moved down by n rows.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -474,13 +474,15 @@ where
         // Clear the viewport off the screen
         self.clear()?;
 
-        // Move the viewport accordingly - if it's not already at the bottom of the terminal
+        // Move the viewport by height, but don't move it past the bottom of the terminal
+        let viewport_at_bottom = self.last_known_size.bottom() - self.viewport_area.height;
         self.set_viewport_area(Rect {
-            x: self.viewport_area.left(),
-            y: (self.viewport_area.top() + height)
-                .min(self.last_known_size.bottom() - self.viewport_area.height),
-            width: self.viewport_area.width,
-            height: self.viewport_area.height,
+            y: self
+                .viewport_area
+                .y
+                .saturating_add(height)
+                .min(viewport_at_bottom),
+            ..self.viewport_area
         });
 
         // Draw contents into buffer

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -471,38 +471,47 @@ where
             return Ok(());
         }
 
+        // Clear the viewport off the screen
         self.clear()?;
-        let height = height.min(self.last_known_size.height);
-        self.backend.append_lines(height)?;
-        let missing_lines =
-            height.saturating_sub(self.last_known_size.bottom() - self.viewport_area.top());
+
+        // Move the viewport accordingly - if it's not already at the bottom of the terminal
+        self.set_viewport_area(Rect {
+            x: self.viewport_area.left(),
+            y: (self.viewport_area.top() + height)
+                .min(self.last_known_size.bottom() - self.viewport_area.height),
+            width: self.viewport_area.width,
+            height: self.viewport_area.height,
+        });
+
+        // Draw contents into buffer
         let area = Rect {
             x: self.viewport_area.left(),
-            y: self.viewport_area.top().saturating_sub(missing_lines),
+            y: 0,
             width: self.viewport_area.width,
             height,
         };
         let mut buffer = Buffer::empty(area);
-
         draw_fn(&mut buffer);
 
-        let iter = buffer.content.iter().enumerate().map(|(i, c)| {
-            let (x, y) = buffer.pos_of(i);
-            (x, y, c)
-        });
-        self.backend.draw(iter)?;
-        self.backend.flush()?;
+        // Split buffer into screen-sized chunks and draw
+        let max_chunk_size = (self.viewport_area.top() * area.width).into();
+        for buffer_content_chunk in buffer.content.chunks(max_chunk_size) {
+            let chunk_size = buffer_content_chunk.len() as u16 / area.width;
 
-        let remaining_lines = self.last_known_size.height - area.bottom();
-        let missing_lines = self.viewport_area.height.saturating_sub(remaining_lines);
-        self.backend.append_lines(self.viewport_area.height)?;
+            self.backend
+                .append_lines(self.viewport_area.height.saturating_sub(1) + chunk_size)?;
 
-        self.set_viewport_area(Rect {
-            x: area.left(),
-            y: area.bottom().saturating_sub(missing_lines),
-            width: area.width,
-            height: self.viewport_area.height,
-        });
+            let iter = buffer_content_chunk.iter().enumerate().map(|(i, c)| {
+                let (x, y) = buffer.pos_of(i);
+                (
+                    x,
+                    self.viewport_area.top().saturating_sub(chunk_size) + y,
+                    c,
+                )
+            });
+            self.backend.draw(iter)?;
+            self.backend.flush()?;
+        }
 
         Ok(())
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -511,6 +511,7 @@ where
             });
             self.backend.draw(iter)?;
             self.backend.flush()?;
+            self.set_cursor(self.viewport_area.left(), self.viewport_area.top())?;
         }
 
         Ok(())

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -1,10 +1,13 @@
 use std::error::Error;
 
 use ratatui::{
+    assert_buffer_eq,
     backend::{Backend, TestBackend},
     layout::Rect,
-    widgets::Paragraph,
-    Terminal,
+    prelude::Buffer,
+    text::Line,
+    widgets::{Paragraph, Widget},
+    Terminal, TerminalOptions, Viewport,
 };
 
 #[test]
@@ -45,5 +48,98 @@ fn terminal_draw_returns_the_completed_frame() -> Result<(), Box<dyn Error>> {
     })?;
     assert_eq!(frame.buffer.get(0, 0).symbol, "t");
     assert_eq!(frame.area, Rect::new(0, 0, 8, 8));
+    Ok(())
+}
+
+#[test]
+fn terminal_insert_before_moves_viewport() -> Result<(), Box<dyn Error>> {
+    let backend = TestBackend::new(8, 5);
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(2),
+        },
+    )?;
+
+    terminal.insert_before(2, |buf| {
+        let lines: Vec<Line> = (0..2).map(|i| Line::from(format!("Line {i}"))).collect();
+        Paragraph::new(lines).render(buf.area, buf);
+    })?;
+
+    terminal.draw(|f| {
+        let paragraph = Paragraph::new("Test");
+        f.render_widget(paragraph, f.size());
+    })?;
+
+    assert_buffer_eq!(
+        terminal.backend().buffer().clone(),
+        Buffer::with_lines(vec![
+            "Line 0  ", "Line 1  ", "Test    ", "        ", "        ",
+        ])
+    );
+
+    Ok(())
+}
+
+#[test]
+fn terminal_insert_before_scrolls_on_large_input() -> Result<(), Box<dyn Error>> {
+    let backend = TestBackend::new(8, 5);
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(2),
+        },
+    )?;
+
+    terminal.insert_before(10, |buf| {
+        let lines: Vec<Line> = (0..10).map(|i| Line::from(format!("Line {i}"))).collect();
+        Paragraph::new(lines).render(buf.area, buf);
+    })?;
+
+    terminal.draw(|f| {
+        let paragraph = Paragraph::new("Test");
+        f.render_widget(paragraph, f.size());
+    })?;
+
+    assert_buffer_eq!(
+        terminal.backend().buffer().clone(),
+        Buffer::with_lines(vec![
+            "Line 7  ", "Line 8  ", "Line 9  ", "Test    ", "        ",
+        ])
+    );
+
+    print!("{:?}", terminal.backend().buffer());
+
+    Ok(())
+}
+
+#[test]
+fn terminal_insert_before_scrolls_on_many_inserts() -> Result<(), Box<dyn Error>> {
+    let backend = TestBackend::new(8, 5);
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(2),
+        },
+    )?;
+
+    for i in 0..4 {
+        terminal.insert_before(1, |buf| {
+            Paragraph::new(Line::raw(format!("Line {i}"))).render(buf.area, buf);
+        })?;
+    }
+
+    terminal.draw(|f| {
+        let paragraph = Paragraph::new("Test");
+        f.render_widget(paragraph, f.size());
+    })?;
+
+    assert_buffer_eq!(
+        terminal.backend().buffer().clone(),
+        Buffer::with_lines(vec![
+            "Line 1  ", "Line 2  ", "Line 3  ", "Test    ", "        ",
+        ])
+    );
+
     Ok(())
 }

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -5,7 +5,6 @@ use ratatui::{
     backend::{Backend, TestBackend},
     layout::Rect,
     prelude::Buffer,
-    text::Line,
     widgets::{Paragraph, Widget},
     Terminal, TerminalOptions, Viewport,
 };
@@ -53,28 +52,42 @@ fn terminal_draw_returns_the_completed_frame() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn terminal_insert_before_moves_viewport() -> Result<(), Box<dyn Error>> {
-    let backend = TestBackend::new(8, 5);
+    // When we have a terminal with 5 lines, and a single line viewport, if we insert a
+    // number of lines less than the `terminal height - viewport height` it should move
+    // viewport down to accommodate the new lines.
+
+    let backend = TestBackend::new(20, 5);
     let mut terminal = Terminal::with_options(
         backend,
         TerminalOptions {
-            viewport: Viewport::Inline(2),
+            viewport: Viewport::Inline(1),
         },
     )?;
 
+    // insert_before cannot guarantee the contents of the viewport remain unharmed
+    // by potential scrolling as such it is necessary to call draw afterwards to
+    // redraw the contents of the viewport over the newly designated area.
     terminal.insert_before(2, |buf| {
-        let lines: Vec<Line> = (0..2).map(|i| Line::from(format!("Line {i}"))).collect();
-        Paragraph::new(lines).render(buf.area, buf);
+        Paragraph::new(vec![
+            "------ Line 1 ------".into(),
+            "------ Line 2 ------".into(),
+        ])
+        .render(buf.area, buf);
     })?;
 
     terminal.draw(|f| {
-        let paragraph = Paragraph::new("Test");
+        let paragraph = Paragraph::new("[---- Viewport ----]");
         f.render_widget(paragraph, f.size());
     })?;
 
     assert_buffer_eq!(
         terminal.backend().buffer().clone(),
         Buffer::with_lines(vec![
-            "Line 0  ", "Line 1  ", "Test    ", "        ", "        ",
+            "------ Line 1 ------",
+            "------ Line 2 ------",
+            "[---- Viewport ----]",
+            "                    ",
+            "                    ",
         ])
     );
 
@@ -83,61 +96,98 @@ fn terminal_insert_before_moves_viewport() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn terminal_insert_before_scrolls_on_large_input() -> Result<(), Box<dyn Error>> {
-    let backend = TestBackend::new(8, 5);
+    // When we have a terminal with 5 lines, and a single line viewport, if we insert many
+    // lines before the viewport (greater than `terminal height - viewport height`) it should
+    // move the viewport down to the bottom of the terminal and scroll all lines above the viewport
+    // until all have been added to the buffer.
+
+    let backend = TestBackend::new(20, 5);
     let mut terminal = Terminal::with_options(
         backend,
         TerminalOptions {
-            viewport: Viewport::Inline(2),
+            viewport: Viewport::Inline(1),
         },
     )?;
 
-    terminal.insert_before(10, |buf| {
-        let lines: Vec<Line> = (0..10).map(|i| Line::from(format!("Line {i}"))).collect();
-        Paragraph::new(lines).render(buf.area, buf);
+    terminal.insert_before(5, |buf| {
+        Paragraph::new(vec![
+            "------ Line 1 ------".into(),
+            "------ Line 2 ------".into(),
+            "------ Line 3 ------".into(),
+            "------ Line 4 ------".into(),
+            "------ Line 5 ------".into(),
+        ])
+        .render(buf.area, buf);
     })?;
 
     terminal.draw(|f| {
-        let paragraph = Paragraph::new("Test");
+        let paragraph = Paragraph::new("[---- Viewport ----]");
         f.render_widget(paragraph, f.size());
     })?;
 
     assert_buffer_eq!(
         terminal.backend().buffer().clone(),
         Buffer::with_lines(vec![
-            "Line 7  ", "Line 8  ", "Line 9  ", "Test    ", "        ",
+            "------ Line 2 ------",
+            "------ Line 3 ------",
+            "------ Line 4 ------",
+            "------ Line 5 ------",
+            "[---- Viewport ----]",
         ])
     );
-
-    print!("{:?}", terminal.backend().buffer());
 
     Ok(())
 }
 
 #[test]
 fn terminal_insert_before_scrolls_on_many_inserts() -> Result<(), Box<dyn Error>> {
-    let backend = TestBackend::new(8, 5);
+    // This test ensures similar behaviour to `terminal_insert_before_scrolls_on_large_input`
+    // but covers a bug previously present whereby multiple small insertions
+    // (less than `terminal height - viewport height`) would have disparate behaviour to one large
+    // insertion. This was caused by an undocumented cap on the height to be inserted, which has now
+    // been removed.
+
+    let backend = TestBackend::new(20, 5);
     let mut terminal = Terminal::with_options(
         backend,
         TerminalOptions {
-            viewport: Viewport::Inline(2),
+            viewport: Viewport::Inline(1),
         },
     )?;
 
-    for i in 0..4 {
-        terminal.insert_before(1, |buf| {
-            Paragraph::new(Line::raw(format!("Line {i}"))).render(buf.area, buf);
-        })?;
-    }
+    terminal.insert_before(1, |buf| {
+        Paragraph::new(vec!["------ Line 1 ------".into()]).render(buf.area, buf);
+    })?;
+
+    terminal.insert_before(1, |buf| {
+        Paragraph::new(vec!["------ Line 2 ------".into()]).render(buf.area, buf);
+    })?;
+
+    terminal.insert_before(1, |buf| {
+        Paragraph::new(vec!["------ Line 3 ------".into()]).render(buf.area, buf);
+    })?;
+
+    terminal.insert_before(1, |buf| {
+        Paragraph::new(vec!["------ Line 4 ------".into()]).render(buf.area, buf);
+    })?;
+
+    terminal.insert_before(1, |buf| {
+        Paragraph::new(vec!["------ Line 5 ------".into()]).render(buf.area, buf);
+    })?;
 
     terminal.draw(|f| {
-        let paragraph = Paragraph::new("Test");
+        let paragraph = Paragraph::new("[---- Viewport ----]");
         f.render_widget(paragraph, f.size());
     })?;
 
     assert_buffer_eq!(
         terminal.backend().buffer().clone(),
         Buffer::with_lines(vec![
-            "Line 1  ", "Line 2  ", "Line 3  ", "Test    ", "        ",
+            "------ Line 2 ------",
+            "------ Line 3 ------",
+            "------ Line 4 ------",
+            "------ Line 5 ------",
+            "[---- Viewport ----]",
         ])
     );
 


### PR DESCRIPTION
This PR fixes some issues encountered in #584 by way of rewriting the `insert_before` method.

> **The function signature for reference:** 
> ```rs
> pub fn insert_before<F>(&mut self, height: u16, draw_fn: F) -> io::Result<()>
> ```

Ultimately it does two things:

1. It fixes a bug triggered by the `height` parameter of a call to `insert_before` being greater than `self.viewport_area.height` - This bug would cause an extra newline to be inserted leaving a gap in the output.
2. Removes the `height` cap by rendering output in chunks. if `height` is too large to fit on the screen (with the viewport) then chunks are rendered as the screen is scrolled.

## A Note About Test Coverage
~~There are currently no tests for the `insert_before` method; I've attempted to test this change with the `TestBackend` but unfortunately due to it not supporting clear `ClearType::AfterCursor` this would prove difficult and I think the noise of adding this functionality wouldn't be worth adding to this PR. As it's a very minimal hit I wondered if it's acceptable?~~

> **Update:** I've now added some test cases for the issues encountered in the `tests/` folder. I know this is now discouraged but there was already a pattern of using the `TestBackend` in this location, but I'd be open to moving them if requested. I've also added the `clear_region` and `append_lines` methods to the `TestBackend` with accompanying tests.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
