### PR TITLE
feat: update table example and table.tape

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -341,6 +341,6 @@ examples/generate.bash
 [ratatui-logo.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/ratatui-logo.gif?raw=true
 [scrollbar.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/scrollbar.gif?raw=true
 [sparkline.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/sparkline.gif?raw=true
-[table.gif]: https://vhs.charm.sh/vhs-3ZNUeRBLSo8nleJgD4KxuM.gif
+[table.gif]:  https://vhs.charm.sh/vhs-6njXBytDf0rwPufUtmSSpI.gif
 [tabs.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/tabs.gif?raw=true
 [user_input.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/user_input.gif?raw=true

--- a/examples/README.md
+++ b/examples/README.md
@@ -341,6 +341,6 @@ examples/generate.bash
 [ratatui-logo.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/ratatui-logo.gif?raw=true
 [scrollbar.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/scrollbar.gif?raw=true
 [sparkline.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/sparkline.gif?raw=true
-[table.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/table.gif?raw=true
+[table.gif]: https://vhs.charm.sh/vhs-3ZNUeRBLSo8nleJgD4KxuM.gif
 [tabs.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/tabs.gif?raw=true
 [user_input.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/user_input.gif?raw=true

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, io, str::FromStr};
+use std::{error::Error, io};
 
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
@@ -7,17 +7,32 @@ use crossterm::{
 };
 use itertools::Itertools;
 use ratatui::{prelude::*, widgets::*};
+use style::palette::material;
+
+const EXAMPLE_TABLE_COLORS: [material::AccentedPalette; 4] = [
+    material::RED,
+    material::GREEN,
+    material::BLUE,
+    material::ORANGE,
+];
+const INFO_TEXT: &str =
+    "(q) to quit / (j, ↑) to go up / (k, ↓) to go down / (l, →) for next color / (h, ←) for previous color";
 
 struct App {
     state: TableState,
     items: Vec<Vec<String>>,
+    scroll_state: ScrollbarState,
+    color_index: usize,
 }
 
 impl App {
     fn new() -> App {
+        let items = generate_fake_names();
         App {
             state: TableState::default().with_selected(0),
-            items: generate_fake_names(),
+            scroll_state: ScrollbarState::new((items.len() - 1) * 4),
+            color_index: 0,
+            items,
         }
     }
     pub fn next(&mut self) {
@@ -32,6 +47,7 @@ impl App {
             None => 0,
         };
         self.state.select(Some(i));
+        self.scroll_state = self.scroll_state.position(i * 4);
     }
 
     pub fn previous(&mut self) {
@@ -46,6 +62,23 @@ impl App {
             None => 0,
         };
         self.state.select(Some(i));
+        self.scroll_state = self.scroll_state.position(i * 4);
+    }
+
+    pub fn next_color(&mut self) {
+        if self.color_index >= EXAMPLE_TABLE_COLORS.len() - 1 {
+            self.color_index = 0;
+        } else {
+            self.color_index += 1;
+        }
+    }
+
+    pub fn previous_color(&mut self) {
+        if self.color_index == 0 {
+            self.color_index = EXAMPLE_TABLE_COLORS.len() - 1;
+        } else {
+            self.color_index -= 1
+        }
     }
 }
 
@@ -107,6 +140,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                     KeyCode::Char('q') => return Ok(()),
                     KeyCode::Down | KeyCode::Char('j') => app.next(),
                     KeyCode::Up | KeyCode::Char('k') => app.previous(),
+                    KeyCode::Right | KeyCode::Char('l') => app.next_color(),
+                    KeyCode::Left | KeyCode::Char('h') => app.previous_color(),
                     _ => {}
                 }
             }
@@ -115,15 +150,22 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
 }
 
 fn ui(f: &mut Frame, app: &mut App) {
-    let rects = Layout::vertical([Constraint::Percentage(100)]).split(f.size());
+    let rects = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .split(f.size());
 
-    // colors from https://tailwindcss.com/docs/customizing-colors
-    let header_bg = Color::from_str("#1e3a8a").unwrap();
-    let header_fg = Color::from_str("#eff6ff").unwrap();
+    let curr_color = EXAMPLE_TABLE_COLORS[app.color_index];
+
+    let buffer_bg = curr_color.c900;
+    let header_bg = curr_color.c900;
+    let header_fg = material::WHITE;
     let header_style = Style::default().fg(header_fg).bg(header_bg);
-    let normal_row_color = Color::from_str("#1e293b").unwrap();
-    let alt_row_color = Color::from_str("#0f172a").unwrap();
+    let row_fg = material::GRAY.c100;
+    let normal_row_color = curr_color.c600;
+    let alt_row_color = curr_color.c400;
     let selected_style = Style::default().add_modifier(Modifier::REVERSED);
+    let footer_border_color = curr_color.c400;
 
     let header = ["Name", "Address", "Email"]
         .iter()
@@ -141,16 +183,16 @@ fn ui(f: &mut Frame, app: &mut App) {
             .cloned()
             .map(|content| Cell::from(Text::from(format!("\n{}\n", content))))
             .collect::<Row>()
-            .style(Style::new().bg(color))
+            .style(Style::new().fg(row_fg).bg(color))
             .height(4)
     });
     let bar = " █ ";
     let t = Table::new(
         rows,
         [
-            Constraint::Length(15),
+            Constraint::Length(25),
+            Constraint::Min(40),
             Constraint::Min(30),
-            Constraint::Min(25),
         ],
     )
     .header(header)
@@ -161,6 +203,29 @@ fn ui(f: &mut Frame, app: &mut App) {
         bar.into(),
         "".into(),
     ]))
+    .bg(buffer_bg)
     .highlight_spacing(HighlightSpacing::Always);
     f.render_stateful_widget(t, rects[0], &mut app.state);
+    f.render_stateful_widget(
+        Scrollbar::default()
+            .orientation(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None),
+        rects[0].inner(&Margin {
+            vertical: 1,
+            horizontal: 1,
+        }),
+        &mut app.scroll_state,
+    );
+
+    let info_footer = Paragraph::new(Line::from(INFO_TEXT))
+        .style(Style::new().fg(row_fg).bg(buffer_bg))
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::new().fg(footer_border_color))
+                .border_type(BorderType::Double),
+        );
+    f.render_widget(info_footer, rects[1]);
 }

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -57,6 +57,18 @@ impl Data {
     fn ref_array(&self) -> [&String; 3] {
         [&self.name, &self.address, &self.email]
     }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn address(&self) -> &str {
+        &self.address
+    }
+
+    fn email(&self) -> &str {
+        &self.email
+    }
 }
 
 struct App {
@@ -261,22 +273,27 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn constraint_len_calculator(items: &[Data]) -> (u16, u16, u16) {
-    items
+    let name_len = items
         .iter()
-        .map(|row| {
-            (
-                UnicodeWidthStr::width(row.name.as_str()) as u16,
-                row.address
-                    .lines()
-                    .map(UnicodeWidthStr::width)
-                    .max()
-                    .unwrap_or(0) as u16,
-                UnicodeWidthStr::width(row.email.as_str()) as u16,
-            )
-        })
-        .fold((0, 0, 0), |acc, row| {
-            (acc.0.max(row.0), acc.1.max(row.1), acc.2.max(row.2))
-        })
+        .map(Data::name)
+        .map(UnicodeWidthStr::width)
+        .max()
+        .unwrap_or(0);
+    let address_len = items
+        .iter()
+        .map(Data::address)
+        .flat_map(str::lines)
+        .map(UnicodeWidthStr::width)
+        .max()
+        .unwrap_or(0);
+    let email_len = items
+        .iter()
+        .map(Data::email)
+        .map(UnicodeWidthStr::width)
+        .max()
+        .unwrap_or(0);
+
+    (name_len as u16, address_len as u16, email_len as u16)
 }
 
 fn render_scrollbar(f: &mut Frame, app: &mut App, area: Rect) {

--- a/examples/table.tape
+++ b/examples/table.tape
@@ -1,30 +1,25 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
 # To run this script, install vhs and run `vhs ./examples/table.tape`
 Output "target/table.gif"
-Set Width 1600
-Set Height 864
+Set Theme "Aardvark Blue"
+Set Width 1400
+Set Height 768
 Hide
 Type "cargo run --example=table --features=crossterm"
 Enter
 Sleep 1s
 Show
 Sleep 2s
-Set TypingSpeed 0.75s
+Set TypingSpeed 1s
+Down 3
+Up 5
 Down 2
-Up 2
-Down 2
+Sleep 1s
 Right 1
-Down 2
+Sleep 1s
 Right 1
-Down 2
+Sleep 1s
 Right 1
-Down 2
+Sleep 1s
 Right 1
-Left 3
-Up 3
-Right 1
-Up 3
-Right 1
-Set TypingSpeed 0.4s
-Up 7
 Sleep 2s

--- a/examples/table.tape
+++ b/examples/table.tape
@@ -12,8 +12,9 @@ Show
 Sleep 2s
 Set TypingSpeed 1s
 Down 3
-Up 5
-Down 2
+Up 6
+Sleep 1s
+Down 3
 Sleep 1s
 Right 1
 Sleep 1s

--- a/examples/table.tape
+++ b/examples/table.tape
@@ -1,19 +1,30 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
 # To run this script, install vhs and run `vhs ./examples/table.tape`
 Output "target/table.gif"
-Set Theme "Aardvark Blue"
-Set Width 1200
-Set Height 800
+Set Width 1600
+Set Height 896
 Hide
 Type "cargo run --example=table --features=crossterm"
 Enter
 Sleep 1s
 Show
 Sleep 2s
-Set TypingSpeed 0.5s
+Set TypingSpeed 0.75s
 Down 2
 Up 2
-Down 8
-Up 12
-Down 4
+Down 2
+Right 1
+Down 2
+Right 1
+Down 2
+Right 1
+Down 2
+Right 1
+Left 3
+Up 3
+Right 1
+Up 3
+Right 1
+Set TypingSpeed 0.4s
+Up 7
 Sleep 2s

--- a/examples/table.tape
+++ b/examples/table.tape
@@ -2,7 +2,7 @@
 # To run this script, install vhs and run `vhs ./examples/table.tape`
 Output "target/table.gif"
 Set Width 1600
-Set Height 896
+Set Height 864
 Hide
 Type "cargo run --example=table --features=crossterm"
 Enter


### PR DESCRIPTION
Issue: https://github.com/ratatui-org/ratatui/issues/800

This PR adds:

for table.rs
- scrollbar to the table
- colors changed to style::palette::material::AccentedPalette
- now colors can be changed with keys (l or →) for the next color, (h or ←) for the previous color
- added a footer for key info

for table.tape
- typing speed changed to 0.75s from 0.5s
- screen size changed to 1600x864 from 1200x800
- pushed keys changed to show the current example better

I'll push the new GIF to the images branch. Edit: https://github.com/ratatui-org/ratatui/pull/841