### PR TITLE
feat(line): implement Widget for Line

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -45,8 +45,6 @@
 //! ]);
 //! ```
 
-use crate::style::Style;
-
 mod grapheme;
 pub use grapheme::StyledGrapheme;
 


### PR DESCRIPTION
This allows us to use Line as a child of other widgets, and to use
Line::render() to render it rather than calling buffer.set_line().

```rust
frame.render_widget(Line::raw("Hello, world!"), area);
// or
Line::raw("Hello, world!").render(frame, area);
```

---

Rebase and merge after #713 is merged