### PR TITLE
fix(doc): do not access deprecated `Cell::symbol` field in doc example

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -145,16 +145,13 @@ impl Default for Cell {
 /// let mut buf = Buffer::empty(Rect{x: 0, y: 0, width: 10, height: 5});
 /// buf.get_mut(0, 2).set_symbol("x");
 /// assert_eq!(buf.get(0, 2).symbol(), "x");
+///
 /// buf.set_string(3, 0, "string", Style::default().fg(Color::Red).bg(Color::White));
-/// assert_eq!(buf.get(5, 0), &Cell{
-///     symbol: String::from("r"),
-///     fg: Color::Red,
-///     bg: Color::White,
-///     #[cfg(feature = "underline-color")]
-///     underline_color: Color::Reset,
-///     modifier: Modifier::empty(),
-///     skip: false
-/// });
+/// let cell = buf.get_mut(5, 0);
+/// assert_eq!(cell.symbol(), "r");
+/// assert_eq!(cell.fg, Color::Red);
+/// assert_eq!(cell.bg, Color::White);
+///
 /// buf.get_mut(5, 0).set_char('x');
 /// assert_eq!(buf.get(5, 0).symbol(), "x");
 /// ```


### PR DESCRIPTION
I noticed one doc example still accessed `Cell::symbol` field deprecated at #624. `cargo test --doc` doesn't show any warnings. `cargo clippy` doesn't check doc examples. So I didn't notice it. This PR fixes the example.