### PR TITLE
perf(buffer)!: apply SSO technique to text buffer in `buffer::Cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ unicode-width = "0.1"
 document-features = { version = "0.2.7", optional = true }
 lru = "0.12.0"
 stability = "0.1.1"
+compact_str = "0.7.1"
 
 [dev-dependencies]
 anyhow = "1.0.71"
@@ -78,7 +79,7 @@ termwiz = ["dep:termwiz"]
 #! The following optional features are available for all backends:
 ## enables serialization and deserialization of style and color types using the [Serde crate].
 ## This is useful if you want to save themes to a file.
-serde = ["dep:serde", "bitflags/serde"]
+serde = ["dep:serde", "bitflags/serde", "compact_str/serde"]
 
 ## enables the [`border!`] macro.
 macros = []

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -35,7 +35,7 @@ use crate::{buffer::Cell, prelude::*};
 ///     "string",
 ///     Style::default().fg(Color::Red).bg(Color::White),
 /// );
-/// let cell = buf.get_mut(5, 0);
+/// let cell = buf.get(5, 0);
 /// assert_eq!(cell.symbol(), "r");
 /// assert_eq!(cell.fg, Color::Red);
 /// assert_eq!(cell.bg, Color::White);


### PR DESCRIPTION
## Description

ratatui allocates one `String` buffer for each `buffer::Cell`. `char` is not sufficient since one character can consist of multiple code points. However, in almost all cases the cells have a single code point. It means that ratatui allocates many small heap memories (~16 Bytes/cell) only for the rare cases.

Allocation on heap is slower than allocation on stack so moving these allocations to stack can improve performance of allocating `buffer::Buffer`.

To archive this, a small string optimization (SSO) is available in general (which is adopted by C++'s `std::string`). Fortunately, [compact_str](https://crates.io/crates/compact_str) crate is a solid implementation of SSO. It provides a drop in replacement of standard `String` so we can use it with very small changes (as diffs of this PR show).

The [`CompactString`](https://docs.rs/compact_str/0.7.1/compact_str/struct.CompactString.html) has the same size as `String` and has 24 bytes inline storage. By using it for text buffer of `buffer::Cell`, the symbol character can be stored on stack in almost all cases.

One problem is that `symbol` field of `Cell` struct is no longer a standard `String` object. Now it is a `CompactString` but it would have small impact on users' code base since users usually modifies the buffer cells through widgets.

## Measurement summary

- Total number of small (16Bytes) heap allocations was reduced from 288895 to 8178
- Total size of small (16Bytes) heap allocations was reduced from 4.41MiB to 127.78KiB
- Performance of initial rendering was 1.77x faster
- Performance of rendering on each tick was 1.14x faster

## Memory profiling

I used `xctrace` (general purpose profiler bundled in Xcode) to measure memory profiling. I modified the `demo` example to use `TextBackend` and stops after 100 tick iterations to measure the impact on this change precisely.

<details>
<summary>Diff applied to demo example</summary>

```diff
diff --git a/examples/demo/dummy.rs b/examples/demo/dummy.rs
new file mode 100644
index 0000000..b733aca
--- /dev/null
+++ b/examples/demo/dummy.rs
@@ -0,0 +1,31 @@
+use std::{error::Error, io};
+
+use ratatui::backend::TestBackend;
+use ratatui::prelude::*;
+
+use crate::{app::App, ui};
+
+pub fn run(enhanced_graphics: bool) -> Result<(), Box<dyn Error>> {
+    let backend = TestBackend::new(318, 82);
+    let mut terminal = Terminal::new(backend)?;
+
+    // create app and run it
+    let app = App::new("Test Demo", enhanced_graphics);
+    let res = run_app(&mut terminal, app);
+
+    if let Err(err) = res {
+        println!("{err:?}");
+        // } else {
+        //     println!("{:?}", terminal.backend().buffer().content);
+    }
+
+    Ok(())
+}
+
+fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
+    for _ in 0..100 {
+        terminal.draw(|f| ui::draw(f, &mut app))?;
+        app.on_tick();
+    }
+    Ok(())
+}
diff --git a/examples/demo/main.rs b/examples/demo/main.rs
index c2f742b..a236d18 100644
--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -1,10 +1,11 @@
-use std::{error::Error, time::Duration};
+use std::{env, error::Error, time::Duration};
 
 use argh::FromArgs;
 
 mod app;
 #[cfg(feature = "crossterm")]
 mod crossterm;
