### PR TITLE
feat(widgets): Collect iterator of `Row` into `Table`

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -16,6 +16,7 @@ This is a quick summary of the sections below:
   - `Line` now has an extra `style` field which applies the style to the entire line
   - `Block` style methods cannot be created in a const context
   - `Tabs::new()` now accepts `IntoIterator<Item: Into<Line<'a>>>`
+  - `Table::new` now accepts `IntoIterator<Item: Into<Row<'a>>>`.
 - [v0.25.0](#v0250)
   - Removed `Axis::title_style` and `Buffer::set_background`
   - `List::new()` now accepts `IntoIterator<Item = Into<ListItem<'a>>>`
@@ -47,20 +48,37 @@ This is a quick summary of the sections below:
 
 ## v0.26.0 (unreleased)
 
+### `Table::new()` now accepts `IntoIterator<Item: Into<Row<'a>>>` ([#774])
+
+[#774]: https://github.com/ratatui-org/ratatui/pull/774
+
+Previously, `Table::new()` accepted `IntoIterator<Item=Row<'a>>`.  The argument change to
+`IntoIterator<Item: Into<Row<'a>>>`, This allows more flexible types from calling scopes, though it
+can some break type inference in the calling scope for empty containers.
+
+This can be resolved either by providing an explicit type (e.g. `Vec::<Row>::new()`), or by using
+`Table::default()`.
+
+```diff
+- let table = Table::new(vec![], widths);
+// becomes
++ let table = Table::default().widths(widths);
+```
+
 ### `Tabs::new()` now accepts `IntoIterator<Item: Into<Line<'a>>>` ([#776])
 
 [#776]: https://github.com/ratatui-org/ratatui/pull/776
 
 Previously, `Tabs::new()` accepted `Vec<T>` where `T: Into<Line<'a>>`.  This allows more flexible
-types from calling scopes, though it can break type inference when the calling scope.
+types from calling scopes, though it can break some type inference in the calling scope.
 
 This typically occurs when collecting an iterator prior to calling `Tabs::new`, and can be resolved
 by removing the call to `.collect()`.
 
 ```diff
-- let table = Tabs::new((0.3).map(|i| format!("{i}")).collect());
+- let tabs = Tabs::new((0.3).map(|i| format!("{i}")).collect());
 // becomes
-+ let table = Tabs::new((0.3).map(|i| format!("{i}")));
++ let tabs = Tabs::new((0.3).map(|i| format!("{i}")));
 ```
 
 ### Table::default() now sets segment_size to None and column_spacing to ([#751])

--- a/examples/demo2/tabs/recipe.rs
+++ b/examples/demo2/tabs/recipe.rs
@@ -146,7 +146,7 @@ fn render_recipe(area: Rect, buf: &mut Buffer) {
 
 fn render_ingredients(selected_row: usize, area: Rect, buf: &mut Buffer) {
     let mut state = TableState::default().with_selected(Some(selected_row));
-    let rows = INGREDIENTS.iter().map(|&i| i.into()).collect_vec();
+    let rows = INGREDIENTS.iter().cloned();
     let theme = THEME.recipe;
     StatefulWidget::render(
         Table::new(rows, [Constraint::Length(7), Constraint::Length(30)])

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -849,7 +849,7 @@ fn widgets_table_should_render_even_if_empty() {
         .draw(|f| {
             let size = f.size();
             let table = Table::new(
-                vec![],
+                Vec::<Row>::new(),
                 [
                     Constraint::Length(6),
                     Constraint::Length(6),


### PR DESCRIPTION
A follow-up from https://github.com/ratatui-org/ratatui/pull/755, allowing any iterator whose item is convertible into `Row` to be collected into a `Table`.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
