### PR TITLE
feat: implement Display for Text, Line, Span

### DIFF
--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -381,6 +381,15 @@ impl Widget for Line<'_> {
     }
 }
 
+impl std::fmt::Display for Line<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for span in &self.spans {
+            write!(f, "{span}")?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -563,6 +572,28 @@ mod tests {
                 StyledGrapheme::new("!", BLUE_ON_WHITE),
             ],
         );
+    }
+
+    #[test]
+    fn display_line_from_vec() {
+        let line_from_vec = Line::from(vec![Span::raw("Hello,"), Span::raw(" world!")]);
+
+        assert_eq!(format!("{line_from_vec}"), "Hello, world!");
+    }
+
+    #[test]
+    fn display_styled_line() {
+        let styled_line = Line::styled("Hello, world!", Style::new().green().italic());
+
+        assert_eq!(format!("{styled_line}"), "Hello, world!");
+    }
+
+    #[test]
+    fn display_line_from_styled_span() {
+        let styled_span = Span::styled("Hello, world!", Style::new().green().italic());
+        let line_from_styled_span = Line::from(styled_span);
+
+        assert_eq!(format!("{line_from_styled_span}"), "Hello, world!");
     }
 
     mod widget {

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -331,6 +331,12 @@ impl Widget for Span<'_> {
     }
 }
 
+impl std::fmt::Display for Span<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.content)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -448,6 +454,19 @@ mod tests {
         let stylized = span.on_yellow().bold();
         assert_eq!(stylized.content, Cow::Borrowed("test content"));
         assert_eq!(stylized.style, Style::new().green().on_yellow().bold());
+    }
+    #[test]
+    fn display_span() {
+        let span = Span::raw("test content");
+
+        assert_eq!(format!("{span}"), "test content");
+    }
+
+    #[test]
+    fn display_styled_span() {
+        let stylized_span = Span::styled("stylized test content", Style::new().green());
+
+        assert_eq!(format!("{stylized_span}"), "stylized test content");
     }
 
     mod widget {

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use itertools::{Itertools, Position};
+
 use crate::prelude::*;
 
 /// A string split over multiple lines where each line is composed of several clusters, each with
@@ -225,6 +227,19 @@ where
     }
 }
 
+impl std::fmt::Display for Text<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (position, line) in self.lines.iter().with_position() {
+            if position == Position::Last {
+                write!(f, "{line}")?;
+            } else {
+                writeln!(f, "{line}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -409,6 +424,53 @@ mod tests {
                 Line::from("The third line"),
                 Line::from("The fourth line"),
             ]
+        );
+    }
+
+    #[test]
+    fn display_raw_text() {
+        let text = Text::raw("The first line\nThe second line");
+
+        assert_eq!(format!("{text}"), "The first line\nThe second line");
+    }
+
+    #[test]
+    fn display_styled_text() {
+        let styled_text = Text::styled(
+            "The first line\nThe second line",
+            Style::new().yellow().italic(),
+        );
+
+        assert_eq!(format!("{styled_text}"), "The first line\nThe second line");
+    }
+
+    #[test]
+    fn display_text_from_vec() {
+        let text_from_vec = Text::from(vec![
+            Line::from("The first line"),
+            Line::from("The second line"),
+        ]);
+
+        assert_eq!(
+            format!("{text_from_vec}"),
+            "The first line\nThe second line"
+        );
+    }
+
+    #[test]
+    fn display_extended_text() {
+        let mut text = Text::from("The first line\nThe second line");
+
+        assert_eq!(format!("{text}"), "The first line\nThe second line");
+
+        text.extend(vec![
+            Line::from("The third line"),
+            Line::from("The fourth line"),
+        ]);
+
+        assert_eq!(
+            format!("{text}"),
+            "The first line\nThe second line\nThe third line\nThe fourth line"
         );
     }
 }


### PR DESCRIPTION
Issue: https://github.com/ratatui-org/ratatui/issues/816

This PR adds:

`std::fmt::Display` for `Text`, `Line`, and `Span` structs.

Display implementation displays actual content while ignoring style.