### PR TITLE
docs: remove deprecated table constructor from breaking changes

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -121,7 +121,7 @@ E.g.
 ```diff
 - let table = Table::new(rows).widths(&[Constraint::Length(1)]);
 // becomes
-+ let table = Table::new(rows).widths([Constraint::Length(1)]);
++ let table = Table::new(rows, [Constraint::Length(1)]);
 ```
 
 ### Layout::new() now accepts direction and constraint parameters ([#557])


### PR DESCRIPTION
We have 2 breaking changes that effects `Table` so I think we should recommend using the new constructor instead of the old one. 