### PR TITLE
docs(example): fix markdown syntax for note

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -286,7 +286,8 @@ cargo run --example=tabs --features=crossterm
 
 Demonstrates one approach to accepting user input. Source [user_input.rs](./user_input.rs).
 
-> [!NOTE] Consider using [`tui-textarea`](https://crates.io/crates/tui-textarea) or
+> [!NOTE]
+> Consider using [`tui-textarea`](https://crates.io/crates/tui-textarea) or
 > [`tui-input`](https://crates.io/crates/tui-input) crates for more functional text entry UIs.
 
 ```shell


### PR DESCRIPTION
By adding a newline, the NOTE can be rendered as follows:

<img width="1062" alt="スクリーンショット 2024-01-03 9 00 42" src="https://github.com/ratatui-org/ratatui/assets/1457682/6180f6b0-9721-4be4-ae96-f0d2a80ea627">
