### PR TITLE
refactor: define struct WrappedLine instead of anonymous tuple

### DIFF
--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -6,7 +6,7 @@ use crate::{
     style::{Style, Styled},
     text::{StyledGrapheme, Text},
     widgets::{
-        reflow::{LineComposer, LineTruncator, WordWrapper},
+        reflow::{LineComposer, LineTruncator, WordWrapper, WrappedLine},
         Block, Widget,
     },
 };
@@ -254,8 +254,11 @@ impl<'a> Widget for Paragraph<'a> {
 impl<'a> Paragraph<'a> {
     fn render_text<C: LineComposer<'a>>(&self, mut composer: C, area: Rect, buf: &mut Buffer) {
         let mut y = 0;
-        while let Some((current_line, current_line_width, current_line_alignment)) =
-            composer.next_line()
+        while let Some(WrappedLine {
+            line: current_line,
+            width: current_line_width,
+            alignment: current_line_alignment,
+        }) = composer.next_line()
         {
             if y >= self.scroll.0 {
                 let mut x = get_line_offset(current_line_width, area.width, current_line_alignment);


### PR DESCRIPTION
It makes the type easier to document, and more obvious for users, given that #607 makes this part of the public API