### PR TITLE
refactor(block)!: remove deprecated `title_on_bottom`

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -11,6 +11,7 @@ github with a [breaking change] label.
 This is a quick summary of the sections below:
 
 - [v0.26.0 (unreleased)](#v0260-unreleased)
+  - Removed deprecated `Block::title_on_bottom`
   - `Line` now has an extra `style` field which applies the style to the entire line
   - `Block` style methods cannot be created in a const context
 - [v0.25.0](#v0250)
@@ -43,6 +44,17 @@ This is a quick summary of the sections below:
   - `List` no longer ignores empty strings
 
 ## v0.26.0 (unreleased)
+
+### Remove deprecated `Block::title_on_bottom` ([#757])
+
+[#757]: https://github.com/ratatui-org/ratatui/pull/757
+
+`Block::title_on_bottom` was deprecated in v0.22. Use `Block::title` and `Title::position` instead.
+
+```diff
+- block.title("foobar").title_on_bottom();
++ block.title(Title::from("foobar").position(Position::Bottom));
+```
 
 ### `Block` style methods cannot be used in a const context ([#720])
 

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -376,12 +376,6 @@ impl<'a> Block<'a> {
         self
     }
 
-    #[deprecated(since = "0.22.0", note = "You should use a `title_position` instead.")]
-    /// This method just calls `title_position` with Position::Bottom
-    pub fn title_on_bottom(self) -> Block<'a> {
-        self.title_position(Position::Bottom)
-    }
-
     /// Sets the default [`Position`] for all block [titles](Title).
     ///
     /// Titles that explicitly set a [`Position`] will ignore this.
@@ -1219,17 +1213,6 @@ mod tests {
                 .render(buffer.area, &mut buffer);
             assert_buffer_eq!(buffer, Buffer::with_lines(vec![expected]));
         }
-    }
-
-    #[test]
-    fn title_on_bottom() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 2));
-        #[allow(deprecated)]
-        Block::default()
-            .title("test")
-            .title_on_bottom()
-            .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["    ", "test"]));
     }
 
     #[test]


### PR DESCRIPTION
`Block::title_on_bottom` was deprecated in v0.22. Use `Block::title` and `Title::position` instead.

References #738