### PR TITLE
feat(block): add `Block::bordered`

### DIFF
--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -267,6 +267,13 @@ impl<'a> Block<'a> {
         }
     }
 
+    /// Create a new block with [all borders](Borders::ALL) shown
+    pub const fn bordered() -> Self {
+        let mut block = Block::new();
+        block.borders = Borders::ALL;
+        block
+    }
+
     /// Adds a title to the block.
     ///
     /// The `title` function allows you to add a title to the block. You can call this function
@@ -819,6 +826,12 @@ mod tests {
         layout::Rect,
         style::{Color, Modifier, Stylize},
     };
+
+    #[test]
+    fn create_with_all_borders() {
+        let block = Block::bordered();
+        assert_eq!(block.borders, Borders::all());
+    }
 
     #[test]
     fn inner_takes_into_account_the_borders() {


### PR DESCRIPTION
This avoid creating a block with no borders and then settings Borders::ALL. i.e.

```diff
- Block::default().borders(Borders::ALL);
+ Block::all_borders();
```

Searching on github, [1.3K use `.borders(Borders:ALL)`](https://github.com/search?q=ratatui+.borders%28Borders%3A%3AALL%29+lang%3Arust+NOT+repo%3Aratatui-org%2Fratatui&type=code) for a total of [1.5K `.borders(` usage](https://github.com/search?q=ratatui+.borders%28+lang%3Arust+NOT+repo%3Aratatui-org%2Fratatui&type=code).

Names I considered:

- `all`: too implicit, `Block::all()` in the wild isn't clear
- `with_borders`: would be confused with `with_borders(b: Borders)` i.e. with a parameter
- `with_all_borders`: the most explicit but too long imo
- `borders_all`: to match with `Borders::ALL` enum, nothing wrong with that, I just feel like `Block::all_borders` is easier to read and more natural