### PR TITLE
fix(example): increase layout cache size

### DIFF
--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -16,6 +16,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
+    // Each line in the example is a layout
+    // There is on average 4 row per example
+    // 4 row * 7 example = 28
+    // Plus additional layout for tabs ...
+    // Examples might also grow in a very near future
+    Layout::init_cache(50);
+
     // create app and run it
     let res = run_app(&mut terminal);
 

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -22,6 +22,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
+    // Each line in the example is a layout
+    // so EXAMPLE_HEIGHT * N_EXAMPLES_PER_TAB = 55 currently
+    // Plus additional layout for tabs ...
+    Layout::init_cache(50);
+
     // create app and run it
     let res = run_app(&mut terminal);
 


### PR DESCRIPTION
This was causing very bad performances especially on scrolling and also some flickering (which is a bug anyway). It's also a good usage demonstration.

<details><summary>Details</summary>
<p>

To show it works I added logging in `Layout::split`:

```diff
diff --git a/src/layout/layout.rs b/src/layout/layout.rs
index b2e1f72..ebcce85 100644
--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -410,6 +410,7 @@ impl Layout {
     /// assert_eq!(layout[..], [Rect::new(0, 0, 3, 2), Rect::new(3, 0, 6, 2)]);
     /// ```
     pub fn split(&self, area: Rect) -> Rc<[Rect]> {
+        eprintln!("split");
         LAYOUT_CACHE.with(|c| {
             c.get_or_init(|| {
                 RefCell::new(LruCache::new(
@@ -418,6 +419,7 @@ impl Layout {
             })
             .borrow_mut()
             .get_or_insert((area, self.clone()), || {
+                eprintln!("calculated");
                 Self::try_split(area, self).expect("failed to split")
             })
             .clone()
```

```sh
cargo run --example layout 2> log
```

And see the output with and without this PR.
</p>
</details> 