### PR TITLE
feat(text): add style and alignment

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -207,7 +207,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         .items
         .iter()
         .map(|i| {
-            let mut lines = vec![Line::from(i.0)];
+            let mut lines = vec![Line::from(i.0.bold()).alignment(Alignment::Center)];
             for _ in 0..i.1 {
                 lines.push(
                     "Lorem ipsum dolor sit amet, consectetur adipiscing elit."

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -269,11 +269,11 @@ impl<'a> Line<'a> {
             .flat_map(move |span| span.styled_graphemes(style))
     }
 
-    /// Patches the style of each Span in an existing Line, adding modifiers from the given style.
+    /// Patches the style of this Line, adding modifiers from the given style.
     ///
     /// This is useful for when you want to apply a style to a line that already has some styling.
     /// In contrast to [`Line::style`], this method will not overwrite the existing style, but
-    /// instead will add the given style's modifiers to the existing style of each `Span`.
+    /// instead will add the given style's modifiers to this Line's style.
     ///
     /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or
     /// your own type that implements [`Into<Style>`]).
@@ -296,7 +296,7 @@ impl<'a> Line<'a> {
         self
     }
 
-    /// Resets the style of each Span in the Line.
+    /// Resets the style of this Line.
     ///
     /// Equivalent to calling `patch_style(Style::reset())`.
     ///
@@ -369,7 +369,7 @@ impl Widget for Line<'_> {
             let span_width = span.width() as u16;
             let span_area = Rect {
                 x,
-                width: span_width,
+                width: span_width.min(area.right() - x),
                 ..area
             };
             span.render(span_area, buf);
@@ -635,11 +635,9 @@ mod tests {
 
         #[test]
         fn render_truncates() {
-            let mut buf = Buffer::empty(Rect::new(0, 0, 11, 1));
-            hello_world().render(Rect::new(0, 0, 11, 1), &mut buf);
-            let mut expected = Buffer::with_lines(vec!["Hello world"]);
-            expected.set_style(Rect::new(0, 0, 6, 1), BLUE.italic());
-            expected.set_style(Rect::new(6, 0, 5, 1), GREEN.italic());
+            let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
+            Line::from("Hello world!").render(Rect::new(0, 0, 5, 1), &mut buf);
+            let expected = Buffer::with_lines(vec!["Hello     "]);
             assert_buffer_eq!(buf, expected);
         }
 

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -493,11 +493,13 @@ mod tests {
         fn render_truncates_too_long_content() {
             let style = Style::new().green().on_yellow();
             let span = Span::styled("test content", style);
-            let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
-            span.render(buf.area, &mut buf);
 
-            let expected =
-                Buffer::with_lines(vec![Line::from(vec!["test conte".green().on_yellow()])]);
+            let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
+            span.render(Rect::new(0, 0, 5, 1), &mut buf);
+
+            let mut expected = Buffer::with_lines(vec![Line::from("test      ")]);
+            expected.set_style(Rect::new(0, 0, 5, 1), (Color::Green, Color::Yellow));
+
             assert_buffer_eq!(buf, expected);
         }
 

--- a/src/widgets/table/cell.rs
+++ b/src/widgets/table/cell.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::{prelude::*, widgets::Widget};
 
 /// A [`Cell`] contains the [`Text`] to be displayed in a [`Row`] of a [`Table`].
 ///
@@ -6,6 +6,8 @@ use crate::prelude::*;
 /// entire area of the cell. Any [`Style`] set on the [`Text`] content will be combined with the
 /// [`Style`] of the [`Cell`] by adding the [`Style`] of the [`Text`] content to the [`Style`] of
 /// the [`Cell`]. Styles set on the text content will only affect the content.
+///
+/// You can use [`Text::alignment`] when creating a cell to align its content.
 ///
 /// # Examples
 ///
@@ -132,24 +134,7 @@ impl<'a> Cell<'a> {
 impl Cell<'_> {
     pub(crate) fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
-        for (i, line) in self.content.lines.iter().enumerate() {
-            if i as u16 >= area.height {
-                break;
-            }
-
-            let x_offset = match line.alignment {
-                Some(Alignment::Center) => (area.width / 2).saturating_sub(line.width() as u16 / 2),
-                Some(Alignment::Right) => area.width.saturating_sub(line.width() as u16),
-                _ => 0,
-            };
-
-            let x = area.x + x_offset;
-            if x >= area.right() {
-                continue;
-            }
-
-            buf.set_line(x, area.y + i as u16, line, area.width);
-        }
+        self.content.clone().render(area, buf);
     }
 }
 

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -14,6 +14,8 @@ use crate::{
 /// You can construct a [`Table`] using either [`Table::new`] or [`Table::default`] and then chain
 /// builder style methods to set the desired properties.
 ///
+/// Table cells can be aligned, for more details see [`Cell`].
+///
 /// Make sure to call the [`Table::widths`] method, otherwise the columns will all have a width of 0
 /// and thus not be visible.
 ///
@@ -691,12 +693,12 @@ impl Table<'_> {
 
             let is_selected = state.selected().is_some_and(|index| index == i);
             if selection_width > 0 && is_selected {
-                // this should in normal cases be safe, because "get_columns_widths" allocates
-                // "highlight_symbol.width()" space but "get_columns_widths"
-                // currently does not bind it to max table.width()
-                for (line, line_row) in highlight_symbol.lines.iter().zip(row_area.rows()) {
-                    line.clone().style(row.style).render(line_row, buf);
-                }
+                let selection_area = Rect {
+                    width: selection_width,
+                    ..row_area
+                };
+                buf.set_style(selection_area, row.style);
+                highlight_symbol.clone().render(selection_area, buf);
             };
             for ((x, width), cell) in columns_widths.iter().zip(row.cells.iter()) {
                 cell.render(


### PR DESCRIPTION
Fixes #758, fixes #801

This PR adds:

- `style` and `alignment` to `Text`
- impl `Widget` for `Text`
- replace `Text` manual draw to call for Widget impl

All places that use `Text` have been updated and support its new features expect paragraph which still has a custom implementation.

---

I fixed some docs in line. I also refactored the truncation tests for line and span to clarify them because line wasn't truncating correctly (also fixed that).