### PR TITLE
docs(examples): document incompatible examples better

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ for more info.
 
 The following example demonstrates the minimal amount of code necessary to setup a terminal and
 render "Hello World!". The full code for this example which contains a little more detail is in
-[hello_world.rs]. For more guidance on different ways to structure your application see the
-[Application Patterns] and [Hello World tutorial] sections in the [Ratatui Website] and the various
-[Examples]. There are also several starter templates in the [templates] repository.
+the [Examples] directory. For more guidance on different ways to structure your application see
+the [Application Patterns] and [Hello World tutorial] sections in the [Ratatui Website] and the
+various [Examples]. There are also several starter templates available in the [templates]
+repository.
 
 Every application built with `ratatui` needs to implement the following steps:
 
@@ -289,8 +290,8 @@ Running this example produces the following output:
 [Handling Events]: https://ratatui.rs/concepts/event-handling/
 [Layout]: https://ratatui.rs/how-to/layout/
 [Styling Text]: https://ratatui.rs/how-to/render/style-text/
-[templates]: https://github.com/ratatui-org/templates
-[Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples
+[templates]: https://github.com/ratatui-org/templates/
+[Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
 [Report a bug]: https://github.com/ratatui-org/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
 [Request a Feature]: https://github.com/ratatui-org/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
 [Create a Pull Request]: https://github.com/ratatui-org/ratatui/compare
@@ -321,7 +322,6 @@ Running this example produces the following output:
 [Termion]: https://crates.io/crates/termion
 [Termwiz]: https://crates.io/crates/termwiz
 [tui-rs]: https://crates.io/crates/tui
-[hello_world.rs]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 [Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square
 [License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square
 [CI Badge]:
@@ -387,9 +387,8 @@ The library comes with the following
 - [Table](https://docs.rs/ratatui/latest/ratatui/widgets/struct.Table.html)
 - [Tabs](https://docs.rs/ratatui/latest/ratatui/widgets/struct.Tabs.html)
 
-Each widget has an associated example which can be found in the [examples](./examples/) folder. Run
-each examples with cargo (e.g. to run the gauge example `cargo run --example gauge`), and quit by
-pressing `q`.
+Each widget has an associated example which can be found in the [Examples] folder. Run each example
+with cargo (e.g. to run the gauge example `cargo run --example gauge`), and quit by pressing `q`.
 
 You can also run all examples by running `cargo make run-examples` (requires `cargo-make` that can
 be installed with `cargo install cargo-make`).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,8 @@
 # Examples
 
+This folder contains unreleased code. View the [examples for the latest release
+(0.25.0)](https://github.com/ratatui-org/ratatui/tree/v0.25.0/examples) instead.
+
 > [!WARNING]
 >
 > There are backwards incompatible changes in these examples, as they are designed to compile

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,22 +1,24 @@
 # Examples
 
 > [!WARNING]
-> The examples in this folder run against the `main` branch. There may be backwards
-> incompatible changes compared to the [latest stable version](https://github.com/ratatui-org/ratatui/releases/latest).
 >
-> If you find that code copied from an example fails to run in your own application, please check
-> the tag of the release that your project is using.
+> There are backwards incompatible changes in these examples, as they are designed to compile
+> against the `main` branch.
 >
-> To view examples that match the version of Ratatui that you are using checkout the matching tag in
-> your local git repository, or select the tag in the "Switch branches/tags" button if you're
-> viewing this file on GitHub.
+> There are a few workaround for this problem:
 >
-> To use incompatible example code as is, you can also use the most recent alpha release of Ratatui
-> (we release these weekly).
-
-These gifs were created using [VHS](https://github.com/charmbracelet/vhs). Each example has a
-corresponding `.tape` file that holds instructions for how to generate the images. Note that the
-images themselves are stored in a separate git branch to avoid bloating the main repository.
+> - View the examples as they were when the latest version was release by selecting the tag that
+>   matches that version. E.g. <https://github.com/ratatui-org/ratatui/tree/v0.25.0/examples>. There
+>   is a combo box at the top of this page which allows you to select any previous tagged version.
+> - To view the code locally, checkout the tag using `git switch --detach v0.25.0`.
+> - Use the latest [alpha version of Ratatui]. These are released weekly on Saturdays.
+> - Compile your code against the main branch either locally by adding e.g. `path = "../ratatui"` to
+>   the dependency, or remotely by adding `git = "https://github.com/ratatui-org/ratatui"`
+>
+> For a list of unreleased breaking changes, see [BREAKING-CHANGES.md].
+>
+> We don't keep the CHANGELOG updated with unreleased changes, check the git commit history or run
+> `git-cliff -u` against a cloned version of this repository.
 
 ## Demo2
 
@@ -310,11 +312,18 @@ cargo run --example=user_input --features=crossterm
 
 ![User Input][user_input.gif]
 
-<!--
-links to images to make it easier to update in bulk
-These are generated with `vhs publish examples/xxx.gif`
+## How to update these examples
 
-To update these examples in bulk:
+These gifs were created using [VHS](https://github.com/charmbracelet/vhs). Each example has a
+corresponding `.tape` file that holds instructions for how to generate the images. Note that the
+images themselves are stored in a separate `images` git branch to avoid bloating the main
+repository.
+
+<!--
+
+Links to images to make them easier to update in bulk. Use the following script to update and upload
+the examples to the images branch. (Requires push access to the branch).
+
 ```shell
 examples/generate.bash
 ```
@@ -344,3 +353,6 @@ examples/generate.bash
 [table.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/table.gif?raw=true
 [tabs.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/tabs.gif?raw=true
 [user_input.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/user_input.gif?raw=true
+
+[alpha version of Ratatui]: https://crates.io/crates/ratatui/versions
+[BREAKING-CHANGES.md]: https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -38,7 +38,7 @@
 //! # std::io::Result::Ok(())
 //! ```
 //!
-//! See the the [examples] directory for more examples.
+//! See the the [Examples] directory for more examples.
 //!
 //! # Raw Mode
 //!
@@ -96,7 +96,7 @@
 //! [Crossterm]: https://crates.io/crates/crossterm
 //! [Termion]: https://crates.io/crates/termion
 //! [Termwiz]: https://crates.io/crates/termwiz
-//! [examples]: https://github.com/ratatui-org/ratatui/tree/main/examples#readme
+//! [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
 //! [Backend Comparison]:
 //!     https://ratatui.rs/concepts/backends/comparison/
 //! [Ratatui Website]: https://ratatui-org.github.io/ratatui-book

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -70,14 +70,14 @@ use crate::{
 /// # std::io::Result::Ok(())
 /// ```
 ///
-/// See the the [examples] directory for more examples. See the [`backend`] module documentation
+/// See the the [Examples] directory for more examples. See the [`backend`] module documentation
 /// for more details on raw mode and alternate screen.
 ///
 /// [`Write`]: std::io::Write
 /// [`Terminal`]: crate::terminal::Terminal
 /// [`backend`]: crate::backend
 /// [Crossterm]: https://crates.io/crates/crossterm
-/// [examples]: https://github.com/ratatui-org/ratatui/tree/main/examples#examples
+/// [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct CrosstermBackend<W: Write> {
     /// The writer used to send commands to the terminal.

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -52,14 +52,14 @@ use crate::{
 /// # std::result::Result::Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
-/// See the the [examples] directory for more examples. See the [`backend`] module documentation
+/// See the the [Examples] directory for more examples. See the [`backend`] module documentation
 /// for more details on raw mode and alternate screen.
 ///
 /// [`backend`]: crate::backend
 /// [`Terminal`]: crate::terminal::Terminal
 /// [`BufferedTerminal`]: termwiz::terminal::buffered::BufferedTerminal
 /// [Termwiz]: https://crates.io/crates/termwiz
-/// [examples]: https://github.com/ratatui-org/ratatui/tree/main/examples#readme
+/// [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
 pub struct TermwizBackend {
     buffered_terminal: BufferedTerminal<SystemTerminal>,
 }

--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -34,9 +34,9 @@ thread_local! {
 /// many of the constraints as possible.
 ///
 /// By default, the last chunk of the computed layout is expanded to fill the remaining space. To
-/// avoid this behavior, add an unused `Constraint::Min(0)` as the last constraint. There is also
-/// an unstable API to prefer equal chunks if other constraints are all satisfied, see
-/// [`SegmentSize`] for more info.
+/// avoid this behavior, add an unused `Constraint::Min(0)` as the last constraint. There is also an
+/// unstable API to prefer equal chunks if other constraints are all satisfied, see [`SegmentSize`]
+/// for more info.
 ///
 /// When the layout is computed, the result is cached in a thread-local cache, so that subsequent
 /// calls with the same parameters are faster. The cache is a simple HashMap, and grows
@@ -78,10 +78,10 @@ thread_local! {
 /// }
 /// ```
 ///
-/// The [`layout.rs` example](https://github.com/ratatui-org/ratatui/blob/main/examples/layout.rs)
-/// shows the effect of combining constraints:
+/// See the `layout`, `flex`, and `constraints` examples in the [Examples] folder for more details
+/// about how to use layouts.
 ///
-/// ![layout
+/// [Examples]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md ![layout
 /// example](https://camo.githubusercontent.com/77d22f3313b782a81e5e033ef82814bb48d786d2598699c27f8e757ccee62021/68747470733a2f2f7668732e636861726d2e73682f7668732d315a4e6f4e4c4e6c4c746b4a58706767396e435635652e676966)
 ///
 /// [`cassowary-rs`]: https://crates.io/crates/cassowary

--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -81,10 +81,11 @@ thread_local! {
 /// See the `layout`, `flex`, and `constraints` examples in the [Examples] folder for more details
 /// about how to use layouts.
 ///
-/// [Examples]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md ![layout
+/// ![layout
 /// example](https://camo.githubusercontent.com/77d22f3313b782a81e5e033ef82814bb48d786d2598699c27f8e757ccee62021/68747470733a2f2f7668732e636861726d2e73682f7668732d315a4e6f4e4c4e6c4c746b4a58706767396e435635652e676966)
 ///
 /// [`cassowary-rs`]: https://crates.io/crates/cassowary
+/// [Examples]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Layout {
     direction: Direction,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,8 @@
 //!
 //! The following example demonstrates the minimal amount of code necessary to setup a terminal and
 //! render "Hello World!". The full code for this example which contains a little more detail is in
-//! [hello_world.rs]. For more guidance on different ways to structure your application see the
-//! [Application Patterns] and [Hello World tutorial] sections in the [Ratatui Website] and the
+//! the [Examples] directory. For more guidance on different ways to structure your application see
+//! the [Application Patterns] and [Hello World tutorial] sections in the [Ratatui Website] and the
 //! various [Examples]. There are also several starter templates available in the [templates]
 //! repository.
 //!
@@ -288,7 +288,7 @@
 //! [Layout]: https://ratatui.rs/how-to/layout/
 //! [Styling Text]: https://ratatui.rs/how-to/render/style-text/
 //! [templates]: https://github.com/ratatui-org/templates/
-//! [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples
+//! [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
 //! [Report a bug]: https://github.com/ratatui-org/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
 //! [Request a Feature]: https://github.com/ratatui-org/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
 //! [Create a Pull Request]: https://github.com/ratatui-org/ratatui/compare
@@ -319,7 +319,6 @@
 //! [Termion]: https://crates.io/crates/termion
 //! [Termwiz]: https://crates.io/crates/termwiz
 //! [tui-rs]: https://crates.io/crates/tui
-//! [hello_world.rs]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 //! [Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square
 //! [License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square
 //! [CI Badge]:

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -21,10 +21,10 @@ use crate::{
 /// [`offset`]: ListState::offset()
 /// [`selected`]: ListState::selected()
 ///
-/// See the [list example] for a more in depth example of the various configuration options and
-/// for how to handle state.
+/// See the list in the [Examples] directory for a more in depth example of the various
+/// configuration options and for how to handle state.
 ///
-/// [list example]: https://github.com/ratatui-org/ratatui/blob/main/examples/list.rs
+/// [Examples]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 ///
 /// # Example
 ///
@@ -364,10 +364,10 @@ where
 /// the user to [scroll](ListState::offset) through items and [select](ListState::select) one of
 /// them.
 ///
-/// See the [list example] for a more in depth example of the various configuration options and for
-/// how to handle state.
+/// See the list in the [Examples] directory for a more in depth example of the various
+/// configuration options and for how to handle state.
 ///
-/// [list example]: https://github.com/ratatui-org/ratatui/blob/main/examples/list.rs
+/// [Examples]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 ///
 /// # Fluent setters
 ///

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -26,11 +26,11 @@ use crate::{
 ///
 /// Note: if the `widths` field is empty, the table will be rendered with equal widths.
 ///
-/// See the [table example] and the recipe and traceroute tabs in the [demo2 example] for a more in
-/// depth example of the various configuration options and for how to handle state.
+/// See the table example and the recipe and traceroute tabs in the demo2 example in the [Examples]
+/// directory for a more in depth example of the various configuration options and for how to handle
+/// state.
 ///
-/// [table example]: https://github.com/ratatui-org/ratatui/blob/master/examples/table.rs
-/// [demo2 example]: https://github.com/ratatui-org/ratatui/blob/master/examples/demo2/
+/// [Examples]: https://github.com/ratatui-org/ratatui/blob/master/examples/README.md
 ///
 /// # Constructor methods
 ///

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -12,11 +12,11 @@
 /// [`offset`]: TableState::offset()
 /// [`selected`]: TableState::selected()
 ///
-/// See the [table example] and the recipe and traceroute tabs in the [demo2 example] for a more in
-/// depth example of the various configuration options and for how to handle state.
+/// See the `table`` example and the `recipe`` and `traceroute`` tabs in the demo2 example in the
+/// [Examples] directory for a more in depth example of the various configuration options and for
+/// how to handle state.
 ///
-/// [table example]: https://github.com/ratatui-org/ratatui/blob/master/examples/table.rs
-/// [demo2 example]: https://github.com/ratatui-org/ratatui/blob/master/examples/demo2/
+/// [Examples]: https://github.com/ratatui-org/ratatui/blob/master/examples/README.md
 ///
 /// # Example
 ///


### PR DESCRIPTION
Examples often take advantage of unreleased API changes, which makes them not copy-paste friendly.
