### PR TITLE
fix(cd): fix grepping the last release

### DIFF
--- a/.github/workflows/calculate-alpha-release.bash
+++ b/.github/workflows/calculate-alpha-release.bash
@@ -11,11 +11,11 @@ set -o pipefail
 # Turn on traces, useful while debugging but commented out by default
 # set -o xtrace
 
-last_release="$(git tag --sort=committerdate | grep -E "v0\.\d+\.\d+$" | tail -1)"
+last_release="$(git tag --sort=committerdate | grep -P "v0+\.\d+\.\d+$" | tail -1)"
 echo "🐭 Last release: ${last_release}"
 
 # detect breaking changes
-if git log --oneline ${last_release}..HEAD | grep -q '!:' || true; then
+if [ -n "$(git log --oneline ${last_release}..HEAD | grep '!:')" ]; then
     echo "🐭 Breaking changes detected since ${last_release}"
     git log --oneline ${last_release}..HEAD | grep '!:'
     # increment the minor version
@@ -33,7 +33,7 @@ echo "🐭 Next release: ${next_release}"
 
 suffix="alpha"
 last_tag="$(git tag --sort=committerdate | tail -1)"
-if [[ "${last_tag}" = "${next-release}-${suffix}"* ]]; then
+if [[ "${last_tag}" = "${next_release}-${suffix}"* ]]; then
     echo "🐭 Last alpha release: ${last_tag}"
     # increment the alpha version
     # e.g. v0.22.1-alpha.12 -> v0.22.1-alpha.13


### PR DESCRIPTION
The alpha deployment has been broken for 3 weeks, precisely since https://github.com/ratatui-org/ratatui/pull/495

(older first)
- https://github.com/ratatui-org/ratatui/actions/runs/7304892972/job/19907742693
- https://github.com/ratatui-org/ratatui/actions/runs/7360766607/job/20037290884
- https://github.com/ratatui-org/ratatui/actions/runs/7428042304/job/20214757237

There was no log but testing locally I figured grepping the last release wasn't working because of `\d` not working with `-E` flag.
I used perl compatible regular expression `-P`, we might also use `-E` together with `[0-9]` if we prefer.

Once this is merged I think it's worth manually triggering the workflow to have an alpha after 0.25 and see if everything works.

EDIT: I also fixed a typo in a variable name https://github.com/ratatui-org/ratatui/commit/edd83a4cccafa103216685f66ca1b1d23ef7ec8e
EDIT 2: fixed the condition that was checking for breaking change in https://github.com/ratatui-org/ratatui/commit/afe44f061e30a0691614474e89c6d971cf3e7fc7

---

<details><summary>Local tests</summary>
<p>

I added fake tags to verify it greps the last release.

![image](https://github.com/ratatui-org/ratatui/assets/36198422/397fadcb-e952-48b9-a95c-066562a537c4)
![image](https://github.com/ratatui-org/ratatui/assets/36198422/2dcec697-3da4-4d43-aace-5b9b5e52832d)
![image](https://github.com/ratatui-org/ratatui/assets/36198422/fd38167e-1079-462c-839f-50fed48a9f46)
![image](https://github.com/ratatui-org/ratatui/assets/36198422/539dd611-7172-4fdd-b6e2-18dc6ec0e01b)

With this we have all four variations of publishing an alpha release:
```sh
user@xubuntu:~/code/ratatui-org/ratatui$ .github/workflows/calculate-alpha-release.bash 
🐭 Last release: v0.25.0
🐭 Breaking changes detected since v0.25.0
bd6b91c refactor!: make `patch_style` & `reset_style` chainable (#754)
bc274e2 refactor(block)!: remove deprecated `title_on_bottom` (#757)
c977293 feat(line)!: add style field, setters and docs (#708)
🐭 Next release: v0.26.0
🐭 Next alpha release: v0.26.0-alpha.0

user@xubuntu:~/code/ratatui-org/ratatui$ git tag v0.26.0

user@xubuntu:~/code/ratatui-org/ratatui$ .github/workflows/calculate-alpha-release.bash 
🐭 Last release: v0.26.0
🐭 Next release: v0.26.1
🐭 Next alpha release: v0.26.1-alpha.0

user@xubuntu:~/code/ratatui-org/ratatui$ git commit -m "foo: bar" --allow-empty
[fix/cd-last-release 2524559] foo: bar

user@xubuntu:~/code/ratatui-org/ratatui$ git tag v0.26.1-alpha.0

user@xubuntu:~/code/ratatui-org/ratatui$ .github/workflows/calculate-alpha-release.bash 
🐭 Last release: v0.26.0
🐭 Next release: v0.26.1
🐭 Last alpha release: v0.26.1-alpha.0
🐭 Next alpha release: v0.26.1-alpha.1

user@xubuntu:~/code/ratatui-org/ratatui$ git commit -m 'foo!: breaking' --allow-empty
[fix/cd-last-release 371578f] foo!: breaking

user@xubuntu:~/code/ratatui-org/ratatui$ .github/workflows/calculate-alpha-release.bash 
🐭 Last release: v0.26.0
🐭 Breaking changes detected since v0.26.0
371578f foo!: breaking
🐭 Next release: v0.27.0
🐭 Next alpha release: v0.27.0-alpha.0

user@xubuntu:~/code/ratatui-org/ratatui$ git tag v0.27.0-alpha.0

user@xubuntu:~/code/ratatui-org/ratatui$ .github/workflows/calculate-alpha-release.bash 
🐭 Last release: v0.26.0
🐭 Breaking changes detected since v0.26.0
371578f foo!: breaking
🐭 Next release: v0.27.0
🐭 Last alpha release: v0.27.0-alpha.0
🐭 Next alpha release: v0.27.0-alpha.1
```

</p>
</details> 