### PR TITLE
feat(rkyv): add {de,}serialization support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ termion = { version = "2.0", optional = true }
 termwiz = { version = "0.20.0", optional = true }
 
 serde = { version = "1", optional = true, features = ["derive"] }
+rkyv = { version = "0.7", optional = true }
+
 bitflags = "2.3"
 cassowary = "0.3"
 indoc = "2.0"
@@ -75,6 +77,8 @@ termwiz = ["dep:termwiz"]
 ## enables serialization and deserialization of style and color types using the [Serde crate].
 ## This is useful if you want to save themes to a file.
 serde = ["dep:serde", "bitflags/serde"]
+## similar to the `serde` feature, but includes traits for the `rkyv` crate instead.
+rkyv = ["dep:rkyv"]
 
 ## enables the [`border!`] macro.
 macros = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ termion = { version = "2.0", optional = true }
 termwiz = { version = "0.20.0", optional = true }
 
 serde = { version = "1", optional = true, features = ["derive"] }
-rkyv = { version = "0.7", optional = true }
+rkyv = { version = "0.7", optional = true, features = ["validation"] }
 
 bitflags = "2.3"
 cassowary = "0.3"
@@ -274,5 +274,5 @@ required-features = ["crossterm"]
 doc-scrape-examples = true
 
 [[test]]