+mod dummy;
 #[cfg(feature = "termion")]
 mod termion;
 #[cfg(feature = "termwiz")]
@@ -25,12 +26,19 @@ struct Cli {
 
 fn main() -> Result<(), Box<dyn Error>> {
     let cli: Cli = argh::from_env();
-    let tick_rate = Duration::from_millis(cli.tick_rate);
-    #[cfg(feature = "crossterm")]
-    crate::crossterm::run(tick_rate, cli.enhanced_graphics)?;
-    #[cfg(feature = "termion")]
-    crate::termion::run(tick_rate, cli.enhanced_graphics)?;
-    #[cfg(feature = "termwiz")]
-    crate::termwiz::run(tick_rate, cli.enhanced_graphics)?;
+    if env::var("DO_NOT_USE_DUMMY_BACKEND")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+    {
+        let tick_rate = Duration::from_millis(cli.tick_rate);
+        #[cfg(feature = "crossterm")]
+        crate::crossterm::run(tick_rate, cli.enhanced_graphics)?;
+        #[cfg(feature = "termion")]
+        crate::termion::run(tick_rate, cli.enhanced_graphics)?;
+        #[cfg(feature = "termwiz")]
+        crate::termwiz::run(tick_rate, cli.enhanced_graphics)?;
+    } else {
+        crate::dummy::run(cli.enhanced_graphics)?;
+    }
     Ok(())
 }
```
</details>

The measured results of 16Bytes heap allocations are as follows:

| | `main` branch | `sso` branch |
|-|-|-|
| Total bytes | 4.41MiB | 127.78KiB |
| # of allocs | 288895 | 8178 |
| Screenshot | <img width="849" alt="before" src="https://github.com/ratatui-org/ratatui/assets/823277/c7e0c8bf-fcd8-46a5-8349-a309a751c07d"> | <img width="843" alt="after" src="https://github.com/ratatui-org/ratatui/assets/823277/f6511921-a6f5-4105-b04a-d575b38c6db8"> |

## Initial rendering performance

I measured E2E launch time (initial rendering) performance using [hyperfine](https://github.com/sharkdp/hyperfine).

I removed the `for` loop to measure a single tick iteration where screen is rendered once.

<details>
<summary>Diff applied to demo example</summary>

```diff
diff --git a/examples/demo/dummy.rs b/examples/demo/dummy.rs
index b733aca..6b2a4f7 100644
--- a/examples/demo/dummy.rs
+++ b/examples/demo/dummy.rs
@@ -23,9 +23,7 @@ pub fn run(enhanced_graphics: bool) -> Result<(), Box<dyn Error>> {
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
-    for _ in 0..100 {
-        terminal.draw(|f| ui::draw(f, &mut app))?;
-        app.on_tick();
-    }
+    terminal.draw(|f| ui::draw(f, &mut app))?;
+    app.on_tick();
     Ok(())
 }
```
</details>

The result on my machine was as follows:

```console
$ hyperfine --shell=none ./demo_main ./demo_sso
Benchmark 1: ./demo_main
  Time (mean ± σ):       8.8 ms ±   0.4 ms    [User: 6.4 ms, System: 1.5 ms]
  Range (min … max):     8.4 ms …  11.4 ms    316 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: ./demo_sso
  Time (mean ± σ):       5.0 ms ±   0.1 ms    [User: 3.0 ms, System: 1.1 ms]
  Range (min … max):     4.7 ms …   5.8 ms    581 runs

Summary
  ./demo_sso ran
    1.77 ± 0.09 times faster than ./demo_main
```

## 100 tick iterations performance

In addition, I measured performance of 100 tick iterations with hyperfine. And it turned out that this branch is 1.14x faster than main branch.

```
$ hyperfine ./demo_main ./demo_sso
Benchmark 1: ./demo_main
  Time (mean ± σ):      85.2 ms ±   2.5 ms    [User: 81.8 ms, System: 2.1 ms]
  Range (min … max):    82.2 ms …  94.9 ms    34 runs

Benchmark 2: ./demo_sso
  Time (mean ± σ):      74.9 ms ±   0.6 ms    [User: 72.2 ms, System: 1.5 ms]
  Range (min … max):    73.3 ms …  76.8 ms    38 runs

Summary
  ./demo_sso ran
    1.14 ± 0.03 times faster than ./demo_main
```

