### PR TITLE
refactor(List): `start_corner` is now `direction`

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -273,6 +273,6 @@ fn ui(f: &mut Frame, app: &mut App) {
         .collect();
     let events_list = List::new(events)
         .block(Block::default().borders(Borders::ALL).title("List"))
-        .start_corner(Corner::BottomLeft);
+        .direction(ListDirection::BottomToTop);
     f.render_widget(events_list, chunks[1]);
 }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -46,7 +46,7 @@ pub use self::{
     chart::{Axis, Chart, Dataset, GraphType},
     clear::Clear,
     gauge::{Gauge, LineGauge},
-    list::{List, ListItem, ListState},
+    list::{List, ListDirection, ListItem, ListState},
     paragraph::{Paragraph, Wrap},
     scrollbar::{ScrollDirection, Scrollbar, ScrollbarOrientation, ScrollbarState},
     sparkline::{RenderDirection, Sparkline},


### PR DESCRIPTION
The previous name `start_corner` did not communicate clearly what the function was doing. The method was renamed to `direction` and a new enum `ListDirection` was added.

Fixes #671 

Same as #672, I feel like this should be for 0.26.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
