### PR TITLE
feat: add popup to layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,11 @@ underline-color = ["dep:crossterm"]
 #! The following features are unstable and may change in the future:
 
 ## Enable all unstable features.
-unstable = ["unstable-segment-size", "unstable-rendered-line-info"]
+unstable = ["unstable-popup-layout", "unstable-segment-size", "unstable-rendered-line-info"]
+
+## Enables [`Popup`](crate::layout::Popup) as a layout which is experimental and may change in the
+## future. See [Issue #617](https://github.com/ratatui-org/ratatui/issues/617) for more details.
+unstable-popup-layout = []
 
 ## Enables the [`Layout::segment_size`](crate::layout::Layout::segment_size) method which is experimental and may change in the
 ## future. See [Issue #536](https://github.com/ratatui-org/ratatui/issues/536) for more details.
@@ -230,7 +234,7 @@ doc-scrape-examples = true
 
 [[example]]
 name = "popup"
-required-features = ["crossterm"]
+required-features = ["crossterm", "unstable-popup-layout"]
 doc-scrape-examples = true
 
 [[example]]

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -5,7 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{layout::Popup, prelude::*, widgets::*};
 
 struct App {
     show_popup: bool,
@@ -86,29 +86,8 @@ fn ui(f: &mut Frame, app: &App) {
 
     if app.show_popup {
         let block = Block::default().title("Popup").borders(Borders::ALL);
-        let area = centered_rect(60, 20, size);
+        let area = Popup::from(size).percent(60, 20);
         f.render_widget(Clear, area); //this clears out the background
         f.render_widget(block, area);
     }
-}
-
-/// helper function to create a centered rect using up certain percentage of the available rect `r`
-fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
-    let popup_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(r);
-
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .split(popup_layout[1])[1]
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -209,6 +209,51 @@ pub enum Direction {
     Vertical,
 }
 
+#[stability::unstable(
+    feature = "popup-layout",
+    reason = "The variant for this feature is not final and may change in the future",
+    issue = "https://github.com/ratatui-org/ratatui/issues/617"
+)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Popup {
+    container: Rect,
+}
+
+impl Popup {
+    /// Returns a new rectangle both centered on `self` and using up a percentage of the containing
+    /// rectangle.
+    #[stability::unstable(
+        feature = "popup-layout",
+        reason = "The variant for this feature is not final and may change in the future",
+        issue = "https://github.com/ratatui-org/ratatui/issues/617"
+    )]
+    pub fn percent(&self, x: u16, y: u16) -> Rect {
+        let popup_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Percentage((100 - y) / 2),
+                Constraint::Percentage(y),
+                Constraint::Percentage((100 - y) / 2),
+            ])
+            .split(self.container);
+
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Percentage((100 - x) / 2),
+                Constraint::Percentage(x),
+                Constraint::Percentage((100 - x) / 2),
+            ])
+            .split(popup_layout[1])[1]
+    }
+}
+
+impl From<Rect> for Popup {
+    fn from(rect: Rect) -> Self {
+        Popup { container: rect }
+    }
+}
+
 /// Option for segment size preferences
 ///
 /// This controls how the space is distributed when the constraints are satisfied. By default, the


### PR DESCRIPTION
Same as with #618: I'm leaving this in draft for now and won't be adding tests or fixing coverage just yet. I'm putting in the effort of accompanying the PR/variant with tests/coverage when the decision is made. 

---

With this variant, the idea is to clearly communicate the intent for creating popups with a distinct struct in the layout module. Alternatively, if you're opposed to the struct, this could be done with plain functions and without the re-export in `src/layout.rs`, as in `ratatui::layout::popup::percentage(x, y, rect)`, but IMO the struct, which can easily be re-exported in `prelude.rs` like I did here, serves as a better, more stream-lined entrypoint for users than a module with plain functions would. 

The other use cases mentioned in https://github.com/ratatui-org/ratatui/issues/617#issuecomment-1801173192, i.e. popup with explicit size, based on margins, I can add later. With this variant though I'd avoid using generics and rather have individual functions, for the same reason as mentioned before: clearly communicate intent and thus more easily understandable API. 

--- 

fixes #617 