### PR TITLE
docs(chart): document chart module

### DIFF
--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -398,12 +398,12 @@ pub mod braille {
 /// Marker to use when plotting data points
 #[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Marker {
-    /// One point per cell in shape of dot ("•")
+    /// One point per cell in shape of dot (`•`)
     #[default]
     Dot,
-    /// One point per cell in shape of a block ("█")
+    /// One point per cell in shape of a block (`█`)
     Block,
-    /// One point per cell in the shape of a bar ("▄")
+    /// One point per cell in the shape of a bar (`▄`)
     Bar,
     /// Use the [Unicode Braille Patterns](https://en.wikipedia.org/wiki/Braille_Patterns) block to
     /// represent data points.
@@ -412,9 +412,9 @@ pub enum Marker {
     ///
     /// Note: Support for this marker is limited to terminals and fonts that support Unicode
     /// Braille Patterns. If your terminal does not support this, you will see unicode replacement
-    /// characters (�) instead of Braille dots.
+    /// characters (`�`) instead of Braille dots (`⠓`, `⣇`, `⣿`).
     Braille,
-    /// Use the unicode block and half block characters ("█", "▄", and "▀") to represent points in
+    /// Use the unicode block and half block characters (`█`, `▄`, and `▀`) to represent points in
     /// a grid that is double the resolution of the terminal. Because each terminal cell is
     /// generally about twice as tall as it is wide, this allows for a square grid of pixels.
     HalfBlock,


### PR DESCRIPTION
This fixes #386 and completes the documentation for the widgets module apart from canvas.

<details><summary>doc screenshots</summary>
<p>

![image](https://github.com/ratatui-org/ratatui/assets/36198422/8eede95d-1d5b-4d18-b1f0-763a2f20025c)
![image](https://github.com/ratatui-org/ratatui/assets/36198422/388340a8-d525-4639-8218-52d7616398a9)
![image](https://github.com/ratatui-org/ratatui/assets/36198422/73ea9294-ddcc-4c6f-9b63-12a7276d68d9)
![image](https://github.com/ratatui-org/ratatui/assets/36198422/cc947613-640a-41b5-a420-dd01891ecb44)
![image](https://github.com/ratatui-org/ratatui/assets/36198422/3ee87981-5ad9-4291-945f-e2610c41941d)


</p>
</details> 