### PR TITLE
fix(chart): exclude unnamed datasets from legend

### DIFF
--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -196,7 +196,7 @@ fn render_chart1(f: &mut Frame, area: Rect, app: &App) {
 
 fn render_line_chart(f: &mut Frame, area: Rect) {
     let datasets = vec![Dataset::default()
-        .name("Line from only 2 points")
+        .name("Line from only 2 points".italic())
         .marker(symbols::Marker::Braille)
         .style(Style::default().fg(Color::Yellow))
         .graph_type(GraphType::Line)
@@ -241,7 +241,7 @@ fn render_scatter(f: &mut Frame, area: Rect) {
             .style(Style::new().yellow())
             .data(&HEAVY_PAYLOAD_DATA),
         Dataset::default()
-            .name("Medium")
+            .name("Medium".underlined())
             .marker(Marker::Braille)
             .graph_type(GraphType::Scatter)
             .style(Style::new().magenta())


### PR DESCRIPTION
Resubmission of #527 as the author seems to be inactive since 3 weeks and the PR is almost done.

@alemidev wrote:

> Currently, creating a `Dataset` to be used with the `Chart` widget will put an empty name by default. When not overriding it with the `.name()` builder method, it will still appear in the resulting chart legend as an empty space.
>
> In a project of mine I draw more specific reference grids as lines with no names, and the legend field either gets filled with empty spaces or not drawn at all due to its length.
>
> With this change, legend won't be drawn for datasets with no name.
>
> To make the name optional in the struct, I changed the `Cow<str>` into an `Option<Cow<str>>` and excluded datasets with empty names using `.filter_map()` in place of simple `.maps()` while iterating.
>
> To properly calculate legend length, getting `datasets.len()` is no longer sufficient and I iterate them one more time to count which ones have names. This looks cleaner and should have a negligible impact, but could be improved by counting them and finding the longest one in just one pass.

I incorporated the given feedback, using a `Line` instead of `Cow` to allow for styling legend.