### PR TITLE
fix(block): make `inner` aware of title positions

### DIFF
--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -295,7 +295,7 @@ mod test {
         backend::TestBackend,
         style::{Color, Modifier, Stylize},
         text::{Line, Span},
-        widgets::Borders,
+        widgets::{block::Position, Borders},
         Terminal,
     };
 
@@ -475,6 +475,20 @@ mod test {
                 "│worlds!    │",
                 "└───────────┘",
             ]),
+        );
+    }
+
+    #[test]
+    fn test_render_paragraph_with_block_with_bottom_title_and_border() {
+        let block = Block::default()
+            .title("Title")
+            .title_position(Position::Bottom)
+            .borders(Borders::BOTTOM);
+        let paragraph = Paragraph::new("Hello, world!").block(block);
+
+        test_case(
+            &paragraph,
+            Buffer::with_lines(vec!["Hello, world!  ", "Title──────────"]),
         );
     }
 


### PR DESCRIPTION
Previously, when computing the inner rendering area of a block, all titles were assumed to be positioned at the top. If some or all titles were at the bottom, this caused various incorrect computations of the inner area, depending on which borders were set; no border at the bottom would lead to an area that's too big, no border at the top but at the bottom and _all_ titles at the bottom would lead to an area that's too small.

Now, when computing the inner area, the positions of the titles are taken into account.

fix #658