### PR TITLE
fix: bug with flex stretch with spacing and proportional constraints 

### DIFF
--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -2201,6 +2201,29 @@ mod tests {
         }
 
         #[test]
+        fn flex_spacing_with_proportional() {
+            Layout::init_cache(1);
+            let [a, _, b] = Rect::new(0, 0, 100, 1).split(
+                &Layout::horizontal([Proportional(1), Fixed(2), Proportional(1)])
+                    .flex(Flex::StretchLast)
+                    .spacing(0),
+            );
+            assert_eq!([(a.x, a.width), (b.x, b.width)], [(0, 49), (51, 49)]);
+
+            // println!("----------------------------------------------------");
+
+            // TODO: broken test
+            // this should be identical to the previous results
+            Layout::init_cache(1);
+            let [a, b] = Rect::new(0, 0, 100, 1).split(
+                &Layout::horizontal([Proportional(1), Proportional(1)])
+                    .flex(Flex::StretchLast)
+                    .spacing(2),
+            );
+            assert_ne!([(a.x, a.width), (b.x, b.width)], [(0, 49), (51, 49)]);
+        }
+
+        #[test]
         fn flex() {
             // length should be spaced around
             let [a, _b, c] = Rect::new(0, 0, 100, 1).split(

--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -543,7 +543,7 @@ impl Layout {
         // If we changed our default layout to use `Flex::Start`, there is a case to be made for
         // this to do `Flex::Start` as well.
         //
-        let flex = if layout.constraints.len() == 1 && layout.flex == Flex::SpaceBetween {
+        let flex = if constraints.len() == 1 && layout.flex == Flex::SpaceBetween {
             Flex::Stretch
         } else {
             layout.flex
@@ -770,8 +770,7 @@ impl Layout {
         // └──────┘└────────────┘
         //
         // size == base_element * scaling_factor
-        for ((&l_constraint, &l_element), (&r_constraint, &r_element)) in layout
-            .constraints
+        for ((&l_constraint, &l_element), (&r_constraint, &r_element)) in constraints
             .iter()
             .zip(elements.iter())
             .filter(|(c, _)| matches!(c, Constraint::Proportional(_)))
@@ -2210,17 +2209,13 @@ mod tests {
             );
             assert_eq!([(a.x, a.width), (b.x, b.width)], [(0, 49), (51, 49)]);
 
-            // println!("----------------------------------------------------");
-
-            // TODO: broken test
-            // this should be identical to the previous results
             Layout::init_cache(1);
             let [a, b] = Rect::new(0, 0, 100, 1).split(
                 &Layout::horizontal([Proportional(1), Proportional(1)])
                     .flex(Flex::StretchLast)
                     .spacing(2),
             );
-            assert_ne!([(a.x, a.width), (b.x, b.width)], [(0, 49), (51, 49)]);
+            assert_eq!([(a.x, a.width), (b.x, b.width)], [(0, 49), (51, 49)]);
         }
 
         #[test]


### PR DESCRIPTION
This PR fixes a bug with layouts when using spacing on proportional constraints.