### PR TITLE
feat(symbols): add wide and tall proportional border set

### DIFF
--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -425,8 +425,9 @@ pub mod border {
         horizontal_bottom: ONE_EIGHTH_BOTTOM_EIGHT,
     };
 
-    /// Wide proportional border with using set of quadrants.
-    /// The border is created using half blocks for top and bottom, and full
+    /// Wide proportional (visually equal width and height) border with using set of quadrants.
+    ///
+    /// The border is created by using half blocks for top and bottom, and full
     /// blocks for right and left sides to make horizontal and vertical borders seem equal.
     ///
     /// ```text
@@ -446,9 +447,10 @@ pub mod border {
         horizontal_bottom: QUADRANT_TOP_HALF,
     };
 
-    /// Tall proportional border with using set of quadrants.
-    /// The border is created using full blocks for all sides, except for the top and bottom,
-    /// which use half blocks to make horizontal and vertical borders seem equal
+    /// Tall proportional (visually equal width and height) border with using set of quadrants.
+    ///
+    /// The border is created by using full blocks for all sides, except for the top and bottom,
+    /// which use half blocks to make horizontal and vertical borders seem equal.
     ///
     /// ```text
     /// ▕█▀▀█

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -424,6 +424,48 @@ pub mod border {
         horizontal_top: ONE_EIGHTH_TOP_EIGHT,
         horizontal_bottom: ONE_EIGHTH_BOTTOM_EIGHT,
     };
+
+    /// Wide proportional border with using set of quadrants.
+    /// The border is created using half blocks for top and bottom, and full
+    /// blocks for right and left sides to make horizontal and vertical borders seem equal.
+    ///
+    /// ```text
+    /// ▄▄▄▄
+    /// █xx█
+    /// █xx█
+    /// ▀▀▀▀
+    /// ```
+    pub const PROPORTIONAL_WIDE: Set = Set {
+        top_right: QUADRANT_BOTTOM_HALF,
+        top_left: QUADRANT_BOTTOM_HALF,
+        bottom_right: QUADRANT_TOP_HALF,
+        bottom_left: QUADRANT_TOP_HALF,
+        vertical_left: QUADRANT_BLOCK,
+        vertical_right: QUADRANT_BLOCK,
+        horizontal_top: QUADRANT_BOTTOM_HALF,
+        horizontal_bottom: QUADRANT_TOP_HALF,
+    };
+
+    /// Tall proportional border with using set of quadrants.
+    /// The border is created using full blocks for all sides, except for the top and bottom,
+    /// which use half blocks to make horizontal and vertical borders seem equal
+    ///
+    /// ```text
+    /// ▕█▀▀█
+    /// ▕█xx█
+    /// ▕█xx█
+    /// ▕█▄▄█
+    /// ```
+    pub const PROPORTIONAL_TALL: Set = Set {
+        top_right: QUADRANT_BLOCK,
+        top_left: QUADRANT_BLOCK,
+        bottom_right: QUADRANT_BLOCK,
+        bottom_left: QUADRANT_BLOCK,
+        vertical_left: QUADRANT_BLOCK,
+        vertical_right: QUADRANT_BLOCK,
+        horizontal_top: QUADRANT_TOP_HALF,
+        horizontal_bottom: QUADRANT_BOTTOM_HALF,
+    };
 }
 
 pub const DOT: &str = "•";


### PR DESCRIPTION
Adds `PROPORTIONAL_WIDE` and `PROPORTIONAL_TALL` border sets.

`symbols::border::PROPORTIONAL_WIDE`
```
▄▄▄▄
█xx█
█xx█
▀▀▀▀
```

`symbols::border::PROPORTIONAL_TALL`
```
█▀▀█
█xx█
█xx█
█▄▄█
```

Fixes: https://github.com/ratatui-org/ratatui/issues/834
