### PR TITLE
chore: disable default benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,9 @@ harness = false
 name = "list"
 harness = false
 
+[lib]
+bench = false
+
 [[bench]]
 name = "paragraph"
 harness = false


### PR DESCRIPTION
This disables the default benchmarking behaviour for the lib target to fix unrecognized criterion benchmark arguments as specified in the [FAQ](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options) of criterion.

I came accross this error when trying to save a baseline for the benchmarks using the [`--save-baseline`](https://bheisler.github.io/criterion.rs/book/user_guide/command_line_options.html#baselines) option.