### PR TITLE
feat: implement Lender for WordWrapper and LineTruncator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bitflags = "2.3"
 cassowary = "0.3"
 indoc = "2.0"
 itertools = "0.11"
+lender = "0.2.1"
 paste = "1.0.2"
 strum = { version = "0.25", features = ["derive"] }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -6,7 +6,7 @@ use crate::{
     style::{Style, Styled},
     text::{StyledGrapheme, Text},
     widgets::{
-        reflow::{LineComposer, LineTruncator, WordWrapper},
+        reflow::{LineComposer, LineTruncator, WordWrapper, WrappedLine},
         Block, Widget,
     },
 };
@@ -244,8 +244,11 @@ impl<'a> Widget for Paragraph<'a> {
             line_composer
         };
         let mut y = 0;
-        while let Some((current_line, current_line_width, current_line_alignment)) =
-            line_composer.next_line()
+        while let Some(WrappedLine {
+            line: current_line,
+            width: current_line_width,
+            alignment: current_line_alignment,
+        }) = line_composer.next_line()
         {
             if y >= self.scroll.0 {
                 let mut x =


### PR DESCRIPTION
As a convenience for users of ratatui, as the [lender](https://crates.io/crates/lender) crate implements plenty of Iterator-like methods.

No test because this does not really add any new code.

This includes a commit from #608 in order to avoid merge conflicts