### PR TITLE
refactor(example): improve constraints and flex examples

### DIFF
--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -91,16 +91,16 @@ impl App {
             .min(self.max_scroll_offset)
     }
 
-    fn render_tabs_and_legend(&self, area: Rect, buf: &mut Buffer) {
-        let [tabs, legend] = area.split(&Layout::vertical([
+    fn render_tabs_and_axis(&self, area: Rect, buf: &mut Buffer) {
+        let [tabs, axis] = area.split(&Layout::vertical([
             Constraint::Fixed(3),
             Constraint::Fixed(3),
         ]));
         self.render_tabs(tabs, buf);
-        self.render_legend(legend, buf);
+        self.render_axis(axis, buf);
     }
 
-    fn render_legend(&self, area: Rect, buf: &mut Buffer) {
+    fn render_axis(&self, area: Rect, buf: &mut Buffer) {
         let width = area.width as usize;
         // a bar like `<----- 80 px ----->`
         let width_label = format!("{} px", width);
@@ -150,7 +150,7 @@ impl App {
 
 impl Widget for App {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let [tabs_and_legend_area, demo_area] =
+        let [tabs_and_axis_area, demo_area] =
             area.split(&Layout::vertical([Fixed(6), Proportional(0)]));
 
         // render demo content into a separate buffer so all examples fit
@@ -158,19 +158,18 @@ impl Widget for App {
             0,
             0,
             buf.area.width,
-            self.selected_example.get_example_count() * EXAMPLE_HEIGHT
-                + tabs_and_legend_area.height,
+            self.selected_example.get_example_count() * EXAMPLE_HEIGHT + tabs_and_axis_area.height,
         ));
 
         self.selected_example.render(demo_buf.area, &mut demo_buf);
 
         // render tabs into a separate buffer
-        let mut tabs_and_legend_buf = Buffer::empty(tabs_and_legend_area);
-        self.render_tabs_and_legend(tabs_and_legend_area, &mut tabs_and_legend_buf);
+        let mut tabs_and_axis_buf = Buffer::empty(tabs_and_axis_area);
+        self.render_tabs_and_axis(tabs_and_axis_area, &mut tabs_and_axis_buf);
 
         // Assemble both buffers
         // NOTE: You shouldn't do this in a production app
-        buf.content = tabs_and_legend_buf.content;
+        buf.content = tabs_and_axis_buf.content;
         buf.content.append(
             &mut demo_buf
                 .content

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -136,7 +136,19 @@ impl App {
                 ExampleSelection::Max,
             ]
             .iter()
-            .map(|e| format!("{:?}", e)),
+            .enumerate()
+            .map(|(i, e)| {
+                format!(
+                    "{indicator}{e:?}",
+                    indicator = {
+                        if i == self.selected_example.selected() {
+                            " \u{2022} "
+                        } else {
+                            "   "
+                        }
+                    }
+                )
+            }),
         )
         .block(
             Block::bordered()
@@ -145,7 +157,8 @@ impl App {
         )
         .highlight_style(Style::default().yellow().bold())
         .select(self.selected_example.selected())
-        .padding("  ", "  ")
+        .divider("")
+        .padding("", "")
         .render(area, buf);
     }
 }

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -7,7 +7,9 @@ use crossterm::{
 };
 use ratatui::{layout::Constraint::*, prelude::*, widgets::*};
 
-const EXAMPLE_HEIGHT: u16 = 3;
+const SPACER_HEIGHT: u16 = 1;
+const ILLUSTRATION_HEIGHT: u16 = 3;
+const EXAMPLE_HEIGHT: u16 = ILLUSTRATION_HEIGHT + SPACER_HEIGHT;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // setup terminal
@@ -368,6 +370,10 @@ impl Example {
 
 impl Widget for Example {
     fn render(self, area: Rect, buf: &mut Buffer) {
+        let [area, _] = area.split(&Layout::vertical([
+            Fixed(ILLUSTRATION_HEIGHT),
+            Fixed(SPACER_HEIGHT),
+        ]));
         let blocks = Layout::horizontal(&self.constraints).split(area);
 
         for (block, constraint) in blocks.iter().zip(&self.constraints) {

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -377,34 +377,33 @@ impl Widget for Example {
         let blocks = Layout::horizontal(&self.constraints).split(area);
 
         for (block, constraint) in blocks.iter().zip(&self.constraints) {
-            let text = format!("{} px", block.width);
-            let fg = match constraint {
-                Constraint::Ratio(_, _) => Color::Indexed(1),
-                Constraint::Percentage(_) => Color::Indexed(2),
-                Constraint::Max(_) => Color::Indexed(3),
-                Constraint::Min(_) => Color::Indexed(4),
-                Constraint::Length(_) => Color::Indexed(5),
-                Constraint::Fixed(_) => Color::Indexed(6),
-                Constraint::Proportional(_) => Color::Indexed(7),
-            };
-            self.illustration(*constraint, text, fg).render(*block, buf);
+            self.illustration(*constraint, block.width)
+                .render(*block, buf);
         }
     }
 }
 
 impl Example {
-    fn illustration(&self, constraint: Constraint, text: String, fg: Color) -> Paragraph {
-        Paragraph::new(format!(" {constraint} ").fg(fg))
+    fn illustration(&self, constraint: Constraint, width: u16) -> Paragraph {
+        let text = format!("{} px", width);
+        let fg = match constraint {
+            Constraint::Ratio(_, _) => Color::Indexed(1),
+            Constraint::Percentage(_) => Color::Indexed(2),
+            Constraint::Max(_) => Color::Indexed(3),
+            Constraint::Min(_) => Color::Indexed(4),
+            Constraint::Length(_) => Color::Indexed(5),
+            Constraint::Fixed(_) => Color::Indexed(6),
+            Constraint::Proportional(_) => Color::Indexed(7),
+        };
+        let title = format!("{constraint}").fg(fg);
+        let content = format!("{text}");
+        Paragraph::new(content)
             .style(Color::DarkGray)
             .alignment(Alignment::Center)
             .block(
                 Block::bordered()
                     .style(Style::default().fg(Color::DarkGray))
-                    .title(
-                        block::Title::from(format!("{text}"))
-                            .alignment(Alignment::Right)
-                            .position(block::Position::Bottom),
-                    ),
+                    .title(block::Title::from(title).alignment(Alignment::Center)),
             )
     }
 }

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -197,19 +197,22 @@ impl App {
     /// This function renders the demo content into a separate buffer and then splices the buffer
     /// into the main buffer. This is done to make it possible to handle scrolling easily.
     fn render_demo(&self, area: Rect, buf: &mut Buffer) {
-        // render demo content into a separate buffer so all examples fit
-        let height = self.selected_tab.get_example_count() * EXAMPLE_HEIGHT;
-        let mut demo_buf = Buffer::empty(Rect { height, ..area });
-        self.selected_tab.render(demo_buf.area, &mut demo_buf);
+        // render demo content into a separate buffer so all examples fit we add an extra
+        // area.height to make sure the last example is fully visible even when the scroll offset is
+        // at the max
+        let height = self.selected_tab.get_example_count() * EXAMPLE_HEIGHT + area.height;
+        let demo_area = Rect::new(0, 0, area.width, height);
+        let mut demo_buf = Buffer::empty(demo_area);
+        self.selected_tab.render(demo_area, &mut demo_buf);
 
         // Splice the visible area into the main buffer
         let start = buf.index_of(area.left(), area.top());
-        let end = buf.content.len().saturating_sub(area.area() as usize);
+        let end = buf.content.len().min(start + area.area() as usize);
 
         let visible_content = demo_buf
             .content
             .into_iter()
-            .skip((buf.area.width * self.scroll_offset) as usize)
+            .skip((demo_area.width * self.scroll_offset) as usize)
             .take(area.area() as usize);
         buf.content.splice(start..end, visible_content);
     }

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -93,7 +93,7 @@ impl App {
     }
 
     fn handle_events(&mut self) -> Result<()> {
-        Ok(if let Event::Key(key) = event::read()? {
+        if let Event::Key(key) = event::read()? {
             use KeyCode::*;
             match key.code {
                 Char('q') | Esc => self.quit(),
@@ -105,7 +105,8 @@ impl App {
                 Char('G') | End => self.bottom(),
                 _ => (),
             }
-        })
+        }
+        Ok(())
     }
 
     fn quit(&mut self) {

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -385,7 +385,6 @@ impl Widget for Example {
 
 impl Example {
     fn illustration(&self, constraint: Constraint, width: u16) -> Paragraph {
-        let text = format!("{} px", width);
         let fg = match constraint {
             Constraint::Ratio(_, _) => Color::Indexed(1),
             Constraint::Percentage(_) => Color::Indexed(2),
@@ -396,7 +395,7 @@ impl Example {
             Constraint::Proportional(_) => Color::Indexed(7),
         };
         let title = format!("{constraint}").fg(fg);
-        let content = format!("{text}");
+        let content = format!("{width} px");
         Paragraph::new(content)
             .style(Color::DarkGray)
             .alignment(Alignment::Center)

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -7,7 +7,7 @@ use crossterm::{
 };
 use ratatui::{layout::Constraint::*, prelude::*, style::palette::tailwind, widgets::*};
 
-const SPACER_HEIGHT: u16 = 1;
+const SPACER_HEIGHT: u16 = 0;
 const ILLUSTRATION_HEIGHT: u16 = 3;
 const EXAMPLE_HEIGHT: u16 = ILLUSTRATION_HEIGHT + SPACER_HEIGHT;
 

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -8,7 +8,7 @@ use crossterm::{
 use ratatui::{layout::Constraint::*, prelude::*, style::palette::tailwind, widgets::*};
 
 const SPACER_HEIGHT: u16 = 0;
-const ILLUSTRATION_HEIGHT: u16 = 3;
+const ILLUSTRATION_HEIGHT: u16 = 4;
 const EXAMPLE_HEIGHT: u16 = ILLUSTRATION_HEIGHT + SPACER_HEIGHT;
 
 // priority 1
@@ -68,6 +68,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>) -> io::Result<()> {
                 Char('h') | Left => app.previous(),
                 Char('j') | Down => app.down(),
                 Char('k') | Up => app.up(),
+                Char('g') | Home => app.top(),
+                Char('G') | End => app.bottom(),
                 _ => (),
             }
         }
@@ -103,6 +105,14 @@ impl App {
             .scroll_offset
             .saturating_add(1)
             .min(self.max_scroll_offset)
+    }
+
+    fn top(&mut self) {
+        self.scroll_offset = 0;
+    }
+
+    fn bottom(&mut self) {
+        self.scroll_offset = self.max_scroll_offset;
     }
 
     fn render_tabs_and_axis(&self, area: Rect, buf: &mut Buffer) {
@@ -152,7 +162,7 @@ impl App {
                 .title("Constraints ".bold())
                 .title(" Use h l or ◄ ► to change tab and j k or ▲ ▼  to scroll"),
         )
-        .highlight_style(Style::default().bold())
+        .highlight_style(Modifier::REVERSED)
         .select(self.selected_example.selected())
         .padding("", "")
         .divider(" ")

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -7,7 +7,7 @@ use crossterm::{
 };
 use ratatui::{layout::Constraint::*, prelude::*, widgets::*};
 
-const EXAMPLE_HEIGHT: u16 = 5;
+const EXAMPLE_HEIGHT: u16 = 3;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // setup terminal
@@ -91,6 +91,34 @@ impl App {
             .min(self.max_scroll_offset)
     }
 
+    fn render_tabs_and_legend(&self, area: Rect, buf: &mut Buffer) {
+        let [tabs, legend] = area.split(&Layout::vertical([
+            Constraint::Fixed(3),
+            Constraint::Fixed(3),
+        ]));
+        self.render_tabs(tabs, buf);
+        self.render_legend(legend, buf);
+    }
+
+    fn render_legend(&self, area: Rect, buf: &mut Buffer) {
+        let width = area.width as usize;
+        // a bar like `<----- 80 px ----->`
+        let width_label = format!("{} px", width);
+        let width_bar = format!(
+            "<{width_label:-^width$}>",
+            width = width - width_label.len() / 2
+        );
+        Paragraph::new(width_bar.dark_gray())
+            .alignment(Alignment::Center)
+            .block(Block::default().padding(Padding {
+                left: 0,
+                right: 0,
+                top: 1,
+                bottom: 0,
+            }))
+            .render(area, buf);
+    }
+
     fn render_tabs(&self, area: Rect, buf: &mut Buffer) {
         // ┌Constraints───────────────────────────────────────────────────────────────────┐
         // │  Fixed  │  Length  │  Percentage  │  Ratio  │  Proportional  │  Min  │  Max  │
@@ -122,25 +150,27 @@ impl App {
 
 impl Widget for App {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let [tabs_area, demo_area] = area.split(&Layout::vertical([Fixed(3), Proportional(0)]));
+        let [tabs_and_legend_area, demo_area] =
+            area.split(&Layout::vertical([Fixed(6), Proportional(0)]));
 
         // render demo content into a separate buffer so all examples fit
         let mut demo_buf = Buffer::empty(Rect::new(
             0,
             0,
             buf.area.width,
-            self.selected_example.get_example_count() * EXAMPLE_HEIGHT,
+            self.selected_example.get_example_count() * EXAMPLE_HEIGHT
+                + tabs_and_legend_area.height,
         ));
 
         self.selected_example.render(demo_buf.area, &mut demo_buf);
 
         // render tabs into a separate buffer
-        let mut tabs_buf = Buffer::empty(tabs_area);
-        self.render_tabs(tabs_area, &mut tabs_buf);
+        let mut tabs_and_legend_buf = Buffer::empty(tabs_and_legend_area);
+        self.render_tabs_and_legend(tabs_and_legend_area, &mut tabs_and_legend_buf);
 
         // Assemble both buffers
         // NOTE: You shouldn't do this in a production app
-        buf.content = tabs_buf.content;
+        buf.content = tabs_and_legend_buf.content;
         buf.content.append(
             &mut demo_buf
                 .content
@@ -237,22 +267,8 @@ impl ExampleSelection {
     fn render_fixed_example(&self, area: Rect, buf: &mut Buffer) {
         let [example1, example2, _] = area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 3]));
 
-        // Fixed(40), Proportional(0)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌──────────────────────────────────────┐┌────────┐
-        // │                 40 px                ││  10 px │
-        // └──────────────────────────────────────┘└────────┘
         Example::new([Fixed(40), Proportional(0)]).render(example1, buf);
 
-        // Fixed(20), Fixed(20), Proportional(0)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌──────────────────┐┌──────────────────┐┌────────┐
-        // │       20 px      ││       20 px      ││  10 px │
-        // └──────────────────┘└──────────────────┘└────────┘
         Example::new([Fixed(20), Fixed(20), Proportional(0)]).render(example2, buf);
     }
 
@@ -260,40 +276,12 @@ impl ExampleSelection {
         let [example1, example2, example3, example4, _] =
             area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 5]));
 
-        // Length(20), Fixed(20)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────┐┌──────────────────┐
-        // │            30 px           ││       20 px      │
-        // └────────────────────────────┘└──────────────────┘
         Example::new([Length(20), Fixed(20)]).render(example1, buf);
 
-        // Length(20), Length(20)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌──────────────────┐┌────────────────────────────┐
-        // │       20 px      ││            30 px           │
-        // └──────────────────┘└────────────────────────────┘
         Example::new([Length(20), Length(20)]).render(example2, buf);
 
-        // Length(20), Min(20)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌──────────────────┐┌────────────────────────────┐
-        // │       20 px      ││            30 px           │
-        // └──────────────────┘└────────────────────────────┘
         Example::new([Length(20), Min(20)]).render(example3, buf);
 
-        // Length(20), Max(20)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────┐┌──────────────────┐
-        // │            30 px           ││       20 px      │
-        // └────────────────────────────┘└──────────────────┘
         Example::new([Length(20), Max(20)]).render(example4, buf);
     }
 
@@ -301,50 +289,14 @@ impl ExampleSelection {
         let [example1, example2, example3, example4, example5, _] =
             area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 6]));
 
-        // Percentage(75), Proportional(0)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
-        //
         Example::new([Percentage(75), Proportional(0)]).render(example1, buf);
 
-        // Percentage(25), Proportional(0)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
         Example::new([Percentage(25), Proportional(0)]).render(example2, buf);
 
-        // Percentage(50), Min(20)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌───────────────────────┐┌───────────────────────┐
-        // │         25 px         ││         25 px         │
-        // └───────────────────────┘└───────────────────────┘
         Example::new([Percentage(50), Min(20)]).render(example3, buf);
 
-        // Percentage(0), Max(0)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
         Example::new([Percentage(0), Max(0)]).render(example4, buf);
 
-        // Percentage(0), Proportional(0)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
         Example::new([Percentage(0), Proportional(0)]).render(example5, buf);
     }
 
@@ -352,111 +304,35 @@ impl ExampleSelection {
         let [example1, example2, example3, example4, _] =
             area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 5]));
 
-        // Ratio(1, 2), Ratio(1, 2)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌───────────────────────┐┌───────────────────────┐
-        // │         25 px         ││         25 px         │
-        // └───────────────────────┘└───────────────────────┘
         Example::new([Ratio(1, 2); 2]).render(example1, buf);
 
-        // Ratio(1, 4), Ratio(1, 4), Ratio(1, 4), Ratio(1, 4)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌───────────┐┌──────────┐┌───────────┐┌──────────┐
-        // │   13 px   ││   12 px  ││   13 px   ││   12 px  │
-        // └───────────┘└──────────┘└───────────┘└──────────┘
         Example::new([Ratio(1, 4); 4]).render(example2, buf);
 
-        // Ratio(1, 2), Ratio(1, 3), Ratio(1, 4)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌───────────────────────┐┌───────────────┐┌──────┐
-        // │         25 px         ││     17 px     ││ 8 px │
-        // └───────────────────────┘└───────────────┘└──────┘
         Example::new([Ratio(1, 2), Ratio(1, 3), Ratio(1, 4)]).render(example3, buf);
 
-        // Ratio(1, 2), Percentage(25), Length(10)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌───────────────────────┐┌───────────┐┌──────────┐
-        // │         25 px         ││   13 px   ││   12 px  │
-        // └───────────────────────┘└───────────┘└──────────┘
         Example::new([Ratio(1, 2), Percentage(25), Length(10)]).render(example4, buf);
     }
 
     fn render_proportional_example(&self, area: Rect, buf: &mut Buffer) {
         let [example1, example2, _] = area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 3]));
 
-        // Proportional(1), Proportional(2), Proportional(3)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌──────┐┌───────────────┐┌───────────────────────┐
-        // │ 8 px ││     17 px     ││         25 px         │
-        // └──────┘└───────────────┘└───────────────────────┘
         Example::new([Proportional(1), Proportional(2), Proportional(3)]).render(example1, buf);
 
-        // Proportional(1), Percentage(50), Proportional(1)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌───────────┐┌───────────────────────┐┌──────────┐
-        // │   13 px   ││         25 px         ││   12 px  │
-        // └───────────┘└───────────────────────┘└──────────┘
         Example::new([Proportional(1), Percentage(50), Proportional(1)]).render(example2, buf);
     }
 
     fn render_min_example(&self, area: Rect, buf: &mut Buffer) {
         let [example1, example2, example3, example4, example5, _] =
             area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 6]));
-        // Percentage(100), Min(0)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
+
         Example::new([Percentage(100), Min(0)]).render(example1, buf);
 
-        // Percentage(100), Min(20)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────┐┌──────────────────┐
-        // │            30 px           ││       20 px      │
-        // └────────────────────────────┘└──────────────────┘
         Example::new([Percentage(100), Min(20)]).render(example2, buf);
 
-        // Percentage(100), Min(40)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────┐┌──────────────────────────────────────┐
-        // │  10 px ││                 40 px                │
-        // └────────┘└──────────────────────────────────────┘
         Example::new([Percentage(100), Min(40)]).render(example3, buf);
 
-        // Percentage(100), Min(60)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
         Example::new([Percentage(100), Min(60)]).render(example4, buf);
 
-        // Percentage(100), Min(80)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
         Example::new([Percentage(100), Min(80)]).render(example5, buf);
     }
 
@@ -464,50 +340,14 @@ impl ExampleSelection {
         let [example1, example2, example3, example4, example5, _] =
             area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 6]));
 
-        // Percentage(0), Max(0)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
         Example::new([Percentage(0), Max(0)]).render(example1, buf);
 
-        //
-        // Percentage(0), Max(20)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────┐┌──────────────────┐
-        // │            30 px           ││       20 px      │
-        // └────────────────────────────┘└──────────────────┘
         Example::new([Percentage(0), Max(20)]).render(example2, buf);
 
-        // Percentage(0), Max(40)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────┐┌──────────────────────────────────────┐
-        // │  10 px ││                 40 px                │
-        // └────────┘└──────────────────────────────────────┘
         Example::new([Percentage(0), Max(40)]).render(example3, buf);
 
-        // Percentage(0), Max(60)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
         Example::new([Percentage(0), Max(60)]).render(example4, buf);
 
-        // Percentage(0), Max(80)
-        //
-        // <---------------------50 px---------------------->
-        //
-        // ┌────────────────────────────────────────────────┐
-        // │                      50 px                     │
-        // └────────────────────────────────────────────────┘
         Example::new([Percentage(0), Max(80)]).render(example5, buf);
     }
 }
