### PR TITLE
feat(layout): add `Rect::clamp()` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ unicode-width = "0.1"
 document-features = { version = "0.2.7", optional = true }
 lru = "0.12.0"
 stability = "0.1.1"
+rstest = "0.18.2"
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ unicode-width = "0.1"
 document-features = { version = "0.2.7", optional = true }
 lru = "0.12.0"
 stability = "0.1.1"
-rstest = "0.18.2"
 
 [dev-dependencies]
 anyhow = "1.0.71"
@@ -55,6 +54,7 @@ fakeit = "1.1"
 palette = "0.7.3"
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
+rstest = "0.18.2"
 
 [features]
 #! The crate provides a set of optional features that can be enabled in your `cargo.toml` file.

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -430,20 +430,20 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Rect::new(20, 20, 10, 10), Rect::new(20, 20, 10, 10), "inside")]
-    #[case(Rect::new(5, 5, 10, 10), Rect::new(10, 10, 10, 10), "up left")]
-    #[case(Rect::new(20, 5, 10, 10), Rect::new(20, 10, 10, 10), "up")]
-    #[case(Rect::new(105, 5, 10, 10), Rect::new(100, 10, 10, 10), "up right")]
-    #[case(Rect::new(5, 20, 10, 10), Rect::new(10, 20, 10, 10), "left")]
-    #[case(Rect::new(105, 20, 10, 10), Rect::new(100, 20, 10, 10), "right")]
-    #[case(Rect::new(5, 105, 10, 10), Rect::new(10, 100, 10, 10), "down left")]
-    #[case(Rect::new(20, 105, 10, 10), Rect::new(20, 100, 10, 10), "down")]
-    #[case(Rect::new(105, 105, 10, 10), Rect::new(100, 100, 10, 10), "down right")]
-    #[case(Rect::new(5, 20, 200, 10), Rect::new(10, 20, 100, 10), "too wide")]
-    #[case(Rect::new(20, 5, 10, 200), Rect::new(20, 10, 10, 100), "too tall")]
-    #[case(Rect::new(0, 0, 200, 200), Rect::new(10, 10, 100, 100), "too large")]
-    fn clamp(#[case] rect: Rect, #[case] expected: Rect, #[case] name: &str) {
+    #[case::inside(Rect::new(20, 20, 10, 10), Rect::new(20, 20, 10, 10))]
+    #[case::up_left(Rect::new(5, 5, 10, 10), Rect::new(10, 10, 10, 10))]
+    #[case::up(Rect::new(20, 5, 10, 10), Rect::new(20, 10, 10, 10))]
+    #[case::up_right(Rect::new(105, 5, 10, 10), Rect::new(100, 10, 10, 10))]
+    #[case::left(Rect::new(5, 20, 10, 10), Rect::new(10, 20, 10, 10))]
+    #[case::right(Rect::new(105, 20, 10, 10), Rect::new(100, 20, 10, 10))]
+    #[case::down_left(Rect::new(5, 105, 10, 10), Rect::new(10, 100, 10, 10))]
+    #[case::down(Rect::new(20, 105, 10, 10), Rect::new(20, 100, 10, 10))]
+    #[case::down_right(Rect::new(105, 105, 10, 10), Rect::new(100, 100, 10, 10))]
+    #[case::too_wide(Rect::new(5, 20, 200, 10), Rect::new(10, 20, 100, 10))]
+    #[case::too_tall(Rect::new(20, 5, 10, 200), Rect::new(20, 10, 10, 100))]
+    #[case::too_large(Rect::new(0, 0, 200, 200), Rect::new(10, 10, 100, 100))]
+    fn clamp(#[case] rect: Rect, #[case] expected: Rect) {
         let other = Rect::new(10, 10, 100, 100);
-        assert_eq!(rect.clamp(other), expected, "{}", name);
+        assert_eq!(rect.clamp(other), expected);
     }
 }

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -194,20 +194,20 @@ impl Rect {
             .expect("invalid number of rects")
     }
 
-    /// Clamp the rect to fit inside the given rect.
+    /// Clamp this rect to fit inside the other rect.
     ///
-    /// If the width or height of the rect is larger than the given rect, it will be clamped to
-    /// the given rect's width or height.
+    /// If the width or height of this rect is larger than the other rect, it will be clamped to the
+    /// other rect's width or height.
     ///
-    /// If the left or top coordinate is smaller than the given rect, it will be clamped to the
-    /// given rect's left or top coordinate.
+    /// If the left or top coordinate of this rect is smaller than the other rect, it will be
+    /// clamped to the other rect's left or top coordinate.
     ///
-    /// If the right or bottom coordinate is larger than the given rect, it will be clamped to the
-    /// given rect's right or bottom coordinate.
+    /// If the right or bottom coordinate of this rect is larger than the other rect, it will be
+    /// clamped to the other rect's right or bottom coordinate.
     ///
