### PR TITLE
docs(examples): Add example of half block rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,11 @@ required-features = ["crossterm"]
 doc-scrape-examples = true
 
 [[example]]
+name = "ratatui-logo"
+required-features = ["crossterm"]
+doc-scrape-examples = true
+
+[[example]]
 name = "scrollbar"
 required-features = ["crossterm"]
 doc-scrape-examples = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -223,6 +223,18 @@ cargo run --example=popup --features=crossterm
 
 ![Popup][popup.gif]
 
+## Ratatui-logo
+
+A fun example of using half blocks to render graphics Source:
+[ratatui-logo.rs](./ratatui-logo.rs).
+
+>
+```shell
+cargo run --example=ratatui-logo --features=crossterm
+```
+
+![Ratatui Logo][ratatui-logo.gif]
+
 ## Scrollbar
 
 Demonstrates the [`Scrollbar`](https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html)
@@ -309,6 +321,7 @@ examples/generate.bash
 [panic.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/panic.gif?raw=true
 [paragraph.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/paragraph.gif?raw=true
 [popup.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/popup.gif?raw=true
+[ratatui-logo.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/ratatui-logo.gif?raw=true
 [scrollbar.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/scrollbar.gif?raw=true
 [sparkline.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/sparkline.gif?raw=true
 [table.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/table.gif?raw=true

--- a/examples/ratatui-logo.rs
+++ b/examples/ratatui-logo.rs
@@ -53,7 +53,7 @@ fn main() -> io::Result<()> {
     })?;
     sleep(Duration::from_secs(5));
     restore()?;
-    println!("");
+    println!();
     Ok(())
 }
 

--- a/examples/ratatui-logo.rs
+++ b/examples/ratatui-logo.rs
@@ -4,17 +4,13 @@ use std::{
     time::Duration,
 };
 
-use crossterm::{
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    ExecutableCommand,
-};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use indoc::indoc;
 use itertools::izip;
 use ratatui::{prelude::*, widgets::*};
 
 /// A fun example of using half block characters to draw a logo
 fn main() -> io::Result<()> {
-    let mut terminal = init()?;
     let r = indoc! {"
             ▄▄▄
             █▄▄▀
@@ -45,6 +41,7 @@ fn main() -> io::Result<()> {
             █
         "}
     .lines();
+    let mut terminal = init()?;
     terminal.draw(|frame| {
         let logo = izip!(r, a.clone(), t.clone(), a, t, u, i)
             .map(|(r, a, t, a2, t2, u, i)| {
@@ -52,22 +49,23 @@ fn main() -> io::Result<()> {
             })
             .collect::<Vec<_>>()
             .join("\n");
-
         frame.render_widget(Paragraph::new(logo), frame.size());
     })?;
     sleep(Duration::from_secs(5));
     restore()?;
+    println!("");
     Ok(())
 }
 
 pub fn init() -> io::Result<Terminal<impl Backend>> {
-    stdout().execute(EnterAlternateScreen)?;
     enable_raw_mode()?;
-    Terminal::new(CrosstermBackend::new(stdout()))
+    let options = TerminalOptions {
+        viewport: Viewport::Inline(3),
+    };
+    Terminal::with_options(CrosstermBackend::new(stdout()), options)
 }
 
 pub fn restore() -> io::Result<()> {
-    stdout().execute(LeaveAlternateScreen)?;
     disable_raw_mode()?;
     Ok(())
 }

--- a/examples/ratatui-logo.rs
+++ b/examples/ratatui-logo.rs
@@ -1,0 +1,73 @@
+use std::{
+    io::{self, stdout},
+    thread::sleep,
+    time::Duration,
+};
+
+use crossterm::{
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use indoc::indoc;
+use itertools::izip;
+use ratatui::{prelude::*, widgets::*};
+
+/// A fun example of using half block characters to draw a logo
+fn main() -> io::Result<()> {
+    let mut terminal = init()?;
+    let r = indoc! {"
+            ▄▄▄
+            █▄▄▀
+            █  █
+        "}
+    .lines();
+    let a = indoc! {"
+             ▄▄
+            █▄▄█
+            █  █
+        "}
+    .lines();
+    let t = indoc! {"
+            ▄▄▄
+             █
+             █
+        "}
+    .lines();
+    let u = indoc! {"
+            ▄  ▄
+            █  █
+            ▀▄▄▀
+        "}
+    .lines();
+    let i = indoc! {"
+            ▄
+            █
+            █
+        "}
+    .lines();
+    terminal.draw(|frame| {
+        let logo = izip!(r, a.clone(), t.clone(), a, t, u, i)
+            .map(|(r, a, t, a2, t2, u, i)| {
+                format!("{:5}{:5}{:4}{:5}{:4}{:5}{:5}", r, a, t, a2, t2, u, i)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        frame.render_widget(Paragraph::new(logo), frame.size());
+    })?;
+    sleep(Duration::from_secs(5));
+    restore()?;
+    Ok(())
+}
+
+pub fn init() -> io::Result<Terminal<impl Backend>> {
+    stdout().execute(EnterAlternateScreen)?;
+    enable_raw_mode()?;
+    Terminal::new(CrosstermBackend::new(stdout()))
+}
+
+pub fn restore() -> io::Result<()> {
+    stdout().execute(LeaveAlternateScreen)?;
+    disable_raw_mode()?;
+    Ok(())
+}

--- a/examples/ratatui-logo.tape
+++ b/examples/ratatui-logo.tape
@@ -1,0 +1,12 @@
+# This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
+# To run this script, install vhs and run `vhs ./examples/popup.tape`
+Output "target/ratatui-logo.gif"
+Set Theme "Aardvark Blue"
+Set Width 550
+Set Height 220
+Hide
+Type "cargo run --example=ratatui-logo --features=crossterm"
+Enter
+Sleep 2s
+Show
+Sleep 2s


### PR DESCRIPTION
Just a fun example because the font I looked at as the "temporary" logo text seemed like it lends itself to an experiment.

![image](https://github.com/ratatui-org/ratatui/assets/381361/cf5ce309-ce2a-4103-aa83-1e1b374a346b)