### PR TITLE
chore(deps): update termion to v3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rust-version = "1.70.0"
 
 [dependencies]
 crossterm = { version = "0.27", optional = true }
-termion = { version = "2.0", optional = true }
+termion = { version = "3.0", optional = true }
 termwiz = { version = "0.20.0", optional = true }
 
 serde = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
This PR updates termion to its latest version. There is only one breaking change https://gitlab.redox-os.org/redox-os/termion#200-to-300-guide.

We don't really use this but our users do in when initializing the terminal. I'm not sure then if this is a breaking change. I'd say no because users can probably still specify termion 2 right?