### PR TITLE
feat(widgets): Collect iterator of `ListItem` into `List`

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -399,6 +399,16 @@ where
 ///
 /// frame.render_stateful_widget(list, area, &mut state);
 /// # }
+/// ```
+///
+/// In addition to `List::new`, any iterator whose element is convertible to `ListItem` can be
+/// collected into `List`.
+///
+/// ```
+/// use ratatui::widgets::List;
+///
+/// (0..5).map(|i| format!("Item{i}")).collect::<List>();
+/// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct List<'a> {
     block: Option<Block<'a>>,
@@ -877,6 +887,15 @@ impl<'a> Styled for ListItem<'a> {
     }
 }
 
+impl<'a, Item> FromIterator<Item> for List<'a>
+where
+    Item: Into<ListItem<'a>>,
+{
+    fn from_iter<Iter: IntoIterator<Item = Item>>(iter: Iter) -> Self {
+        List::new(iter)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
@@ -1325,6 +1344,13 @@ mod tests {
             "└────────┘",
         ]);
         assert_buffer_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn test_collect_list_from_iterator() {
+        let collected: List = (0..3).map(|i| format!("Item{i}")).collect();
+        let expected = List::new(["Item0", "Item1", "Item2"]);
+        assert_eq!(collected, expected);
     }
 
     #[test]


### PR DESCRIPTION
A follow-up from https://github.com/ratatui-org/ratatui/pull/755, allowing any iterator whose item is convertible into `ListItem` to be collected into a `List`.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
