### PR TITLE
feat(tabs): add a function that returns the current tab

### DIFF
--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -112,6 +112,11 @@ impl<'a> Tabs<'a> {
         self
     }
 
+    /// Returns the current selected tab
+    pub fn selected(self) -> usize {
+        self.selected
+    }
+
     /// Sets the style of the tabs.
     ///
     /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or


### PR DESCRIPTION
### Problem

It was not possible to get the current selected tab

