### PR TITLE
feat: Add `Constraint::Fixed(x)` and `Constraint::Proportional(x)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,11 @@ required-features = ["crossterm"]
 doc-scrape-examples = true
 
 [[example]]
+name = "constraints"
+required-features = ["crossterm"]
+doc-scrape-examples = false
+
+[[example]]
 name = "list"
 required-features = ["crossterm"]
 doc-scrape-examples = true

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -1,0 +1,495 @@
+use std::{error::Error, io};
+
+use crossterm::{
+    event::{self, Event, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use itertools::Itertools;
+use ratatui::{layout::Constraint::*, prelude::*, widgets::*};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // create app and run it
+    let res = run_app(&mut terminal);
+
+    // restore terminal
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    if let Err(err) = res {
+        println!("{err:?}");
+    }
+
+    Ok(())
+}
+
+fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> io::Result<()> {
+    let mut selection = ExampleSelection::Fixed;
+    loop {
+        terminal.draw(|f| f.render_widget(selection, f.size()))?;
+
+        if let Event::Key(key) = event::read()? {
+            use KeyCode::*;
+            match key.code {
+                Char('q') => break Ok(()),
+                Char('j') | Char('l') | Down | Right => {
+                    selection = selection.next();
+                }
+                Char('k') | Char('h') | Up | Left => {
+                    selection = selection.previous();
+                }
+                _ => (),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum ExampleSelection {
+    Fixed,
+    Length,
+    Percentage,
+    Ratio,
+    Proportional,
+    Min,
+    Max,
+}
+
+impl ExampleSelection {
+    fn previous(&self) -> Self {
+        use ExampleSelection::*;
+        match *self {
+            Fixed => Fixed,
+            Length => Fixed,
+            Percentage => Length,
+            Ratio => Percentage,
+            Proportional => Ratio,
+            Min => Proportional,
+            Max => Min,
+        }
+    }
+
+    fn next(&self) -> Self {
+        use ExampleSelection::*;
+        match *self {
+            Fixed => Length,
+            Length => Percentage,
+            Percentage => Ratio,
+            Ratio => Proportional,
+            Proportional => Min,
+            Min => Max,
+            Max => Max,
+        }
+    }
+
+    fn selected(&self) -> usize {
+        use ExampleSelection::*;
+        match self {
+            Fixed => 0,
+            Length => 1,
+            Percentage => 2,
+            Ratio => 3,
+            Proportional => 4,
+            Min => 5,
+            Max => 6,
+        }
+    }
+}
+
+impl Widget for ExampleSelection {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let [tabs, area] = area.split(&Layout::vertical([Fixed(3), Proportional(0)]));
+        let [area, _] = area.split(&Layout::horizontal([Fixed(80), Proportional(0)]));
+
+        self.render_tabs(tabs, buf);
+
+        match self {
+            ExampleSelection::Fixed => self.render_fixed_example(area, buf),
+            ExampleSelection::Length => self.render_length_example(area, buf),
+            ExampleSelection::Percentage => self.render_percentage_example(area, buf),
+            ExampleSelection::Ratio => self.render_ratio_example(area, buf),
+            ExampleSelection::Proportional => self.render_proportional_example(area, buf),
+            ExampleSelection::Min => self.render_min_example(area, buf),
+            ExampleSelection::Max => self.render_max_example(area, buf),
+        }
+    }
+}
+
+impl ExampleSelection {
+    fn render_tabs(&self, area: Rect, buf: &mut Buffer) {
+        // ┌Constraints───────────────────────────────────────────────────────────────────┐
+        // │  Fixed  │  Length  │  Percentage  │  Ratio  │  Proportional  │  Min  │  Max  │
+        // └──────────────────────────────────────────────────────────────────────────────┘
+        Tabs::new(
+            [
+                ExampleSelection::Fixed,
+                ExampleSelection::Length,
+                ExampleSelection::Percentage,
+                ExampleSelection::Ratio,
+                ExampleSelection::Proportional,
+                ExampleSelection::Min,
+                ExampleSelection::Max,
+            ]
+            .iter()
+            .map(|e| format!("{:?}", e)),
+        )
+        .block(Block::bordered().title("Constraints"))
+        .highlight_style(Style::default().yellow())
+        .select(self.selected())
+        .padding("  ", "  ")
+        .render(area, buf);
+    }
+
+    fn render_fixed_example(&self, area: Rect, buf: &mut Buffer) {
+        let [example1, example2, _] = area.split(&Layout::vertical([Fixed(8); 3]));
+
+        // Fixed(40), Proportional(0)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌──────────────────────────────────────┐┌────────┐
+        // │                 40 px                ││  10 px │
+        // └──────────────────────────────────────┘└────────┘
+        Example::new([Fixed(40), Proportional(0)]).render(example1, buf);
+
+        // Fixed(20), Fixed(20), Proportional(0)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌──────────────────┐┌──────────────────┐┌────────┐
+        // │       20 px      ││       20 px      ││  10 px │
+        // └──────────────────┘└──────────────────┘└────────┘
+        Example::new([Fixed(20), Fixed(20), Proportional(0)]).render(example2, buf);
+    }
+
+    fn render_length_example(&self, area: Rect, buf: &mut Buffer) {
+        let [example1, example2, example3, example4, _] =
+            area.split(&Layout::vertical([Fixed(8); 5]));
+
+        // Length(20), Fixed(20)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────┐┌──────────────────┐
+        // │            30 px           ││       20 px      │
+        // └────────────────────────────┘└──────────────────┘
+        Example::new([Length(20), Fixed(20)]).render(example1, buf);
+
+        // Length(20), Length(20)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌──────────────────┐┌────────────────────────────┐
+        // │       20 px      ││            30 px           │
+        // └──────────────────┘└────────────────────────────┘
+        Example::new([Length(20), Length(20)]).render(example2, buf);
+
+        // Length(20), Min(20)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌──────────────────┐┌────────────────────────────┐
+        // │       20 px      ││            30 px           │
+        // └──────────────────┘└────────────────────────────┘
+        Example::new([Length(20), Min(20)]).render(example3, buf);
+
+        // Length(20), Max(20)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────┐┌──────────────────┐
+        // │            30 px           ││       20 px      │
+        // └────────────────────────────┘└──────────────────┘
+        Example::new([Length(20), Max(20)]).render(example4, buf);
+    }
+
+    fn render_percentage_example(&self, area: Rect, buf: &mut Buffer) {
+        let [example1, example2, example3, example4, example5, _] =
+            area.split(&Layout::vertical([Fixed(8); 6]));
+
+        // Percentage(75), Proportional(0)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        //
+        Example::new([Percentage(75), Proportional(0)]).render(example1, buf);
+
+        // Percentage(25), Proportional(0)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(25), Proportional(0)]).render(example2, buf);
+
+        // Percentage(50), Min(20)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌───────────────────────┐┌───────────────────────┐
+        // │         25 px         ││         25 px         │
+        // └───────────────────────┘└───────────────────────┘
+        Example::new([Percentage(50), Min(20)]).render(example3, buf);
+
+        // Percentage(0), Max(0)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(0), Max(0)]).render(example4, buf);
+
+        // Percentage(0), Proportional(0)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(0), Proportional(0)]).render(example5, buf);
+    }
+
+    fn render_ratio_example(&self, area: Rect, buf: &mut Buffer) {
+        let [example1, example2, example3, example4, _] =
+            area.split(&Layout::vertical([Fixed(8); 5]));
+
+        // Ratio(1, 2), Ratio(1, 2)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌───────────────────────┐┌───────────────────────┐
+        // │         25 px         ││         25 px         │
+        // └───────────────────────┘└───────────────────────┘
+        Example::new([Ratio(1, 2); 2]).render(example1, buf);
+
+        // Ratio(1, 4), Ratio(1, 4), Ratio(1, 4), Ratio(1, 4)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌───────────┐┌──────────┐┌───────────┐┌──────────┐
+        // │   13 px   ││   12 px  ││   13 px   ││   12 px  │
+        // └───────────┘└──────────┘└───────────┘└──────────┘
+        Example::new([Ratio(1, 4); 4]).render(example2, buf);
+
+        // Ratio(1, 2), Ratio(1, 3), Ratio(1, 4)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌───────────────────────┐┌───────────────┐┌──────┐
+        // │         25 px         ││     17 px     ││ 8 px │
+        // └───────────────────────┘└───────────────┘└──────┘
+        Example::new([Ratio(1, 2), Ratio(1, 3), Ratio(1, 4)]).render(example3, buf);
+
+        // Ratio(1, 2), Percentage(25), Length(10)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌───────────────────────┐┌───────────┐┌──────────┐
+        // │         25 px         ││   13 px   ││   12 px  │
+        // └───────────────────────┘└───────────┘└──────────┘
+        Example::new([Ratio(1, 2), Percentage(25), Length(10)]).render(example4, buf);
+    }
+
+    fn render_proportional_example(&self, area: Rect, buf: &mut Buffer) {
+        let [example1, example2, _] = area.split(&Layout::vertical([Fixed(8); 3]));
+
+        // Proportional(1), Proportional(2), Proportional(3)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌──────┐┌───────────────┐┌───────────────────────┐
+        // │ 8 px ││     17 px     ││         25 px         │
+        // └──────┘└───────────────┘└───────────────────────┘
+        Example::new([Proportional(1), Proportional(2), Proportional(3)]).render(example1, buf);
+
+        // Proportional(1), Percentage(50), Proportional(1)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌───────────┐┌───────────────────────┐┌──────────┐
+        // │   13 px   ││         25 px         ││   12 px  │
+        // └───────────┘└───────────────────────┘└──────────┘
+        Example::new([Proportional(1), Percentage(50), Proportional(1)]).render(example2, buf);
+    }
+
+    fn render_min_example(&self, area: Rect, buf: &mut Buffer) {
+        let [example1, example2, example3, example4, example5, _] =
+            area.split(&Layout::vertical([Fixed(8); 6]));
+        // Percentage(100), Min(0)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(100), Min(0)]).render(example1, buf);
+
+        // Percentage(100), Min(20)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────┐┌──────────────────┐
+        // │            30 px           ││       20 px      │
+        // └────────────────────────────┘└──────────────────┘
+        Example::new([Percentage(100), Min(20)]).render(example2, buf);
+
+        // Percentage(100), Min(40)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────┐┌──────────────────────────────────────┐
+        // │  10 px ││                 40 px                │
+        // └────────┘└──────────────────────────────────────┘
+        Example::new([Percentage(100), Min(40)]).render(example3, buf);
+
+        // Percentage(100), Min(60)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(100), Min(60)]).render(example4, buf);
+
+        // Percentage(100), Min(80)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(100), Min(80)]).render(example5, buf);
+    }
+
+    fn render_max_example(&self, area: Rect, buf: &mut Buffer) {
+        let [example1, example2, example3, example4, example5, _] =
+            area.split(&Layout::vertical([Fixed(8); 6]));
+
+        // Percentage(0), Max(0)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(0), Max(0)]).render(example1, buf);
+
+        //
+        // Percentage(0), Max(20)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────┐┌──────────────────┐
+        // │            30 px           ││       20 px      │
+        // └────────────────────────────┘└──────────────────┘
+        Example::new([Percentage(0), Max(20)]).render(example2, buf);
+
+        // Percentage(0), Max(40)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────┐┌──────────────────────────────────────┐
+        // │  10 px ││                 40 px                │
+        // └────────┘└──────────────────────────────────────┘
+        Example::new([Percentage(0), Max(40)]).render(example3, buf);
+
+        // Percentage(0), Max(60)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(0), Max(60)]).render(example4, buf);
+
+        // Percentage(0), Max(80)
+        //
+        // <---------------------50 px---------------------->
+        //
+        // ┌────────────────────────────────────────────────┐
+        // │                      50 px                     │
+        // └────────────────────────────────────────────────┘
+        Example::new([Percentage(0), Max(80)]).render(example5, buf);
+    }
+}
+
+struct Example {
+    constraints: Vec<Constraint>,
+}
+
+impl Example {
+    fn new<C>(constraints: C) -> Self
+    where
+        C: Into<Vec<Constraint>>,
+    {
+        Self {
+            constraints: constraints.into(),
+        }
+    }
+}
+
+impl Widget for Example {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let [title, legend, area] = area.split(&Layout::vertical([Ratio(1, 3); 3]));
+        let blocks = Layout::horizontal(&self.constraints).split(area);
+
+        self.heading().render(title, buf);
+
+        self.legend(legend.width as usize).render(legend, buf);
+
+        for (i, block) in blocks.iter().enumerate() {
+            let text = format!("{} px", block.width);
+            let fg = Color::Indexed(i as u8 + 1);
+            self.illustration(text, fg).render(*block, buf);
+        }
+    }
+}
+
+impl Example {
+    fn heading(&self) -> Paragraph {
+        // Renders the following
+        //
+        // Fixed(40), Proportional(0)
+        let spans = self.constraints.iter().enumerate().map(|(i, c)| {
+            let color = Color::Indexed(i as u8 + 1);
+            Span::styled(format!("{:?}", c), color)
+        });
+        let heading =
+            Line::from(Itertools::intersperse(spans, Span::raw(", ")).collect::<Vec<Span>>());
+        Paragraph::new(heading).block(Block::default().padding(Padding::vertical(1)))
+    }
+
+    fn legend(&self, width: usize) -> Paragraph {
+        // a bar like `<----- 80 px ----->`
+        let width_label = format!("{} px", width);
+        let width_bar = format!(
+            "<{width_label:-^width$}>",
+            width = width - width_label.len() / 2
+        );
+        Paragraph::new(width_bar.dark_gray()).alignment(Alignment::Center)
+    }
+
+    fn illustration(&self, text: String, fg: Color) -> Paragraph {
+        // Renders the following
+        //
+        // ┌─────────┐┌─────────┐
+        // │  40 px  ││  40 px  │
+        // └─────────┘└─────────┘
+        Paragraph::new(text)
+            .alignment(Alignment::Center)
+            .block(Block::bordered().style(Style::default().fg(fg)))
+    }
+}

--- a/examples/constraints.tape
+++ b/examples/constraints.tape
@@ -1,0 +1,14 @@
+# This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
+# To run this script, install vhs and run `vhs ./examples/constraints.tape`
+Output "target/constraints.gif"
+Set Theme "Aardvark Blue"
+Set FontSize 18
+Set Width 1200
+Set Height 1200
+Hide
+Type "cargo run --example=constraints --features=crossterm"
+Enter
+Sleep 2s
+Show
+Sleep 5s
+Right @5s 7

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -203,6 +203,8 @@ fn constraint_label(constraint: Constraint) -> String {
         Min(n) => format!("{n}"),
         Max(n) => format!("{n}"),
         Percentage(n) => format!("{n}"),
+        Proportional(n) => format!("{n}"),
+        Fixed(n) => format!("{n}"),
         Ratio(a, b) => format!("{a}:{b}"),
     }
 }

--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -457,17 +457,11 @@ impl Layout {
         // apply the constraints
         for (&constraint, &element) in layout.constraints.iter().zip(elements.iter()) {
             match constraint {
-                Constraint::Percentage(p) => {
-                    let percent = f64::from(p) / 100.00;
-                    solver.add_constraint(element.size() | EQ(STRONG) | (area_size * percent))?;
-                }
-                Constraint::Ratio(n, d) => {
-                    // avoid division by zero by using 1 when denominator is 0
-                    let ratio = f64::from(n) / f64::from(d.max(1));
-                    solver.add_constraint(element.size() | EQ(STRONG) | (area_size * ratio))?;
-                }
-                Constraint::Length(l) => {
-                    solver.add_constraint(element.size() | EQ(STRONG) | f64::from(l))?
+                Constraint::Fixed(l) => {
+                    // when fixed is used, element size matching value provided will be the first
+                    // priority. We use `REQUIRED - 1` instead `REQUIRED` because we don't want
+                    // it to panic in cases when it cannot.
+                    solver.add_constraint(element.size() | EQ(REQUIRED - 1.0) | f64::from(l))?
                 }
                 Constraint::Max(m) => {
                     solver.add_constraints(&[
@@ -481,6 +475,83 @@ impl Layout {
                         element.size() | EQ(MEDIUM) | f64::from(m),
                     ])?;
                 }
+                Constraint::Length(l) => {
+                    solver.add_constraint(element.size() | EQ(STRONG) | f64::from(l))?
+                }
+                Constraint::Percentage(p) => {
+                    let percent = f64::from(p) / 100.00;
+                    solver.add_constraint(element.size() | EQ(STRONG) | (area_size * percent))?;
+                }
+                Constraint::Ratio(n, d) => {
+                    // avoid division by zero by using 1 when denominator is 0
+                    let ratio = f64::from(n) / f64::from(d.max(1));
+                    solver.add_constraint(element.size() | EQ(STRONG) | (area_size * ratio))?;
+                }
+                Constraint::Proportional(_) => {
+                    // given no other constraints, this segment will grow as much as possible.
+                    //
+                    // in the current implementation, this constraint will not have any effect
+                    // since in every combination of constraints, other constraints governing
+                    // element size will take a higher priority.
+                    //
+                    // this constraint is placed here only for future proofing.
+                    solver.add_constraint(element.size() | EQ(WEAK) | area_size)?;
+                }
+            }
+        }
+        // Make every `Proportional` constraint proportionally equal to each other
+        // This will make it fill up empty spaces equally
+        //
+        // [Proportional(1), Proportional(1)]
+        // ┌──────┐┌──────┐
+        // │abcdef││abcdef│
+        // └──────┘└──────┘
+        //
+        // [Proportional(1), Proportional(2)]
+        // ┌──────┐┌────────────┐
+        // │abcdef││abcdefabcdef│
+        // └──────┘└────────────┘
+        //
+        // size == base_element * scaling_factor
+        for ((&l_constraint, &l_element), (&r_constraint, &r_element)) in layout
+            .constraints
+            .iter()
+            .zip(elements.iter())
+            .filter(|(c, _)| matches!(c, Constraint::Proportional(_)))
+            .tuple_combinations()
+        {
+            // `Proportional` will only expand into _excess_ available space. You can think of
+            // `Proportional` element sizes as starting from `0` and incrementally
+            // increasing while proportionally matching other `Proportional` spaces AND
+            // also meeting all other constraints.
+            if let (
+                Constraint::Proportional(l_scaling_factor),
+                Constraint::Proportional(r_scaling_factor),
+            ) = (l_constraint, r_constraint)
+            {
+                // because of the way cassowary works, we need to use `*` instead of `/`
+                // l_size / l_scaling_factor == l_size / l_scaling_factor
+                // ≡
+                // l_size * r_scaling_factor == r_size * r_scaling_factor
+                //
+                // we make `0` act as `1e-6`.
+                // this gives us a numerically stable solution and more consistent behavior along
+                // the number line
+                //
+                // I choose `1e-6` because we want a value that is as close to `0.0` as possible
+                // without causing it to behave like `0.0`. `1e-9` for example gives the same
+                // results as true `0.0`.
+                // I found `1e-6` worked well in all the various combinations of constraints I
+                // experimented with.
+                let (l_scaling_factor, r_scaling_factor) = (
+                    f64::from(l_scaling_factor).max(1e-6),
+                    f64::from(r_scaling_factor).max(1e-6),
+                );
+                solver.add_constraint(
+                    (r_scaling_factor * l_element.size())
+                        | EQ(REQUIRED - 1.0)
+                        | (l_scaling_factor * r_element.size()),
+                )?;
             }
         }
         // prefer equal chunks if other constraints are all satisfied
@@ -1150,7 +1221,6 @@ mod tests {
 
         #[test]
         fn length_constraints() {
-            // 3 lengths for reference
             // cassowary implementation tends to put excess in last variable
             let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
                 Length(25),
@@ -1198,6 +1268,16 @@ mod tests {
             let [a, b] =
                 Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Ratio(1, 4), Length(25)]));
             assert_eq!([a.width, b.width], [25, 75]);
+
+            // Length is lower priority to Fixed
+            let [a, b] =
+                Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Fixed(25), Length(25)]));
+            assert_eq!([a.width, b.width], [25, 75]);
+
+            // Length is lower priority to Fixed
+            let [a, b] =
+                Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Length(25), Fixed(25)]));
+            assert_eq!([a.width, b.width], [75, 25]);
         }
 
         // these are a few tests that document existing bugs in the layout algorithm
@@ -1263,6 +1343,381 @@ mod tests {
                     Rect::new(4, 0, 3, 1),
                 ]
             );
+        }
+
+        #[test]
+        fn proportional_fixed() {
+            // fixed doesn't panic when results don't match exactly
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Fixed(33),
+                Fixed(33),
+                Fixed(33),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [33, 33, 34]);
+
+            // cassowary implementation tends to put excess in last variable
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Fixed(25),
+                Fixed(25),
+                Fixed(25),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [25, 25, 50]);
+
+            // fixed with min and max
+            let [a, b, c] =
+                Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Min(25), Fixed(25), Max(25)]));
+            assert_eq!([a.width, b.width, c.width], [50, 25, 25]);
+
+            // fixed with percent and ratio
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Percentage(25),
+                Fixed(25),
+                Ratio(1, 4),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [25, 25, 50]);
+
+            // 3 lengths for reference
+            // cassowary implementation tends to put excess in last variable
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Length(25),
+                Length(25),
+                Length(25),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [25, 25, 50]);
+
+            // fixed with length
+            let [_a, _b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Length(25),
+                Length(25),
+                Fixed(25),
+            ]));
+            // this test gives different results when run over and over again
+            //
+            // assert_eq!([a.width, b.width], [25, 50]);
+            // assert_eq!([a.width, b.width], [50, 25]);
+            //
+            // So we check just that the last value is exactly what we want it to be
+            assert_eq!(c.width, 25);
+
+            // ensure that middle width is 1
+            // last length of 100 will not be met
+            let [a, b, c] =
+                Rect::new(0, 0, 50, 1).split(&Layout::horizontal([Min(20), Fixed(1), Length(100)]));
+
+            assert_eq!([a.width, b.width, c.width], [20, 1, 29]);
+
+            // ensure that middle width is 1
+            // first length of 100 will not be met
+            let [a, b, c] =
+                Rect::new(0, 0, 50, 1).split(&Layout::horizontal([Length(100), Fixed(1), Min(20)]));
+            assert_eq!([a.width, b.width, c.width], [29, 1, 20]);
+
+            // middle fixed width is satisfied exactly
+            // left and right are equal to each other
+            let [a, b, c] = Rect::new(0, 0, 50, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Fixed(10),
+                Proportional(1),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [20, 10, a.width]);
+
+            // middle fixed width is satisfied exactly
+            // ratio of left and right is 1 / 2
+            let [a, b, c] = Rect::new(0, 0, 50, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Fixed(10),
+                Proportional(2),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [13, 10, 27]);
+
+            // second width is double all the others
+            let [a, b, c, d] = Rect::new(0, 0, 50, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(2),
+                Proportional(1),
+                Proportional(1),
+            ]));
+            assert_eq!([a.width, b.width, c.width, d.width], [10, 20, 10, 10]);
+
+            // second width is still double all the others
+            let [a, b, c, d] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(2),
+                Proportional(1),
+                Proportional(1),
+            ]));
+            assert_eq!([a.width, b.width, c.width, d.width], [20, 40, 20, 20]);
+
+            // incremental proportions
+            let [a, b, c, d] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(2),
+                Proportional(3),
+                Proportional(4),
+            ]));
+            assert_eq!([a.width, b.width, c.width, d.width], [10, 20, 30, 40]);
+
+            // decremental proportions
+            let [a, b, c, d] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(4),
+                Proportional(3),
+                Proportional(2),
+                Proportional(1),
+            ]));
+            assert_eq!([a.width, b.width, c.width, d.width], [40, 30, 20, 10]);
+
+            // randomly ordered proportions
+            let [a, b, c, d] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(3),
+                Proportional(2),
+                Proportional(4),
+            ]));
+            assert_eq!([a.width, b.width, c.width, d.width], [10, 30, 20, 40]);
+
+            // randomly ordered proportions with fixed
+            let [a, b, c, d, e] = Rect::new(0, 0, 200, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(3),
+                Fixed(100),
+                Proportional(2),
+                Proportional(4),
+            ]));
+            assert_eq!(
+                [a.width, b.width, c.width, d.width, e.width],
+                [10, 30, 100, 20, 40]
+            );
+
+            // randomly ordered proportions with length
+            let [a, b, c, d, e] = Rect::new(0, 0, 200, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(3),
+                Length(100),
+                Proportional(2),
+                Proportional(4),
+            ]));
+            assert_eq!(
+                [a.width, b.width, c.width, d.width, e.width],
+                [10, 30, 100, 20, 40]
+            );
+
+            // randomly ordered proportions with percentage
+            let [a, b, c, d, e] = Rect::new(0, 0, 200, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(3),
+                Percentage(50),
+                Proportional(2),
+                Proportional(4),
+            ]));
+            assert_eq!(
+                [a.width, b.width, c.width, d.width, e.width],
+                [10, 30, 100, 20, 40]
+            );
+
+            // randomly ordered proportions with min
+            let [a, b, c, d, e] = Rect::new(0, 0, 200, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(3),
+                Min(100),
+                Proportional(2),
+                Proportional(4),
+            ]));
+            assert_eq!(
+                [a.width, b.width, c.width, d.width, e.width],
+                [10, 30, 100, 20, 40]
+            );
+
+            // randomly ordered proportions with max
+            let [a, b, c, d, e] = Rect::new(0, 0, 200, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(3),
+                Max(100),
+                Proportional(2),
+                Proportional(4),
+            ]));
+            assert_eq!(
+                [a.width, b.width, c.width, d.width, e.width],
+                [10, 30, 100, 20, 40]
+            );
+
+            // first and third widths are zero
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Proportional(1),
+                Proportional(0),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [0, 100, 0]);
+
+            // Proportional always divides proportionally amongst zeros
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Fixed(1),
+                Proportional(0),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [50, 1, 49]);
+
+            // Proportional always divides proportionally amongst zeros
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Length(1),
+                Proportional(0),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [50, 1, 49]);
+
+            // Proportional always divides proportionally amongst zeros
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Percentage(1),
+                Proportional(0),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [50, 1, 49]);
+
+            // Proportional always divides proportionally amongst zeros
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Ratio(1, 100),
+                Proportional(0),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [50, 1, 49]);
+
+            // Proportional always divides proportionally amongst zeros
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Min(1),
+                Proportional(0),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [50, 1, 49]);
+
+            // Proportional always divides proportionally amongst zeros
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Max(1),
+                Proportional(0),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [50, 1, 49]);
+
+            // first and third widths are zero
+            let [a, b, c, d] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Proportional(2),
+                Proportional(0),
+                Proportional(1),
+            ]));
+            assert_eq!([a.width, b.width, c.width, d.width], [0, 67, 0, 33]);
+
+            // 0 proportional will fill empty space
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Proportional(2),
+                Percentage(20),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [0, 80, 20]);
+
+            let [a, b] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(0),
+                Proportional(u16::MAX),
+            ]));
+            assert_eq!([a.width, b.width], [0, 100]);
+
+            // 0 proportional will fill empty space
+            let [a, b] = Rect::new(0, 0, 100, 1)
+                .split(&Layout::horizontal([Proportional(0), Percentage(20)]));
+            assert_eq!([a.width, b.width], [80, 20]);
+
+            // 1 proportional will fill empty spaces
+            let [a, b] = Rect::new(0, 0, 100, 1)
+                .split(&Layout::horizontal([Proportional(1), Percentage(20)]));
+            assert_eq!([a.width, b.width], [80, 20]);
+
+            // proportional can be zero because of high scaling factor
+            let [a, b, c] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(u16::MAX),
+                Proportional(1),
+                Percentage(20),
+            ]));
+            assert_eq!([a.width, b.width, c.width], [80, 0, 20]);
+
+            // single 0 proportional will fill empty space
+            let [a, b] =
+                Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Proportional(0), Length(20)]));
+            assert_eq!([a.width, b.width], [80, 20]);
+
+            // single 0 proportional will fill empty space
+            let [a, b] =
+                Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Proportional(0), Max(20)]));
+            assert_eq!([a.width, b.width], [80, 20]);
+
+            // 1 proportional will fill empty space
+            let [a, b] =
+                Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Proportional(1), Max(20)]));
+            assert_eq!([a.width, b.width], [80, 20]);
+
+            // 0 min still fills empty space
+            let [a, b] =
+                Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Min(0), Percentage(20)]));
+            assert_eq!([a.width, b.width], [80, 20]);
+
+            // percentage constraint doesn't hold against defying `Max`
+            let [a, b] =
+                Rect::new(0, 0, 100, 1).split(&Layout::horizontal([Max(0), Percentage(20)]));
+            assert_eq!([a.width, b.width], [0, 100]);
+
+            // specifying behavior of proportional with min and length
+            let [a, b, c, d, e] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(1),
+                Proportional(1),
+                Min(30),
+                Length(50),
+            ]));
+            assert_eq!(
+                [a.width, b.width, c.width, d.width, e.width],
+                [7, 6, 7, 30, 50]
+            );
+
+            // proportional is lower priority than length
+            let [a, b, c, d, e] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(1),
+                Proportional(1),
+                Length(50),
+                Length(50),
+            ]));
+            assert_eq!(
+                [a.width, b.width, c.width, d.width, e.width],
+                [0, 0, 0, 50, 50]
+            );
+
+            // proportional is lower priority than min and max
+            let [a, b, c, d, e] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(1),
+                Proportional(1),
+                Min(50),
+                Max(50),
+            ]));
+            assert_eq!(
+                [a.width, b.width, c.width, d.width, e.width],
+                [0, 0, 0, 50, 50]
+            );
+
+            // proportional is lower priority than percentage
+            let [a, b, c, d] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(1),
+                Proportional(1),
+                Percentage(100),
+            ]));
+            assert_eq!([a.width, b.width, c.width, d.width], [0, 0, 0, 100]);
+
+            // proportional is lower priority than ratio
+            let [a, b, c, d] = Rect::new(0, 0, 100, 1).split(&Layout::horizontal([
+                Proportional(1),
+                Proportional(1),
+                Proportional(1),
+                Ratio(1, 1),
+            ]));
+            assert_eq!([a.width, b.width, c.width, d.width], [0, 0, 0, 100]);
         }
     }
 }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -745,10 +745,12 @@ impl<'a> Chart<'a> {
             if let Some(inner_width) = legends.clone().max() {
                 let legend_width = inner_width + 2;
                 let legend_height = legends.count() as u16 + 2;
+                #[allow(deprecated)]
                 let max_legend_width = self
                     .hidden_legend_constraints
                     .0
                     .apply(layout.graph_area.width);
+                #[allow(deprecated)]
                 let max_legend_height = self
                     .hidden_legend_constraints
                     .1


### PR DESCRIPTION
This PR adds `Constraint::Fixed(x)` and `Constraint::Proportional(x)`. I've also added a simple example showing how some constraints interact with each other:

![constraints](https://github.com/ratatui-org/ratatui/assets/1813121/d87fc37a-b2ee-407c-80e1-3d6e28792d08)


This PR also deprecates the unused `Constraint::apply` method.

This PR allows users to create more advanced layouts. For example, we can force column spacing in the table layouts with a `Fixed` constraint.

Without this PR:

<img width="754" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/42bb7a0a-267d-4058-9013-106722149a57">

With this PR:

<img width="757" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/1f40bbd2-9dc2-407b-87d8-4a013232b7ae">

In the second screenshot, there's a column spacing after the description column. This does not exist in the first screenshot.

I've also improved the docstring for the enum variants (with some static ascii illustrations from the example):

<img width="1012" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/f72841a6-8413-4c75-abb0-2074964d0801">

**Additional information**

Currently we have the following levels of priorities:

- `Constraint::Min(lower)` and `Constraint::Max(upper)`
    - `segment >= lower` and `segment <= upper` have weights `STRONG`
    - `segment == lower` and `segment == upper` have weights `MEDIUM`
- `Constraint::Length(v)`, `Constraint::Percentage(v)` and `Constraint::Ratio(v)`
    - `segment == v` has weight `STRONG`

With this PR it becomes the following:

- (NEW) `Constraint::Fixed(v)`
    - `segment == v` has weight `REQUIRED - 1`
- (unchanged) `Constraint::Min(lower)` and `Constraint::Max(upper)`
    - `segment >= lower` and `segment <= upper` have weights `STRONG`
    - `segment == lower` and `segment == upper` have weights `MEDIUM`
- (unchanged) `Constraint::Length(v)`, `Constraint::Percentage(v)` and `Constraint::Ratio(v)`
    - `segment == v` has weight `STRONG`
- (NEW) `Constraint::Proportional(scaling_factor)`
    - `segment == total_available_area` has weight `WEAK`
    - `fill_segment / scaling_factor == any_other_fill_segment / any_other_fill_segment_scaling_factor` has weight `REQUIRED - 1`