@@ -529,10 +369,7 @@ impl Example {
 
 impl Widget for Example {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let [legend, area] = area.split(&Layout::vertical([Ratio(1, 3); 2]));
         let blocks = Layout::horizontal(&self.constraints).split(area);
-
-        self.legend(legend.width as usize).render(legend, buf);
 
         for (block, constraint) in blocks.iter().zip(&self.constraints) {
             let text = format!("{} px", block.width);
@@ -551,23 +388,6 @@ impl Widget for Example {
 }
 
 impl Example {
-    fn legend(&self, width: usize) -> Paragraph {
-        // a bar like `<----- 80 px ----->`
-        let width_label = format!("{} px", width);
-        let width_bar = format!(
-            "<{width_label:-^width$}>",
-            width = width - width_label.len() / 2
-        );
-        Paragraph::new(width_bar.dark_gray())
-            .alignment(Alignment::Center)
-            .block(Block::default().padding(Padding {
-                left: 0,
-                right: 0,
-                top: 1,
-                bottom: 0,
-            }))
-    }
-
     fn illustration(&self, constraint: Constraint, text: String, fg: Color) -> Paragraph {
         Paragraph::new(format!("{:?}", constraint))
             .alignment(Alignment::Center)

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -394,12 +394,17 @@ impl Widget for Example {
 
 impl Example {
     fn illustration(&self, constraint: Constraint, text: String, fg: Color) -> Paragraph {
-        Paragraph::new(format!("{:?}", constraint))
+        Paragraph::new(format!(" {constraint} ").fg(fg))
+            .style(Color::DarkGray)
             .alignment(Alignment::Center)
             .block(
                 Block::bordered()
-                    .style(Style::default().fg(fg))
-                    .title(block::Title::from(text).alignment(Alignment::Center)),
+                    .style(Style::default().fg(Color::DarkGray))
+                    .title(
+                        block::Title::from(format!("{text}"))
+                            .alignment(Alignment::Right)
+                            .position(block::Position::Bottom),
+                    ),
             )
     }
 }

--- a/examples/constraints.tape
+++ b/examples/constraints.tape
@@ -4,7 +4,7 @@ Output "target/constraints.gif"
 Set Theme "Aardvark Blue"
 Set FontSize 18
 Set Width 1200
-Set Height 1200
+Set Height 700
 Hide
 Type "cargo run --example=constraints --features=crossterm"
 Enter

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -45,17 +45,15 @@ const EXAMPLE_DATA: &[(&str, &[Constraint])] = &[
     ("", &[Min(20), Max(20), Length(20), Fixed(20)]),
     ("`Proportional(u16)` always fills up space in every `Flex` layout", &[Proportional(0), Proportional(0)]),
     (
-        "`Proportional()` can be to scale with respect to other `Proportional()`",
-        &[Proportional(1), Proportional(2), Length(20), Fixed(20)],
+        "`Proportional(1)` can be to scale with respect to other `Proportional(2)`",
+        &[Proportional(1), Proportional(2)],
     ),
     (
-        "",
+        "`Proportional(0)` collapses if there are other non-zero `Proportional(_)`\nconstraints. e.g. `[Proportional(0), Proportional(0), Proportional(1)]`:",
         &[
-            Min(10),
-            Proportional(3),
-            Proportional(2),
-            Length(15),
-            Fixed(15),
+            Proportional(0),
+            Proportional(0),
+            Proportional(1),
         ],
     ),
 ];

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -309,38 +309,37 @@ impl Widget for Example {
             .split(area);
 
         for (block, constraint) in blocks.iter().zip(&self.constraints) {
-            let text = format!("{} px", block.width);
-            let fg = match constraint {
-                Constraint::Ratio(_, _) => Color::Indexed(1),
-                Constraint::Percentage(_) => Color::Indexed(2),
-                Constraint::Max(_) => Color::Indexed(3),
-                Constraint::Min(_) => Color::Indexed(4),
-                Constraint::Length(_) => Color::Indexed(5),
-                Constraint::Fixed(_) => Color::Indexed(6),
-                Constraint::Proportional(_) => Color::Indexed(7),
-            };
             let [block, _] = block.split(&Layout::vertical([
                 Fixed(ILLUSTRATION_HEIGHT),
                 Fixed(SPACER_HEIGHT),
             ]));
-            self.illustration(*constraint, text, fg).render(block, buf);
+            self.illustration(*constraint, block.width)
+                .render(block, buf);
         }
     }
 }
 
 impl Example {
-    fn illustration(&self, constraint: Constraint, text: String, fg: Color) -> Paragraph {
-        Paragraph::new(format!(" {constraint} ").fg(fg))
+    fn illustration(&self, constraint: Constraint, width: u16) -> Paragraph {
+        let text = format!("{} px", width);
+        let fg = match constraint {
+            Constraint::Ratio(_, _) => Color::Indexed(1),
+            Constraint::Percentage(_) => Color::Indexed(2),
+            Constraint::Max(_) => Color::Indexed(3),
+            Constraint::Min(_) => Color::Indexed(4),
+            Constraint::Length(_) => Color::Indexed(5),
+            Constraint::Fixed(_) => Color::Indexed(6),
+            Constraint::Proportional(_) => Color::Indexed(7),
+        };
+        let title = format!("{constraint}").fg(fg);
+        let content = format!("{text}");
+        Paragraph::new(content)
             .style(Color::DarkGray)
             .alignment(Alignment::Center)
             .block(
                 Block::bordered()
                     .style(Style::default().fg(Color::DarkGray))
-                    .title(
-                        block::Title::from(format!("{text}"))
-                            .alignment(Alignment::Right)
-                            .position(block::Position::Bottom),
-                    ),
+                    .title(block::Title::from(title).alignment(Alignment::Center)),
             )
     }
 }

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -321,7 +321,6 @@ impl Widget for Example {
 
 impl Example {
     fn illustration(&self, constraint: Constraint, width: u16) -> Paragraph {
-        let text = format!("{} px", width);
         let fg = match constraint {
             Constraint::Ratio(_, _) => Color::Indexed(1),
             Constraint::Percentage(_) => Color::Indexed(2),
@@ -332,7 +331,7 @@ impl Example {
             Constraint::Proportional(_) => Color::Indexed(7),
         };
         let title = format!("{constraint}").fg(fg);
-        let content = format!("{text}");
+        let content = format!("{width} px");
         Paragraph::new(content)
             .style(Color::DarkGray)
             .alignment(Alignment::Center)

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -92,9 +92,9 @@ fn main() -> Result<()> {
     let terminal = init_terminal()?;
 
     // Each line in the example is a layout
-    // so EXAMPLE_HEIGHT * N_EXAMPLES_PER_TAB = 55 currently
+    // so 13 examples * 7 = 91 currently
     // Plus additional layout for tabs ...
-    Layout::init_cache(100);
+    Layout::init_cache(120);
 
     App::default().run(terminal)?;
 
@@ -130,6 +130,8 @@ impl App {
                 Char('h') | Left => self.previous(),
                 Char('j') | Down => self.down(),
                 Char('k') | Up => self.up(),
+                Char('g') | Home => self.top(),
+                Char('G') | End => self.bottom(),
                 _ => (),
             },
             _ => {}
@@ -154,6 +156,14 @@ impl App {
             .scroll_offset
             .saturating_add(1)
             .min(max_scroll_offset())
+    }
+
+    fn top(&mut self) {
+        self.scroll_offset = 0;
+    }
+
+    fn bottom(&mut self) {
+        self.scroll_offset = max_scroll_offset();
     }
 
     fn quit(&mut self) {

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -12,7 +12,7 @@ use ratatui::{
     widgets::{block::Title, *},
 };
 
-const SPACER_HEIGHT: u16 = 1;
+const SPACER_HEIGHT: u16 = 0;
 const ILLUSTRATION_HEIGHT: u16 = 4;
 const EXAMPLE_HEIGHT: u16 = ILLUSTRATION_HEIGHT + SPACER_HEIGHT;
 const N_EXAMPLES_PER_TAB: u16 = 11;

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -279,19 +279,19 @@ impl SelectedTab {
 impl Widget for SelectedTab {
     fn render(self, area: Rect, buf: &mut Buffer) {
         match self {
-            SelectedTab::StretchLast => self.render_example(area, buf, Flex::StretchLast),
-            SelectedTab::Stretch => self.render_example(area, buf, Flex::Stretch),
-            SelectedTab::Start => self.render_example(area, buf, Flex::Start),
-            SelectedTab::Center => self.render_example(area, buf, Flex::Center),
-            SelectedTab::End => self.render_example(area, buf, Flex::End),
-            SelectedTab::SpaceAround => self.render_example(area, buf, Flex::SpaceAround),
-            SelectedTab::SpaceBetween => self.render_example(area, buf, Flex::SpaceBetween),
+            SelectedTab::StretchLast => self.render_examples(area, buf, Flex::StretchLast),
+            SelectedTab::Stretch => self.render_examples(area, buf, Flex::Stretch),
+            SelectedTab::Start => self.render_examples(area, buf, Flex::Start),
+            SelectedTab::Center => self.render_examples(area, buf, Flex::Center),
+            SelectedTab::End => self.render_examples(area, buf, Flex::End),
+            SelectedTab::SpaceAround => self.render_examples(area, buf, Flex::SpaceAround),
+            SelectedTab::SpaceBetween => self.render_examples(area, buf, Flex::SpaceBetween),
         }
     }
 }
 
 impl SelectedTab {
-    fn render_example(&self, area: Rect, buf: &mut Buffer, flex: Flex) {
+    fn render_examples(&self, area: Rect, buf: &mut Buffer, flex: Flex) {
         let heights = EXAMPLE_DATA
             .iter()
             .map(|(desc, _)| if desc.is_empty() { 4 } else { 5 });
@@ -321,10 +321,12 @@ impl Widget for Example {
             .flex(self.flex)
             .split(illustrations);
 
-        format!("// {}", self.description)
-            .italic()
-            .fg(Color::from_str("#908caa").unwrap())
-            .render(title, buf);
+        if !self.description.is_empty() {
+            format!("// {}", self.description)
+                .italic()
+                .fg(Color::from_str("#908caa").unwrap())
+                .render(title, buf);
+        }
 
         for (block, constraint) in blocks.iter().zip(&self.constraints) {
             self.illustration(*constraint, block.width)

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -179,13 +179,13 @@ impl From<ExampleSelection> for Line<'static> {
         .try_into()
         .unwrap();
         match example {
-            StretchLast => "  StretchLast  ".bg(stretch_last).into(),
-            Stretch => "  Stretch  ".bg(stretch).into(),
-            Start => "  Start  ".bg(start).into(),
-            Center => "  Center  ".bg(center).into(),
-            End => "  End  ".bg(end).into(),
-            SpaceAround => " SpaceAround  ".bg(space_around).into(),
-            SpaceBetween => "  SpaceBetween  ".bg(space_between).into(),
+            StretchLast => " StretchLast ".bg(stretch_last).into(),
+            Stretch => " Stretch ".bg(stretch).into(),
+            Start => " Start ".bg(start).into(),
+            Center => " Center ".bg(center).into(),
+            End => " End ".bg(end).into(),
+            SpaceAround => " SpaceAround ".bg(space_around).into(),
+            SpaceBetween => " SpaceBetween ".bg(space_between).into(),
         }
     }
 }

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -364,11 +364,7 @@ impl Widget for Example {
             Paragraph::new(
                 self.description
                     .split('\n')
-                    .map(|s| {
-                        format!("// {}", s)
-                            .italic()
-                            .fg(Color::from_str("#908caa").unwrap())
-                    })
+                    .map(|s| format!("// {}", s).italic().fg(tailwind::SLATE.c400))
                     .map(Line::from)
                     .collect::<Vec<Line>>(),
             )

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -330,12 +330,17 @@ impl Widget for Example {
 
 impl Example {
     fn illustration(&self, constraint: Constraint, text: String, fg: Color) -> Paragraph {
-        Paragraph::new(format!("{:?}", constraint))
+        Paragraph::new(format!(" {constraint} ").fg(fg))
+            .style(Color::DarkGray)
             .alignment(Alignment::Center)
             .block(
                 Block::bordered()
-                    .style(Style::default().fg(fg))
-                    .title(block::Title::from(text).alignment(Alignment::Center)),
+                    .style(Style::default().fg(Color::DarkGray))
+                    .title(
+                        block::Title::from(format!("{text}"))
+                            .alignment(Alignment::Right)
+                            .position(block::Position::Bottom),
+                    ),
             )
     }
 }

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -133,7 +133,19 @@ impl App {
                 ExampleSelection::SpaceBetween,
             ]
             .iter()
-            .map(|e| format!("{:?}", e)),
+            .enumerate()
+            .map(|(i, e)| {
+                format!(
+                    "{indicator}{e:?}",
+                    indicator = {
+                        if i == self.selected_example.selected() {
+                            " \u{2022} "
+                        } else {
+                            "   "
+                        }
+                    }
+                )
+            }),
         )
         .block(
             Block::bordered()
@@ -142,7 +154,8 @@ impl App {
         )
         .highlight_style(Style::default().yellow().bold())
         .select(self.selected_example.selected())
-        .padding(" ", " ")
+        .divider("")
+        .padding("", "")
         .render(area, buf);
     }
 }

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -1,7 +1,4 @@
-use std::{
-    io::{self, stdout},
-    str::FromStr,
-};
+use std::io::{self, stdout};
 
 use color_eyre::{config::HookBuilder, Result};
 use crossterm::{

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -237,21 +237,38 @@ impl App {
         // render demo content into a separate buffer so all examples fit we add an extra
         // area.height to make sure the last example is fully visible even when the scroll offset is
         // at the max
-        let height = example_height() + area.height;
-        let mut demo_buf = Buffer::empty(Rect { height, ..area });
+        let height = example_height();
         let demo_area = Rect::new(0, 0, area.width, height);
-        self.selected_tab.render(demo_buf.area, &mut demo_buf);
+        let mut demo_buf = Buffer::empty(demo_area);
 
-        // Splice the visible area into the main buffer
-        let start = buf.index_of(area.left(), area.top());
-        let end = buf.content.len().min(start + area.area() as usize);
+        let scrollbar_needed = self.scroll_offset != 0 || height > area.height;
+        let content_area = if scrollbar_needed {
+            Rect {
+                width: demo_area.width - 1,
+                ..demo_area
+            }
+        } else {
+            demo_area
+        };
+        self.selected_tab.render(content_area, &mut demo_buf);
 
         let visible_content = demo_buf
             .content
             .into_iter()
-            .skip((demo_area.width * self.scroll_offset) as usize)
+            .skip((area.width * self.scroll_offset) as usize)
             .take(area.area() as usize);
-        buf.content.splice(start..end, visible_content);
+        for (i, cell) in visible_content.enumerate() {
+            let x = i as u16 % area.width;
+            let y = i as u16 / area.width;
+            *buf.get_mut(area.x + x, area.y + y) = cell;
+        }
+
+        if scrollbar_needed {
+            let area = area.intersection(buf.area);
+            let mut state = ScrollbarState::new(max_scroll_offset() as usize)
+                .position(self.scroll_offset as usize);
+            Scrollbar::new(ScrollbarOrientation::VerticalRight).render(area, buf, &mut state);
+        }
     }
 }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/ratatui-org/ratatui/pull/811.

It improves the UI of the layouts by

- thoughtful accessible color that represent priority in constraints resolving
- using QUADRANT_OUTSIDE symbol set for block rendering
- adding a scrollbar
- panic handling
- refactoring for readability

to name a few. Here are some example gifs of the outcome:

![constraints](https://github.com/ratatui-org/ratatui/assets/381361/8eed34cf-e959-472f-961b-d439bfe3324e)

![flex](https://github.com/ratatui-org/ratatui/assets/381361/3195a56c-9cb6-4525-bc1c-b969c0d6a812)
