### PR TITLE
chore: add comment on PRs with unsigned commits

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -44,6 +44,23 @@ jobs:
           header: pr-title-lint-error
           delete: true
 
+  check-signed:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Check commit signature and add comment if needed
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1
+        with:
+          comment: |
+            Thank you for opening this pull request!
+
+            We require commits to be signed and it looks like this PR contains unsigned commits.
+
+            Get help in the [CONTRIBUTING.md](https://github.com/ratatui-org/ratatui/blob/main/CONTRIBUTING.md#sign-your-commits)
+            or on [Github doc](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
   check-breaking-change-label:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
We sometimes forget to check for commit signature and are only reminded at the time of merging.
We also sometime forget to link to relevant documentation and whatnot.

This adds friction to new contributors and some redundant work for us.

I propose to use [this action](https://github.com/marketplace/actions/check-signed-commits-in-pr) to post a comment on PRs with unsigned commits. Contributors will be pinged when pushing even if no one is around and can work on that.

Let me know your thoughts and good resources to link in the comment.

~~I'll put an unsigned commit on this PR so we can see what it looks like (I'll rebase once this is approved).~~

Pipelines take the workflow from main so I guess we'll hope and see ...