### PR TITLE
fix: fix PR write permission to upload unsigned commit comment

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       # Check commit signature and add comment if needed
       - name: Check signed commits in PR


### PR DESCRIPTION
Follow up to https://github.com/ratatui-org/ratatui/pull/768

Checked here https://github.com/Valentin271/ratatui/pull/1

My guess is job-local permissions overwrite workflow permissions instead of merging. I couldn't find the official info in the doc.