-name = "state_serde"
-required-features = ["serde"]
+name = "state_serialization"
+required-features = ["serde", "rkyv"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ fakeit = "1.1"
 palette = "0.7.3"
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
+serde_json = "1.0.109"
 
 [features]
 #! The crate provides a set of optional features that can be enabled in your `cargo.toml` file.
@@ -267,3 +268,7 @@ doc-scrape-examples = true
 name = "inline"
 required-features = ["crossterm"]
 doc-scrape-examples = true
+
+[[test]]
+name = "state_serde"
+required-features = ["serde"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,7 +5,7 @@ skip_core_tasks = true
 
 [env]
 # all features except the backend ones
-ALL_FEATURES = "all-widgets,macros,serde"
+ALL_FEATURES = "all-widgets,macros,rkyv,serde"
 
 # Windows does not support building termion, so this avoids the build failure by providing two
 # sets of flags, one for Windows and one for other platforms.

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -36,7 +36,8 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct TestBackend {
     width: u16,

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -34,6 +34,10 @@ use crate::{
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct TestBackend {
     width: u16,
     buffer: Buffer,

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -47,7 +47,8 @@ use crate::{buffer::Cell, prelude::*};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct Buffer {
     /// The area represented by this buffer

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -45,6 +45,10 @@ use crate::{buffer::Cell, prelude::*};
 /// ```
 #[derive(Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct Buffer {
     /// The area represented by this buffer
     pub area: Rect,

--- a/src/buffer/cell.rs
+++ b/src/buffer/cell.rs
@@ -7,7 +7,8 @@ use crate::prelude::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct Cell {
     #[deprecated(

--- a/src/buffer/cell.rs
+++ b/src/buffer/cell.rs
@@ -5,6 +5,10 @@ use crate::prelude::*;
 /// A buffer cell
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct Cell {
     #[deprecated(
         since = "0.24.1",

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -16,7 +16,8 @@ pub use offset::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct Rect {
     /// The x coordinate of the top left corner of the rect.

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -14,6 +14,10 @@ pub use offset::*;
 /// area they are supposed to render to.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct Rect {
     /// The x coordinate of the top left corner of the rect.
     pub x: u16,

--- a/src/style.rs
+++ b/src/style.rs
@@ -95,7 +95,8 @@ pub use color::Color;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct Modifier(u16); // separated struct is needed for a painless rkyv derive
 
@@ -248,7 +249,8 @@ impl fmt::Debug for Modifier {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct Style {
     pub fg: Option<Color>,

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -65,6 +65,10 @@ use std::{
 /// [ANSI color table]: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub enum Color {
     /// Resets the foreground or background color
     #[default]

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -67,7 +67,8 @@ use std::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub enum Color {
     /// Resets the foreground or background color

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -48,7 +48,8 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct ListState {
     offset: usize,

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -46,6 +46,10 @@ use crate::{
 /// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct ListState {
     offset: usize,
     selected: Option<usize>,

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -45,6 +45,7 @@ use crate::{
 /// # }
 /// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListState {
     offset: usize,
     selected: Option<usize>,

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -43,6 +43,10 @@ pub enum ScrollDirection {
 /// default of 0 and it'll use the track size as a `viewport_content_length`.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct ScrollbarState {
     // The total length of the scrollable content.
     content_length: usize,

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -42,6 +42,7 @@ pub enum ScrollDirection {
 /// If you don't have multi-line content, you can leave the `viewport_content_length` set to the
 /// default of 0 and it'll use the track size as a `viewport_content_length`.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollbarState {
     // The total length of the scrollable content.
     content_length: usize,

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -45,7 +45,8 @@ pub enum ScrollDirection {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct ScrollbarState {
     // The total length of the scrollable content.

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -48,7 +48,8 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
 )]
 pub struct TableState {
     pub(crate) offset: usize,

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -45,6 +45,7 @@
 /// [`Table::widths`]: crate::widgets::Table::widths
 /// [`Frame::render_stateful_widget`]: crate::Frame::render_stateful_widget
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TableState {
     pub(crate) offset: usize,
     pub(crate) selected: Option<usize>,

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -46,6 +46,10 @@
 /// [`Frame::render_stateful_widget`]: crate::Frame::render_stateful_widget
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct TableState {
     pub(crate) offset: usize,
     pub(crate) selected: Option<usize>,

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -1,0 +1,115 @@
+//! State like [`ListState`], [`TableState`] and [`ScrollbarState`] can be serialized and
+//! deserialized through serde. This allows saving your entire state to disk when the user exits the
+//! the app, and restore it again upon re-opening the app.
+//! This way, they get right back to where they were, without having to re-seek to their previous
+//! position, if that's applicable for the app at hand.
+//!
+//! **Note**: For this pattern to work easily, you need to have some toplevel struct which stores
+//! _only_ state and not any draw commands.
+//!
+//! **Note**: For many applications, it might be beneficial to instead keep your own state and
+//! instead construct the state for widgets on the fly instead, if that allows you to express you
+//! the semantic meaning of your state better or only fetch part of a dataset.
+
+use ratatui::{backend::TestBackend, prelude::*, widgets::*};
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn state_serde_roundtrip() {
+    // default unmodified case
+    test_case(
+        0,
+        Buffer::with_lines(vec![
+            "┌────────────────────────────┐",
+            "│awa                         │",
+            "│banana                      │",
+            "│Cats!!                      │",
+            "│d20                         │",
+            "│Echo                        │",
+            "│Foxtrot                     │",
+            "│Golf                        │",
+            "│Hotel                       │",
+            "└────────────────────────────┘",
+        ]),
+    );
+    // scrolled, but not cut off
+    test_case(
+        1,
+        Buffer::with_lines(vec![
+            "┌────────────────────────────┐",
+            "│banana                      │",
+            "│Cats!!                      │",
+            "│d20                         │",
+            "│Echo                        │",
+            "│Foxtrot                     │",
+            "│Golf                        │",
+            "│Hotel                       │",
+            "│IwI                         │",
+            "└────────────────────────────┘",
+        ]),
+    );
+    // scrolled and partly cut off
+    test_case(
+        4,
+        Buffer::with_lines(vec![
+            "┌────────────────────────────┐",
+            "│Echo                        │",
+            "│Foxtrot                     │",
+            "│Golf                        │",
+            "│Hotel                       │",
+            "│IwI                         │",
+            "│Juliett                     │",
+            "│                            │",
+            "│                            │",
+            "└────────────────────────────┘",
+        ]),
+    );
+}
+
+fn test_case(scroll: usize, expected: Buffer) {
+    // make sure the buffer is what we expect it to be
+    // then "forget" the original state
+    let serialized = {
+        let mut state = State {
+            list: ListState::default()
+                .with_offset(scroll)
+                .with_selected(Some(scroll)),
+        };
+
+        state.check(&expected);
+        serde_json::to_string_pretty(&state).unwrap()
+    };
+
+    // at this point nothing is carried over except for
+    // 1. the serialized state
+    // 2. the expected target buffer
+
+    // so reconstruct the state
+    let mut state: State = serde_json::from_str(&serialized).unwrap();
+    state.check(&expected)
+}
+
+#[derive(Serialize, Deserialize)]
+struct State {
+    list: ListState,
+}
+
+impl State {
+    fn check(&mut self, expected: &Buffer) {
+        // In an actual application, you'd want to create a backend once and store it somewhere
+        let backend = TestBackend::new(30, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|f| {
+                let list = List::new([
+                    "awa", "banana", "Cats!!", "d20", "Echo", "Foxtrot", "Golf", "Hotel", "IwI",
+                    "Juliett",
+                ])
+                .block(Block::default().borders(Borders::ALL));
+                f.render_stateful_widget(list, f.size(), &mut self.list);
+            })
+            .unwrap();
+        terminal.backend().assert_buffer(expected);
+    }
+}

--- a/tests/state_serialization.rs
+++ b/tests/state_serialization.rs
@@ -1,22 +1,46 @@
 //! State like [`ListState`], [`TableState`] and [`ScrollbarState`] can be serialized and
-//! deserialized through serde. This allows saving your entire state to disk when the user exits the
-//! the app, and restore it again upon re-opening the app.
-//! This way, they get right back to where they were, without having to re-seek to their previous
-//! position, if that's applicable for the app at hand.
+//! deserialized through the [`serde`] and [`rkyv`] crates.
 //!
-//! **Note**: For this pattern to work easily, you need to have some toplevel struct which stores
+//! This allows saving your entire state to disk when the user exits the app, and restore it again
+//! upon re-opening the app. This way, they get right back to where they were, without having to
+//! re-seek to their previous position, if that's applicable for the app at hand.
+//!
+//! It might also be useful to synchronize state with another machine, in which case you might want
+//! to look at [CRDT]s as implemented by for example the [`yrs`] or [`crdts`] crates though.
+//!
+//! **Note**: For serialization to work easily, you need to have some toplevel struct which stores
 //! _only_ state and not any draw commands.
 //!
 //! **Note**: For many applications, it might be beneficial to instead keep your own state and
 //! instead construct the state for widgets on the fly instead, if that allows you to express you
 //! the semantic meaning of your state better or only fetch part of a dataset.
+//!
+//! [`serde`]: https://crates.io/crates/serde
+//! [`rkyv`]: https://crates.io/crates/rkyv
+//! [CRDT]: https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type
+//! [`yrs`]: https://crates.io/crates/yrs
+//! [`crdts`]: https://crates.io/crates/crdts
 
 // not too happy about the redundancy in these tests,
 // but if that helps readability then it's ok i guess /shrug
 
+// regenerate the rkyv smoke refs in this with python, where `a` is the list emitted by the failure:
+// print(str(list(map(lambda x: hex(x), a))).replace("'", ""))
+
 use ratatui::{backend::TestBackend, prelude::*, widgets::*};
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+#[archive(check_bytes)]
 struct AppState {
     list_state: ListState,
     table_state: TableState,
@@ -32,11 +56,32 @@ impl Default for AppState {
         }
     }
 }
+
 impl AppState {
     fn select(&mut self, index: usize) {
         self.list_state.select(Some(index));
         self.table_state.select(Some(index));
         self.scrollbar_state = self.scrollbar_state.position(index);
+    }
+
+    #[track_caller]
+    fn serialize_serde(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap()
+    }
+
+    #[track_caller]
+    fn deserialize_serde(repr: &str) -> Self {
+        serde_json::from_str(repr).unwrap()
+    }
+
+    #[track_caller]
+    fn serialize_rkyv(&self) -> rkyv::util::AlignedVec {
+        rkyv::to_bytes::<_, 512>(self).unwrap()
+    }
+
+    #[track_caller]
+    fn deserialize_rkyv(repr: &[u8]) -> Self {
+        rkyv::from_bytes(repr).unwrap()
     }
 }
 
@@ -84,7 +129,7 @@ const DEFAULT_STATE_BUFFER: [&'static str; 5] = [
     "Echo     │Echo      ▼",
 ];
 
-const DEFAULT_STATE_REPR: &'static str = r#"{
+const DEFAULT_STATE_REPR_SERDE: &'static str = r#"{
   "list_state": {
     "offset": 0,
     "selected": null
@@ -99,6 +144,10 @@ const DEFAULT_STATE_REPR: &'static str = r#"{
     "viewport_content_length": 0
   }
 }"#;
+const DEFAULT_STATE_REPR_RKYV: [u8; 36] = [
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x0, 0x0, 0x0, 0x0, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+];
 
 #[test]
 fn default_state_serialize() {
@@ -107,14 +156,21 @@ fn default_state_serialize() {
     let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER.to_vec());
     assert_buffer(&mut state, &expected);
 
-    let state = serde_json::to_string_pretty(&state).unwrap();
-    assert_eq!(state, DEFAULT_STATE_REPR);
+    let ser_state = state.serialize_serde();
+    assert_eq!(ser_state, DEFAULT_STATE_REPR_SERDE);
+
+    let ser_state = state.serialize_rkyv();
+    assert_eq!(ser_state.into_vec(), DEFAULT_STATE_REPR_RKYV.to_vec());
 }
 
 #[test]
 fn default_state_deserialize() {
     let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER.to_vec());
-    let mut state: AppState = serde_json::from_str(DEFAULT_STATE_REPR).unwrap();
+
+    let mut state = AppState::deserialize_serde(DEFAULT_STATE_REPR_SERDE);
+    assert_buffer(&mut state, &expected);
+
+    let mut state = AppState::deserialize_rkyv(&DEFAULT_STATE_REPR_RKYV);
     assert_buffer(&mut state, &expected);
 }
 
@@ -125,7 +181,7 @@ const SELECTED_STATE_BUFFER: [&'static str; 5] = [
     "  d20    │  d20     ║",
     "  Echo   │  Echo    ▼",
 ];
-const SELECTED_STATE_REPR: &'static str = r#"{
+const SELECTED_STATE_REPR_SERDE: &'static str = r#"{
   "list_state": {
     "offset": 0,
     "selected": 1
@@ -140,6 +196,10 @@ const SELECTED_STATE_REPR: &'static str = r#"{
     "viewport_content_length": 0
   }
 }"#;
+const SELECTED_STATE_REPR_RKYV: [u8; 36] = [
+    0x1, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0,
+    0x0, 0x0, 0x0, 0x0, 0x0, 0xa, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+];
 
 #[test]
 fn selected_state_serialize() {
@@ -149,14 +209,26 @@ fn selected_state_serialize() {
     let expected = Buffer::with_lines(SELECTED_STATE_BUFFER.to_vec());
     assert_buffer(&mut state, &expected);
 
-    let state = serde_json::to_string_pretty(&state).unwrap();
-    assert_eq!(state, SELECTED_STATE_REPR);
+    let ser_state = state.serialize_serde();
+    assert_eq!(ser_state, SELECTED_STATE_REPR_SERDE);
+
+    let ser_state = state.serialize_rkyv();
+    assert_eq!(ser_state.into_vec(), SELECTED_STATE_REPR_RKYV.to_vec());
 }
 
 #[test]
 fn selected_state_deserialize() {
     let expected = Buffer::with_lines(SELECTED_STATE_BUFFER.to_vec());
-    let mut state: AppState = serde_json::from_str(SELECTED_STATE_REPR).unwrap();
+
+    let mut state = AppState::deserialize_serde(SELECTED_STATE_REPR_SERDE);
+    assert_buffer(&mut state, &expected);
+
+    // apparently something between rkyv/rustc is not playing well with const in this specific case
+    // causing the const to be misaligned
+    // but that doesn't happen if the variable is locally bound instead
+    // so work around that for now, until it's fixed in rkyv or the like
+    let repr = SELECTED_STATE_REPR_RKYV;
+    let mut state = AppState::deserialize_rkyv(&repr);
     assert_buffer(&mut state, &expected);
 }
 
@@ -168,7 +240,7 @@ const SCROLLED_STATE_BUFFER: [&'static str; 5] = [
     ">>IwI    │>>IwI     ▼",
 ];
 
-const SCROLLED_STATE_REPR: &'static str = r#"{
+const SCROLLED_STATE_REPR_SERDE: &'static str = r#"{
   "list_state": {
     "offset": 4,
     "selected": 8
@@ -183,6 +255,10 @@ const SCROLLED_STATE_REPR: &'static str = r#"{
     "viewport_content_length": 0
   }
 }"#;
+const SCROLLED_STATE_REPR_RKYV: [u8; 36] = [
+    0x1, 0x0, 0x0, 0x0, 0x8, 0x0, 0x0, 0x0, 0x4, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x8, 0x0, 0x0,
+    0x0, 0x4, 0x0, 0x0, 0x0, 0xa, 0x0, 0x0, 0x0, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+];
 
 #[test]
 fn scrolled_state_serialize() {
@@ -192,13 +268,20 @@ fn scrolled_state_serialize() {
     let expected = Buffer::with_lines(SCROLLED_STATE_BUFFER.to_vec());
     assert_buffer(&mut state, &expected);
 
-    let state = serde_json::to_string_pretty(&state).unwrap();
-    assert_eq!(state, SCROLLED_STATE_REPR);
+    let ser_state = state.serialize_serde();
+    assert_eq!(ser_state, SCROLLED_STATE_REPR_SERDE);
+
+    let ser_state = state.serialize_rkyv();
+    assert_eq!(ser_state.into_vec(), SCROLLED_STATE_REPR_RKYV.to_vec());
 }
 
 #[test]
 fn scrolled_state_deserialize() {
     let expected = Buffer::with_lines(SCROLLED_STATE_BUFFER.to_vec());
-    let mut state: AppState = serde_json::from_str(SCROLLED_STATE_REPR).unwrap();
+
+    let mut state = AppState::deserialize_serde(SCROLLED_STATE_REPR_SERDE);
+    assert_buffer(&mut state, &expected);
+
+    let mut state = AppState::deserialize_rkyv(&SCROLLED_STATE_REPR_RKYV);
     assert_buffer(&mut state, &expected);
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

Adds full-fledged support for the [`rkyv`](https://lib.rs/crates/rkyv) crate behind an optional feature. rkyv is basically "what if we'd take a structure out of memory and put it back again when we need it".

Extends the roundtrip test to be agnostic over the serialization strategy.

Depends on #723 and includes its changes, review that first. Supersedes #712 together with #723. Closes #711.