### PR TITLE
feat(Paragraph): add `line_count` and `line_width` unstable helper methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,11 +93,17 @@ underline-color = ["dep:crossterm"]
 #! The following features are unstable and may change in the future:
 
 ## Enable all unstable features.
-unstable = ["unstable-segment-size"]
+unstable = ["unstable-segment-size", "unstable-rendered-line-info"]
 
 ## Enables the [`Layout::segment_size`](crate::layout::Layout::segment_size) method which is experimental and may change in the
 ## future. See [Issue #536](https://github.com/ratatui-org/ratatui/issues/536) for more details.
 unstable-segment-size = []
+
+## Enables the [`Paragraph::line_count`](crate::widgets::Paragraph::line_count)
+## [`Paragraph::line_width`](crate::widgets::Paragraph::line_width) methods
+## which are experimental and may change in the future.
+## See [Issue 293](https://github.com/ratatui-org/ratatui/issues/293) for more details.
+unstable-rendered-line-info = []
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This PR adds two methods to the `Paragraph` widget to help get information about the rendered paragraph. The first method, `Paragraph::line_count`, takes a bounding width and returns the number of lines necessary to display the full paragraph when rendered. My motivation for this method is to use it with scrollbars. If a paragraph has wrapped text, it is currently impossible to get the number of lines it will need.

The second method is a natural extension of this, `Paragraph::line_width`. This returns the smallest line width needed to fully display every line of a paragraph. This is simply the maximum line widths. Together, these two methods can be used to calculate the minimum bounding box for a paragraph.