### PR TITLE
docs: GitHub admonition syntax for examples README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 > [!WARNING]
 > The examples in this folder run against the `main` branch. There may be backwards
-> incompatible changes to the example code.
+> incompatible changes compared to the [latest stable version](https://github.com/ratatui-org/ratatui/releases/latest).
 >
 > If you find that code copied from an example fails to run in your own application, please check
 > the tag of the release that your project is using.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 # Examples
 
-> [!WARNING] The examples in this folder run against the `main` branch. There may be backwards
+> [!WARNING]
+> The examples in this folder run against the `main` branch. There may be backwards
 > incompatible changes to the example code.
 >
 > If you find that code copied from an example fails to run in your own application, please check


### PR DESCRIPTION

Old:

<img width="1056" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/737f746b-ef42-43d4-a816-c78b6ef84f51">

New:

<img width="1056" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/b1429969-5b1e-4e1c-b736-92881414a13d">

