### PR TITLE
chore: fix breaking changes doc versions

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -11,7 +11,8 @@ github with a [breaking change] label.
 This is a quick summary of the sections below:
 
 - Unreleased (0.24.1)
-  -
+  -`Table::widths()` now accepts `AsRef<[Constraint]>`
+  - Layout::new() now accepts direction and constraint parameters
 
 - [v0.24.0](#v0240)
   - MSRV is now 1.70.0
@@ -39,6 +40,8 @@ This is a quick summary of the sections below:
 
 ### `Table::widths()` now accepts `AsRef<[Constraint]>` ([#628])
 
+[#628]: https://github.com/ratatui-org/ratatui/pull/628
+
 Previously `Table::widths()` took a slice (`&'a [Constraint]`). This change will introduce clippy
 `needless_borrow` warnings for places where slices are passed to this method. To fix these, remove
 the `&`.
@@ -51,11 +54,7 @@ let table = Table::new(rows).widths(&[Constraint::Length(1)]);
 let table = Table::new(rows).widths([Constraint::Length(1)]);
 ```
 
-[#628]: https://github.com/ratatui-org/ratatui/pull/628
-
-## [v0.24.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.24.0)
-
-### Layout::new() now takes direction and constraint parameters ([#557])
+### Layout::new() now accepts direction and constraint parameters ([#557])
 
 [#557]: https://github.com/ratatui-org/ratatui/pull/557
 
@@ -73,6 +72,8 @@ let layout = layout::default()
 // or
 let layout = layout::new(Direction::Vertical, [Constraint::Min(1), Constraint::Max(2)]);
 ```
+
+## [v0.24.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.24.0)
 
 ### ScrollbarState field type changed from `u16` to `usize` ([#456])
 


### PR DESCRIPTION
Moves the layout::new change to unreleasedd section and adds the table change
