### PR TITLE
feat(state): serialization, deserialization and rkyv support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ termion = { version = "2.0", optional = true }
 termwiz = { version = "0.20.0", optional = true }
 
 serde = { version = "1", optional = true, features = ["derive"] }
+rkyv = { version = "0.7.43", optional = true }
 bitflags = "2.3"
 cassowary = "0.3"
 indoc = "2.0"
@@ -71,9 +72,11 @@ termion = ["dep:termion"]
 termwiz = ["dep:termwiz"]
 
 #! The following optional features are available for all backends:
-## enables serialization and deserialization of state, style and color types using the
-## [Serde crate]. This is useful if you want to save themes or the current view to a file.
+## enables serialization and deserialization of style and color types using the [Serde crate].
+## This is useful if you want to save themes to a file.
 serde = ["dep:serde", "bitflags/serde"]
+## same as with the serde feature, except for the `rkyv` crate.
+rkyv = ["dep:rkyv"]
 
 ## enables the [`border!`] macro.
 macros = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ termion = ["dep:termion"]
 termwiz = ["dep:termwiz"]
 
 #! The following optional features are available for all backends:
-## enables serialization and deserialization of style and color types using the [Serde crate].
-## This is useful if you want to save themes to a file.
+## enables serialization and deserialization of state, style and color types using the
+## [Serde crate]. This is useful if you want to save themes or the current view to a file.
 serde = ["dep:serde", "bitflags/serde"]
 
 ## enables the [`border!`] macro.

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -14,6 +14,10 @@ pub use offset::*;
 /// area they are supposed to render to.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct Rect {
     /// The x coordinate of the top left corner of the rect.
     pub x: u16,

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -62,6 +62,10 @@ use std::{
 /// [ANSI color table]: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub enum Color {
     /// Resets the foreground or background color
     #[default]

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -48,6 +48,7 @@ use crate::{
 /// # }
 /// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListState {
     offset: usize,
     selected: Option<usize>,

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -49,6 +49,10 @@ use crate::{
 /// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct ListState {
     offset: usize,
     selected: Option<usize>,

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -44,6 +44,7 @@ pub enum ScrollDirection {
 /// If you don't have multi-line content, you can leave the `viewport_content_length` set to the
 /// default of 0 and it'll use the track size as a `viewport_content_length`.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollbarState {
     // The total length of the scrollable content.
     content_length: usize,

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -45,6 +45,10 @@ pub enum ScrollDirection {
 /// default of 0 and it'll use the track size as a `viewport_content_length`.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct ScrollbarState {
     // The total length of the scrollable content.
     content_length: usize,

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -369,6 +369,7 @@ pub enum HighlightSpacing {
 /// Note that if [`Table::widths`] is not called before rendering, the rendered columns will have
 /// equal width.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TableState {
     offset: usize,
     selected: Option<usize>,

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -370,6 +370,10 @@ pub enum HighlightSpacing {
 /// equal width.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct TableState {
     offset: usize,
     selected: Option<usize>,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

Adds `serde` for the state of stateful widgets as well, and introduces `rkyv` at every almost place where `serde` is found.

Closes https://github.com/ratatui-org/ratatui/issues/711.

**Note:** I did not test this one bit _yet_. I'm only putting it up to have it somewhere and to save someone else the effort.