### PR TITLE
fix(Rect): Fixed underflow in the `Rect.intersection` method

### DIFF
--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -155,8 +155,8 @@ impl Rect {
         Rect {
             x: x1,
             y: y1,
-            width: x2 - x1,
-            height: y2 - y1,
+            width: x2.saturating_sub(x1),
+            height: y2.saturating_sub(y1),
         }
     }
 


### PR DESCRIPTION
The `Rect.intersection` method contained the simple `-` operator, which panics on underflow.
This is strange, as all the other methods in `Rect` use `saturating_add` and `saturating_sub`.
So I changed the `-` operation to a `saturating_sub`, so that `Rect.intersection` never panics.
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
