### PR TITLE
refactor!: make `patch_style` & `reset_style` chainable

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -11,6 +11,7 @@ github with a [breaking change] label.
 This is a quick summary of the sections below:
 
 - [v0.26.0 (unreleased)](#v0260-unreleased)
+  - `patch_style` & `reset_style` now consume and return `Self`
   - Removed deprecated `Block::title_on_bottom`
   - `Line` now has an extra `style` field which applies the style to the entire line
   - `Block` style methods cannot be created in a const context
@@ -44,6 +45,23 @@ This is a quick summary of the sections below:
   - `List` no longer ignores empty strings
 
 ## v0.26.0 (unreleased)
+
+### `patch_style` & `reset_style` now consumes and returns `Self` ([#754])
+
+[#754]: https://github.com/ratatui-org/ratatui/pull/754
+
+Previously, `patch_style` and `reset_style` in `Text`, `Line` and `Span` were using a mutable
+reference to `Self`. To be more consistent with the rest of `ratatui`, which is using fluent
+setters, these now take ownership of `Self` and return it.
+
+The following example shows how to migrate for `Line`, but the same applies for `Text` and `Span`.
+
+```diff
+- let mut line = Line::from("foobar");
+- line.patch_style(style);
+// becomes
++ let line = Line::new("foobar").patch_style(style);
+```
 
 ### Remove deprecated `Block::title_on_bottom` ([#757])
 
@@ -81,7 +99,7 @@ the `Span::style` field.
   let line = Line {
       spans: vec!["".into()],
       alignment: Alignment::Left,
-+     ..Default::default()    
++     ..Default::default()
   };
 
   // or
@@ -99,7 +117,7 @@ the `Span::style` field.
 These items were deprecated since 0.10.
 
 - You should use styling capabilities of [`text::Line`] given as argument of [`Axis::title`]
-instead of `Axis::title_style`
+  instead of `Axis::title_style`
 - You should use styling capabilities of [`Buffer::set_style`] instead of `Buffer::set_background`
 
 [`text::Line`]: https://docs.rs/ratatui/latest/ratatui/text/struct.Line.html
@@ -289,7 +307,7 @@ new module locations. E.g.:
 ```diff
 - use ratatui::{widgets::scrollbar::{Scrollbar, Set}};
 // becomes
-+ use ratatui::{widgets::Scrollbar, symbols::scrollbar::Set} 
++ use ratatui::{widgets::Scrollbar, symbols::scrollbar::Set}
 ```
 
 ### MSRV updated to 1.67 ([#361])
@@ -310,7 +328,7 @@ changelog](https://github.com/bitflags/bitflags/blob/main/CHANGELOG.md#200-rc2).
 
 ## [v0.21.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.21.0)
 
-### MSRV is 1.65.0  ([#171])
+### MSRV is 1.65.0 ([#171])
 
 [#171]: https://github.com/ratatui-org/ratatui/issues/171
 
@@ -321,7 +339,7 @@ The minimum supported rust version is now 1.65.0.
 [#114]: https://github.com/ratatui-org/ratatui/issues/114
 
 In order to support inline viewports, the unstable method `Terminal::with_options()` was stabilized
-and  `ViewPort` was changed from a struct to an enum.
+and `ViewPort` was changed from a struct to an enum.
 
 ```diff
 let terminal = Terminal::with_options(backend, TerminalOptions {
@@ -338,7 +356,7 @@ let terminal = Terminal::with_options(backend, TerminalOptions {
 [#168]: https://github.com/ratatui-org/ratatui/issues/168
 
 A new type `Masked` was introduced that implements `From<Text<'a>>`. This causes any code that did
-previously did not need to use type annotations to fail to compile.  To fix this, annotate or call
+previously did not need to use type annotations to fail to compile. To fix this, annotate or call
 to_string() / to_owned() / as_str() on the value. E.g.:
 
 ```diff

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -201,8 +201,7 @@ fn ui(f: &mut Frame, app: &App) {
             Style::default(),
         ),
     };
-    let mut text = Text::from(Line::from(msg));
-    text.patch_style(style);
+    let text = Text::from(Line::from(msg)).patch_style(style);
     let help_message = Paragraph::new(text);
     f.render_widget(help_message, help_area);
 

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -193,32 +193,42 @@ impl<'a> Span<'a> {
     /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or
     /// your own type that implements [`Into<Style>`]).
     ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    ///
     /// # Example
     ///
     /// ```rust
     /// # use ratatui::prelude::*;
-    /// let mut span = Span::styled("test content", Style::new().green().italic());
-    /// span.patch_style(Style::new().red().on_yellow().bold());
+    /// let span = Span::styled("test content", Style::new().green().italic())
+    ///     .patch_style(Style::new().red().on_yellow().bold());
     /// assert_eq!(span.style, Style::new().red().on_yellow().italic().bold());
     /// ```
-    pub fn patch_style<S: Into<Style>>(&mut self, style: S) {
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn patch_style<S: Into<Style>>(mut self, style: S) -> Self {
         self.style = self.style.patch(style);
+        self
     }
 
     /// Resets the style of the Span.
     ///
     /// This is Equivalent to calling `patch_style(Style::reset())`.
     ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    ///
     /// # Example
     ///
     /// ```rust
     /// # use ratatui::prelude::*;
-    /// let mut span = Span::styled("Test Content", Style::new().green().on_yellow().italic());
-    /// span.reset_style();
+    /// let span = Span::styled(
+    ///     "Test Content",
+    ///     Style::new().dark_gray().on_yellow().italic(),
+    /// )
+    /// .reset_style();
     /// assert_eq!(span.style, Style::reset());
     /// ```
-    pub fn reset_style(&mut self) {
-        self.patch_style(Style::reset());
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn reset_style(self) -> Self {
+        self.patch_style(Style::reset())
     }
 
     /// Returns the unicode width of the content held by this span.
@@ -410,15 +420,14 @@ mod tests {
 
     #[test]
     fn reset_style() {
-        let mut span = Span::styled("test content", Style::new().green());
-        span.reset_style();
+        let span = Span::styled("test content", Style::new().green()).reset_style();
         assert_eq!(span.style, Style::reset());
     }
 
     #[test]
     fn patch_style() {
-        let mut span = Span::styled("test content", Style::new().green().on_yellow());
-        span.patch_style(Style::new().red().bold());
+        let span = Span::styled("test content", Style::new().green().on_yellow())
+            .patch_style(Style::new().red().bold());
         assert_eq!(span.style, Style::new().red().on_yellow().bold());
     }
 


### PR DESCRIPTION
Previously, `patch_style` and `reset_style` in `Text`, `Line` and `Span` were using a mutable reference to `Self`. To be more consistent with the rest of `ratatui`, which is using fluent setters, these now take ownership of `Self` and return it.

Closes #644

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
