### PR TITLE
chore: add commit footers to git-cliff config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -30,6 +30,13 @@ body = """
   {{commit.body | indent(prefix="  ") }}
   ````
 {%- endif %}
+{%- for footer in commit.footers %}
+{%- if footer.token != "Signed-off-by" and footer.token != "Co-authored-by" %}
+
+  {{ footer.token | indent(prefix="  ") }}{{ footer.separator }}
+  {{ footer.value | indent(prefix="  ") }}
+{%- endif %}
+{%- endfor %}
 {% endmacro -%}
 
 {% for group, commits in commits | group_by(attribute="group") %}


### PR DESCRIPTION
Fixes: https://github.com/orhun/git-cliff/issues/297

Any line in the commit that ends in a colon gets truncated by git-cliff in the default configuration. This fixes that.

The following is the output of `git-cliff -u -o CHANGELOG.md` compared before and after this change.

`````diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 8f0082ca..1028e066 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@ All notable changes to this project will be documented in this file.
   - Adds missing docs
   ````
 
+  BREAKING CHANGE:
+  `Line::style` is now a field of `Line` instead of being
+  stored in each `Span`.
+
 - [bbf2f90](https://github.com/ratatui-org/ratatui/commit/bbf2f906fbe7e593fdeb5dd7530d3479788f77a5)
   *(rect.rs)* Implement Rows and Columns iterators in Rect ([#765](https://github.com/ratatui-org/ratatui/issues/765))
 
@@ -261,6 +265,12 @@ All notable changes to this project will be documented in this file.
   now accepts `IntoIterator<Item: Into<Row>>`.
   ````
 
+  BREAKING CHANGE:
+  The compiler can no longer infer the element type of the container
+  passed to `Table::new()`.  For example, `Table::new(vec![], widths)`
+  will no longer compile, as the type of `vec![]` can no longer be
+  inferred.
+
 - [2faa879](https://github.com/ratatui-org/ratatui/commit/2faa879658a439d233edc4ac886fb42c17ff971a)
   *(table)* Accept Text for highlight_symbol ([#781](https://github.com/ratatui-org/ratatui/issues/781))
 
@@ -323,6 +333,15 @@ All notable changes to this project will be documented in this file.
   implementing `Into<Line>`.
   ````
 
+  BREAKING CHANGE:
+  Calls to `Tabs::new()` whose argument is collected from an iterator
+  will no longer compile.  For example,
+
+  `Tabs:
+  :new(["a","b"].into_iter().collect())` will no longer compile,
+  because the return type of `.collect()` can no longer be inferred to
+  be a `Vec<_>`.
+
 - [b459228](https://github.com/ratatui-org/ratatui/commit/b459228e26b9429b8a09084d76251361f7f5bfd3)
   *(termwiz)* Add `From` termwiz style impls ([#726](https://github.com/ratatui-org/ratatui/issues/726))
 
@@ -380,6 +399,9 @@ All notable changes to this project will be documented in this file.
   test it visually, shared below:
   ````
 
+  https:
+  //github.com/ratatui-org/ratatui/assets/1813121/c8716c59-493f-4631-add5-feecf4bd4e06
+
 - [9a3815b](https://github.com/ratatui-org/ratatui/commit/9a3815b66d8b6e4ff9f6475666f5742701e256bb)
   *(uncategorized)* Add Constraint::Fixed and Constraint::Proportional ✨ ([#783](https://github.com/ratatui-org/ratatui/issues/783))
 
@@ -407,6 +429,30 @@ All notable changes to this project will be documented in this file.
   // can now be simplified to
   ````
 
+  Line:
+  :styled("hello", Color::Red);
+
+  Line:
+  :styled("world", Modifier::BOLD);
+  ```
+
+  Fixes https://github.com/ratatui-org/ratatui/issues/694
+
+  BREAKING CHANGE:
+  All style related methods now accept `S: Into<Style>`
+  instead of `Style`. This means that if you are already passing an
+  ambiguous type that implements `Into<Style>` you will need to remove
+  the `.into()` call.
+
+  `Block` style methods can no longer be called from a const context as
+  trait functions cannot (yet) be const.
+
+  * feat: add tuple conversions to Style
+
+  Adds conversions for various Color and Modifier combinations
+
+  * chore: add unit tests
+
 ### Bug Fixes
 
 - [ee54493](https://github.com/ratatui-org/ratatui/commit/ee544931633ada25d84daa95e4e3a0b17801cb8b)
@@ -450,6 +496,14 @@ All notable changes to this project will be documented in this file.
   manually.
   ````
 
+  BREAKING CHANGE:
+  The default() implementation of Table now sets the
+  column_spacing field to 1 and the segment_size field to
+
+  SegmentSize:
+  :None. This will affect the rendering of a small amount of
+  apps.
+
 - [b0ed658](https://github.com/ratatui-org/ratatui/commit/b0ed658970e8a94f25948c80d511102c197a8f6a)
   *(table)* Render missing widths as equal ([#710](https://github.com/ratatui-org/ratatui/issues/710))
 
@@ -459,6 +513,9 @@ All notable changes to this project will be documented in this file.
   behaviour to default to equal widths for each column.
   ````
 
+  Fixes #
+  510.
+
 - [f2eab71](https://github.com/ratatui-org/ratatui/commit/f2eab71ccf11a206c253bf4efeafc744f103b116)
   *(uncategorized)* Broken tests in table.rs ([#784](https://github.com/ratatui-org/ratatui/issues/784))
 
@@ -476,6 +533,9 @@ All notable changes to this project will be documented in this file.
 - [bc274e2](https://github.com/ratatui-org/ratatui/commit/bc274e2bd9cfee1133dfbcca3c95374560706537)
   *(block)* Remove deprecated `title_on_bottom` ([#757](https://github.com/ratatui-org/ratatui/issues/757)) [**breaking**]
 
+  `Block:
+  :title_on_bottom` was deprecated in v0.22. Use `Block::title` and `Title::position` instead.
+
 - [a62632a](https://github.com/ratatui-org/ratatui/commit/a62632a947a950f7ab303e67eb910b01f4ee256d)
   *(buffer)* Split buffer module into files ([#721](https://github.com/ratatui-org/ratatui/issues/721))
 
@@ -621,6 +681,12 @@ All notable changes to this project will be documented in this file.
 - [fab943b](https://github.com/ratatui-org/ratatui/commit/fab943b61afb1c5f79d03b1f3764067ac26945d0)
   *(contributing)* Add deprecation notice guideline ([#761](https://github.com/ratatui-org/ratatui/issues/761))
 
+- [1ed9503](https://github.com/ratatui-org/ratatui/commit/1ed950330e0bf3550fcb900a86f9bb20cb1035db)
+  *(uncategorized)* Add commit footers to git-cliff config
+
+  Fixes:
+  https://github.com/orhun/git-cliff/issues/297
+
 - [c24216c](https://github.com/ratatui-org/ratatui/commit/c24216cf307bba7d19ed579a10ef541e28dfd4bc)
   *(uncategorized)* Add comment on PRs with unsigned commits ([#768](https://github.com/ratatui-org/ratatui/issues/768))
 
`````