### PR TITLE
feat(table): accept Text for highlight_symbol

### DIFF
--- a/examples/table.tape
+++ b/examples/table.tape
@@ -3,14 +3,17 @@
 Output "target/table.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200
-Set Height 600
+Set Height 800
 Hide
 Type "cargo run --example=table --features=crossterm"
 Enter
 Sleep 1s
 Show
-Down@1s 4
-Up@1s 2
-Down@1s 8
-Up@1s 12
-Sleep 5s
+Sleep 2s
+Set TypingSpeed 0.5s
+Down 2
+Up 2
+Down 8
+Up 12
+Down 4
+Sleep 2s


### PR DESCRIPTION
This allows for multi-line symbols to be used as the highlight symbol.

```rust
let table = Table::new(rows, widths)
    .highlight_symbol(Text::from(vec![
        "".into(),
        " █ ".into(),
        " █ ".into(),
        "".into(),
    ]));
```

  ![Made with VHS](https://vhs.charm.sh/vhs-6z75EkofPu13czwIq1ZhYw.gif)
