### PR TITLE
feat(table): Add a Table::segment_size method

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -182,7 +182,7 @@ pub enum Alignment {
     reason = "The name for this feature is not final and may change in the future",
     issue = "https://github.com/ratatui-org/ratatui/issues/536"
 )]
-#[derive(Debug, Default, Display, EnumString, Clone, Eq, PartialEq, Hash)]
+#[derive(Copy, Debug, Default, Display, EnumString, Clone, Eq, PartialEq, Hash)]
 pub enum SegmentSize {
     /// prefer equal chunks if other constraints are all satisfied
     EvenDistribution,


### PR DESCRIPTION
It works just like Layout::segment_size, but for Tables.  Previously, it was impossible to distribute extra space anywhere in a Table.

Fixes #370