### PR TITLE
chore(ci): use cargo-nextest for running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: Install cargo-make
         uses: taiki-e/install-action@cargo-make
+      - name: Install cargo-make
+        uses: taiki-e/install-action@nextest
       - name: Test ${{ matrix.backend }}
         run: cargo make test-backend ${{ matrix.backend }}
         env:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -90,12 +90,17 @@ args = [
   "warnings",
 ]
 
+[tasks.install-nextest]
+description = "Install cargo-nextest"
+install_crate = { crate_name = "cargo-nextest", binary = "cargo-nextest", test_arg = "--help" }
+
 [tasks.test]
 description = "Run tests"
-dependencies = ["test-doc"]
+dependencies = ["test-doc", "install-nextest"]
 command = "cargo"
 args = [
-  "test",
+  "nextest",
+  "run",
   "--all-targets",
   "--no-default-features",
   "${ALL_FEATURES_FLAG}",
@@ -109,9 +114,11 @@ args = ["test", "--doc", "--no-default-features", "${ALL_FEATURES_FLAG}"]
 [tasks.test-backend]
 # takes a command line parameter to specify the backend to test (e.g. "crossterm")
 description = "Run backend-specific tests"
+dependencies = ["install-nextest"]
 command = "cargo"
 args = [
-  "test",
+  "nextest",
+  "run",
   "--all-targets",
   "--no-default-features",
   "--features",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -96,7 +96,11 @@ install_crate = { crate_name = "cargo-nextest", binary = "cargo-nextest", test_a
 
 [tasks.test]
 description = "Run tests"
-dependencies = ["test-doc", "install-nextest"]
+run_task = { name = ["test-lib", "test-doc"] }
+
+[tasks.test-lib]
+description = "Run default tests"
+dependencies = ["install-nextest"]
 command = "cargo"
 args = [
   "nextest",


### PR DESCRIPTION
Switch to [nextest](https://nexte.st/) for running tests.

Motivation:

- `cargo test`: 19.332s
- `cargo nextest run`: 0.981s

Please note:

- `cargo-nextest` does not support running doctests yet: https://github.com/nextest-rs/nextest/issues/16
- The `cargo-nextest` binary is installed automatically via `cargo-make`, see https://github.com/sagiegurari/cargo-make#crates
