### PR TITLE
feat(List)!: `new` now accepts `IntoIterator<Item = Into<ListItem>>`

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -11,8 +11,9 @@ github with a [breaking change] label.
 This is a quick summary of the sections below:
 
 - Unreleased (0.24.1)
+  - `List::new()` now accepts `IntoIterator<Item = Into<ListItem<'a>>>`
   - `Table::new()` now requires specifying the widths
-  -`Table::widths()` now accepts `IntoIterator<Item = AsRef<Constraint>>`
+  - `Table::widths()` now accepts `IntoIterator<Item = AsRef<Constraint>>`
   - Layout::new() now accepts direction and constraint parameters
   - The default `Tabs::highlight_style` is now `Style::new().reversed()`
 
@@ -40,6 +41,21 @@ This is a quick summary of the sections below:
 
 ## Unreleased (v0.24.1)
 
+### `List::new()` now accepts `IntoIterator<Item = Into<ListItem<'a>>>` ([#672])
+
+[#672]: https://github.com/ratatui-org/ratatui/pull/672
+
+Previously `List::new()` took `Into<Vec<ListItem<'a>>>`. This change will throw a compilation 
+error for `IntoIterator`s with an indeterminate item (e.g. empty vecs).
+
+E.g.
+
+```rust
+let list = List::new(vec![]);
+// becomes
+let list = List::default();
+```
+
 ### The default `Tabs::highlight_style` is now `Style::new().reversed()` ([#635])
 
 Previously the default highlight style for tabs was `Style::default()`, which meant that a `Tabs`
@@ -53,10 +69,12 @@ Previously the default highlight style for tabs was `Style::default()`, which me
 widget in the default configuration would not show any indication of the selected tab.
 
 
-### `Table::new()` now requires specifying the widths of the columrs (#664)
+### `Table::new()` now requires specifying the widths of the columns (#664)
+
+[#664]: https://github.com/ratatui-org/ratatui/pull/664
 
 Previously `Table`s could be constructed without widths. In almost all cases this is an error.
-A new widths parameter is now manadatory on `Table::new()`. Existing code of the form:
+A new widths parameter is now mandatory on `Table::new()`. Existing code of the form:
 
 ```rust
 Table::new(rows).widths(widths)

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -20,7 +20,7 @@ fn list_should_shows_the_length() {
     assert_eq!(list.len(), 3);
     assert!(!list.is_empty());
 
-    let empty_list = List::new(vec![]);
+    let empty_list = List::default();
     assert_eq!(empty_list.len(), 0);
     assert!(empty_list.is_empty());
 }


### PR DESCRIPTION
This allows to build list like

```rust
List::new(["Item 1", "Item 2"])
```

Fixes #670 

I think this should be added for 0.26 to not add too much breaking change for 0.25. Moreover there's another breaking change for list coming with #671. It makes sense to release them together.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
