### PR TITLE
refactor(example): add scroll to flex example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,7 @@ doc-scrape-examples = false
 [[example]]
 name = "flex"
 required-features = ["crossterm"]
-doc-scrape-examples = false
+doc-scrape-examples = true
 
 [[example]]
 name = "list"

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -39,7 +39,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 const N_EXAMPLES_PER_TAB: u16 = 7;
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> io::Result<()> {
-    // each example has 5 height
     // we always want to show the last example when scrolling
     let mut app = App::default().max_scroll_offset((N_EXAMPLES_PER_TAB - 1) * EXAMPLE_HEIGHT);
 
@@ -118,8 +117,7 @@ impl Widget for App {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let [tabs_area, demo_area] = area.split(&Layout::vertical([Fixed(3), Proportional(0)]));
 
-        // render demo content into a separate buffer
-        // there's 6 examples and each is just 5 pixels tall.
+        // render demo content into a separate buffer so all examples fit
         let mut demo_buf = Buffer::empty(Rect::new(
             0,
             0,
@@ -218,7 +216,7 @@ impl Widget for ExampleSelection {
 impl ExampleSelection {
     fn render_example(&self, area: Rect, buf: &mut Buffer, flex: Flex) {
         let [example1, example2, example3, example4, example5, example6, example7] = area
-            .split(&Layout::vertical([Fixed(5); N_EXAMPLES_PER_TAB as usize]).flex(Flex::Start));
+            .split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); N_EXAMPLES_PER_TAB as usize]).flex(Flex::Start));
 
         Example::new([Length(20), Length(15)])
             .flex(flex)

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -105,7 +105,7 @@ impl App {
                 .title(Title::from("Flex Layouts ".bold()))
                 .title(" Use h l or ◄ ► to change tab and j k or ▲ ▼  to scroll".bold()),
         )
-        .highlight_style(Style::default().yellow())
+        .highlight_style(Style::default().bold())
         .select(self.selected_example.selected())
         .padding(" ", " ")
         .render(area, buf);

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -105,7 +105,7 @@ impl App {
                 .title(Title::from("Flex Layouts ".bold()))
                 .title(" Use h l or ◄ ► to change tab and j k or ▲ ▼  to scroll".bold()),
         )
-        .highlight_style(Style::default().bold())
+        .highlight_style(Style::default().yellow().bold())
         .select(self.selected_example.selected())
         .padding(" ", " ")
         .render(area, buf);

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -11,6 +11,8 @@ use ratatui::{
     widgets::{block::Title, *},
 };
 
+const EXAMPLE_HEIGHT: u16 = 5;
+
 fn main() -> Result<(), Box<dyn Error>> {
     // setup terminal
     enable_raw_mode()?;
@@ -35,9 +37,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> io::Result<()> {
-    // there's 6 examples that are each 5 height
+    // there's 6 examples
     // we always want to show the last example when scrolling
-    let mut app = App::default().max_scroll_offset((6 - 1) * 5);
+    let mut app = App::default().max_scroll_offset((6 - 1) * EXAMPLE_HEIGHT);
     loop {
         terminal.draw(|f| f.render_widget(app, f.size()))?;
 
@@ -80,7 +82,7 @@ impl App {
         self.scroll_offset = self
             .scroll_offset
             .saturating_add(1)
-            .clamp(0, self.max_scroll_offset)
+            .min(self.max_scroll_offset)
     }
 
     fn render_tabs(&self, area: Rect, buf: &mut Buffer) {
@@ -115,7 +117,7 @@ impl Widget for App {
 
         // render demo content into a separate buffer
         // there's 6 examples and each is just 5 pixels tall.
-        let mut demo_buf = Buffer::empty(Rect::new(0, 0, buf.area.width, 6 * 5));
+        let mut demo_buf = Buffer::empty(Rect::new(0, 0, buf.area.width, 6 * EXAMPLE_HEIGHT));
 
         self.selected_example.render(demo_buf.area, &mut demo_buf);
 
@@ -208,9 +210,9 @@ impl Widget for ExampleSelection {
 impl ExampleSelection {
     fn render_example(&self, area: Rect, buf: &mut Buffer, flex: Flex) {
         let [example1, example2, example3, example4, example5, example6, _] =
-            area.split(&Layout::vertical([Fixed(5); 7]));
+            area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 7]));
 
-        Example::new([Length(20), Length(10)])
+        Example::new([Length(20), Length(12)])
             .flex(flex)
             .render(example1, buf);
         Example::new([Length(20), Fixed(20)])

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -12,6 +12,7 @@ use ratatui::{
 };
 
 const EXAMPLE_HEIGHT: u16 = 5;
+const N_EXAMPLES_PER_TAB: u16 = 11;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // setup terminal
@@ -35,8 +36,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
-
-const N_EXAMPLES_PER_TAB: u16 = 7;
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> io::Result<()> {
     // we always want to show the last example when scrolling
@@ -215,42 +214,33 @@ impl Widget for ExampleSelection {
 
 impl ExampleSelection {
     fn render_example(&self, area: Rect, buf: &mut Buffer, flex: Flex) {
-        let [example1, example2, example3, example4, example5, example6, example7] = area
-            .split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); N_EXAMPLES_PER_TAB as usize]).flex(Flex::Start));
+        let areas = &Layout::vertical([Fixed(EXAMPLE_HEIGHT); N_EXAMPLES_PER_TAB as usize])
+            .flex(Flex::Start)
+            .split(area);
 
-        Example::new([Length(20), Length(15)])
-            .flex(flex)
-            .render(example1, buf);
-        Example::new([Length(20), Fixed(20)])
-            .flex(flex)
-            .render(example2, buf);
-        Example::new([Proportional(1), Proportional(1), Length(20), Fixed(20)])
-            .flex(flex)
-            .render(example3, buf);
-        Example::new([Min(20), Length(20), Fixed(20)])
-            .flex(flex)
-            .render(example4, buf);
-        Example::new([Min(20), Proportional(0), Length(20), Fixed(20)])
-            .flex(flex)
-            .render(example5, buf);
-        Example::new([
-            Min(10),
-            Proportional(0),
-            Percentage(20),
-            Length(15),
-            Fixed(15),
-        ])
-        .flex(flex)
-        .render(example6, buf);
-        Example::new([
-            Min(10),
-            Proportional(3),
-            Proportional(2),
-            Length(15),
-            Fixed(15),
-        ])
-        .flex(flex)
-        .render(example7, buf);
+        let examples = [
+            vec![Length(20), Fixed(20), Percentage(20)],
+            vec![Fixed(20), Percentage(20), Length(20)],
+            vec![Percentage(20), Length(20), Fixed(20)],
+            vec![Length(20), Length(15)],
+            vec![Length(20), Fixed(20)],
+            vec![Min(20), Max(20)],
+            vec![Max(20)],
+            vec![Min(20), Max(20), Length(20), Fixed(20)],
+            vec![Proportional(0), Proportional(0)],
+            vec![Proportional(1), Proportional(1), Length(20), Fixed(20)],
+            vec![
+                Min(10),
+                Proportional(3),
+                Proportional(2),
+                Length(15),
+                Fixed(15),
+            ],
+        ];
+
+        for (area, constraints) in areas.iter().zip(examples) {
+            Example::new(constraints).flex(flex).render(*area, buf);
+        }
     }
 }
 

--- a/examples/flex.tape
+++ b/examples/flex.tape
@@ -7,7 +7,11 @@ Set Height 1410
 Hide
 Type "cargo run --example=flex --features=crossterm"
 Enter
-Sleep 1s
+Sleep 2s
 Show
-Sleep 5s
+Sleep 2s
 Right @5s 7
+Sleep 2s
+Left 7
+Sleep 2s
+Down @200ms 50

--- a/examples/flex.tape
+++ b/examples/flex.tape
@@ -1,0 +1,13 @@
+# This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
+# To run this script, install vhs and run `vhs ./examples/layout.tape`
+Output "target/flex.gif"
+Set Theme "Aardvark Blue"
+Set Width 1200
+Set Height 1410
+Hide
+Type "cargo run --example=flex --features=crossterm"
+Enter
+Sleep 1s
+Show
+Sleep 5s
+Right @5s 7


### PR DESCRIPTION
On a standard size terminal, flex example is cut off which is a shame because of how great it is.

![image](https://github.com/ratatui-org/ratatui/assets/36198422/b0e9d441-5f74-4bf5-a032-d974feb31f7d)

I added scroll to the example.

`constraints` will also need that but I first want to validate this kind of janky implementation.