-    /// This is different from [`Rect::intersection`] because it will move the rect to fit inside
-    /// the given rect, while [`Rect::intersection`] will keep the rect's position and truncate
-    /// its size.
+    /// This is different from [`Rect::intersection`] because it will move this rect to fit inside
+    /// the other rect, while [`Rect::intersection`] instead would keep this rect's position and
+    /// truncate its size to only that which is inside the other rect.
     ///
     /// # Examples
     ///

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -229,6 +229,8 @@ impl Rect {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -427,67 +429,21 @@ mod tests {
         let [_a, _b, _c] = Rect::new(0, 0, 2, 1).split(&layout);
     }
 
-    #[test]
-    fn clamp() {
+    #[rstest]
+    #[case(Rect::new(20, 20, 10, 10), Rect::new(20, 20, 10, 10), "inside")]
+    #[case(Rect::new(5, 5, 10, 10), Rect::new(10, 10, 10, 10), "up left")]
+    #[case(Rect::new(20, 5, 10, 10), Rect::new(20, 10, 10, 10), "up")]
+    #[case(Rect::new(105, 5, 10, 10), Rect::new(100, 10, 10, 10), "up right")]
+    #[case(Rect::new(5, 20, 10, 10), Rect::new(10, 20, 10, 10), "left")]
+    #[case(Rect::new(105, 20, 10, 10), Rect::new(100, 20, 10, 10), "right")]
+    #[case(Rect::new(5, 105, 10, 10), Rect::new(10, 100, 10, 10), "down left")]
+    #[case(Rect::new(20, 105, 10, 10), Rect::new(20, 100, 10, 10), "down")]
+    #[case(Rect::new(105, 105, 10, 10), Rect::new(100, 100, 10, 10), "down right")]
+    #[case(Rect::new(5, 20, 200, 10), Rect::new(10, 20, 100, 10), "too wide")]
+    #[case(Rect::new(20, 5, 10, 200), Rect::new(20, 10, 10, 100), "too tall")]
+    #[case(Rect::new(0, 0, 200, 200), Rect::new(10, 10, 100, 100), "too large")]
+    fn clamp(#[case] rect: Rect, #[case] expected: Rect, #[case] name: &str) {
         let other = Rect::new(10, 10, 100, 100);
-
-        assert_eq!(
-            Rect::new(10, 10, 10, 10).clamp(other),
-            Rect::new(10, 10, 10, 10),
-            "inside"
-        );
-
-        assert_eq!(
-            Rect::new(5, 5, 10, 10).clamp(other),
-            Rect::new(10, 10, 10, 10),
-            "outside top left"
-        );
-        assert_eq!(
-            Rect::new(20, 5, 10, 10).clamp(other),
-            Rect::new(20, 10, 10, 10),
-            "outside top"
-        );
-        assert_eq!(
-            Rect::new(105, 5, 10, 10).clamp(other),
-            Rect::new(100, 10, 10, 10),
-            "outside top right"
-        );
-        assert_eq!(
-            Rect::new(5, 20, 10, 10).clamp(other),
-            Rect::new(10, 20, 10, 10),
-            "outside left"
-        );
-        assert_eq!(
-            Rect::new(105, 20, 10, 10).clamp(other),
-            Rect::new(100, 20, 10, 10),
-            "outside right"
-        );
-        assert_eq!(
-            Rect::new(5, 105, 10, 10).clamp(other),
-            Rect::new(10, 100, 10, 10),
-            "outside bottom left"
-        );
-        assert_eq!(
-            Rect::new(20, 105, 10, 10).clamp(other),
-            Rect::new(20, 100, 10, 10),
-            "outside bottom"
-        );
-        assert_eq!(
-            Rect::new(105, 105, 10, 10).clamp(other),
-            Rect::new(100, 100, 10, 10),
-            "outside bottom right"
-        );
-
-        assert_eq!(
-            Rect::new(5, 20, 200, 10).clamp(other),
-            Rect::new(10, 20, 100, 10),
-            "too wide"
-        );
-
-        assert_eq!(
-            Rect::new(20, 5, 10, 200).clamp(other),
-            Rect::new(20, 10, 10, 100),
-            "too tall"
-        );
+        assert_eq!(rect.clamp(other), expected, "{}", name);
     }
 }


### PR DESCRIPTION
This ensures a rectangle does not end up outside an area. This is useful
when you want to be able to dynamically move a rectangle around, but
keep it constrained to a certain area.

For example, this can be used to implement a draggable window that can
be moved around, but not outside the terminal window.

```rust
let window_area = Rect::new(state.x, state.y, 20, 20).clamp(area);
state.x = rect.x;
state.y = rect.y;
```