### PR TITLE
test(Scrollbar): Backport new scrollbar implementation's tests

### DIFF
--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -708,29 +708,34 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_renders_empty_with_content_length_is_zero() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, 8));
-        let mut state = ScrollbarState::default().position(0);
+    #[rstest]
+    #[case("        ", 0)]
+    #[case("████████", 1)]
+    #[case("████████", 2)]
+    #[case("████████", 3)]
+    #[case("████████", 4)]
+    #[case("████████", 5)]
+    #[case("████████", 6)]
+    #[case("████████", 7)]
+    #[case("████████", 8)]
+    fn test_renders_empty_with_content_length_is_zero(
+        #[case] expected: &str,
+        #[case] content_length: usize,
+    ) {
+        let size = expected.width();
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, size as u16));
+        let mut state = ScrollbarState::new(content_length).position(0);
         Scrollbar::default()
             .begin_symbol(None)
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec!["  ", "  ", "  ", "  ", "  ", "  ", "  ", "  "])
-        );
-
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, 8));
-        let mut state = ScrollbarState::new(8).position(0);
-        Scrollbar::default()
-            .begin_symbol(None)
-            .end_symbol(None)
-            .render(buffer.area, &mut buffer, &mut state);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![" █", " █", " █", " █", " █", " █", " █", " █"])
-        );
+        let empty_string: String = " ".repeat(size);
+        let bar = empty_string
+            .chars()
+            .zip(expected.chars())
+            .map(|(a, b)| format!("{a}{b}"))
+            .collect_vec();
+        assert_buffer_eq!(buffer, Buffer::with_lines(bar));
     }
 
     #[test]

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -1133,8 +1133,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case("█═", 0, 2, "position_0")]
-    #[case("═█", 1, 2, "position_1")]
+    #[case("██", 0, 2, "position_0")]
+    #[case("██", 1, 2, "position_1")]
     fn render_scrollbar_simplest(
         #[case] expected: &str,
         #[case] position: usize,
@@ -1160,16 +1160,16 @@ mod tests {
     }
 
     #[rstest]
-    #[case("#####-----", 0, 10, "position_0")]
-    #[case("-#####----", 1, 10, "position_1")]
-    #[case("-#####----", 2, 10, "position_2")]
-    #[case("--#####---", 3, 10, "position_3")]
-    #[case("--#####---", 4, 10, "position_4")]
-    #[case("---#####--", 5, 10, "position_5")]
-    #[case("---#####--", 6, 10, "position_6")]
-    #[case("----#####-", 7, 10, "position_7")]
-    #[case("----#####-", 8, 10, "position_8")]
-    #[case("-----#####", 9, 10, "position_9")]
+    #[case("##########", 0, 10, "position_0")]
+    #[case("##########", 1, 10, "position_1")]
+    #[case("##########", 2, 10, "position_2")]
+    #[case("##########", 3, 10, "position_3")]
+    #[case("##########", 4, 10, "position_4")]
+    #[case("##########", 5, 10, "position_5")]
+    #[case("##########", 6, 10, "position_6")]
+    #[case("##########", 7, 10, "position_7")]
+    #[case("##########", 8, 10, "position_8")]
+    #[case("##########", 9, 10, "position_9")]
     fn render_scrollbar_simple(
         #[case] expected: &str,
         #[case] position: usize,
@@ -1253,8 +1253,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case("#########-", 0, 2, "position_0")]
-    #[case("-#########", 1, 2, "position_1")]
+    #[case("##########", 0, 2, "position_0")]
+    #[case("##########", 1, 2, "position_1")]
     fn render_scrollbar_almost_fullbar(
         #[case] expected: &str,
         #[case] position: usize,
@@ -1281,191 +1281,191 @@ mod tests {
         );
     }
 
-    // #[rstest]
-    // #[case("█████═════", 0, 10, "position_0")]
-    // #[case("═█████════", 1, 10, "position_1")]
-    // #[case("═█████════", 2, 10, "position_2")]
-    // #[case("══█████═══", 3, 10, "position_3")]
-    // #[case("══█████═══", 4, 10, "position_4")]
-    // #[case("═══█████══", 5, 10, "position_5")]
-    // #[case("═══█████══", 6, 10, "position_6")]
-    // #[case("════█████═", 7, 10, "position_7")]
-    // #[case("════█████═", 8, 10, "position_8")]
-    // #[case("═════█████", 9, 10, "position_9")]
-    // #[case("═════█████", 100, 10, "position_out_of_bounds")]
-    // fn render_scrollbar_without_symbols(
-    //     #[case] expected: &str,
-    //     #[case] position: usize,
-    //     #[case] content_length: usize,
-    //     #[case] assertion_message: &str,
-    // ) {
-    //     let size = expected.width() as u16;
-    //     let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
-    //     let mut state = ScrollbarState::default()
-    //         .position(position)
-    //         .content_length(content_length);
-    //     Scrollbar::default()
-    //         .orientation(ScrollbarOrientation::HorizontalBottom)
-    //         .begin_symbol(None)
-    //         .end_symbol(None)
-    //         .render(buffer.area, &mut buffer, &mut state);
-    //     assert_eq!(
-    //         buffer,
-    //         Buffer::with_lines(vec![expected]),
-    //         "{}",
-    //         assertion_message
-    //     );
-    // }
-    //
-    // #[rstest]
-    // #[case("<####---->", 0, 10, "position_0")]
-    // #[case("<#####--->", 1, 10, "position_1")]
-    // #[case("<-####--->", 2, 10, "position_2")]
-    // #[case("<-####--->", 3, 10, "position_3")]
-    // #[case("<--####-->", 4, 10, "position_4")]
-    // #[case("<--####-->", 5, 10, "position_5")]
-    // #[case("<---####->", 6, 10, "position_6")]
-    // #[case("<---####->", 7, 10, "position_7")]
-    // #[case("<---#####>", 8, 10, "position_8")]
-    // #[case("<----####>", 9, 10, "position_9")]
-    // #[case("<----####>", 10, 10, "position_one_out_of_bounds")]
-    // #[case("<----####>", 15, 10, "position_few_out_of_bounds")]
-    // #[case("<----####>", 500, 10, "position_very_many_out_of_bounds")]
-    // fn render_scrollbar_with_symbols(
-    //     #[case] expected: &str,
-    //     #[case] position: usize,
-    //     #[case] content_length: usize,
-    //     #[case] assertion_message: &str,
-    // ) {
-    //     let size = expected.width() as u16;
-    //     let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
-    //     let mut state = ScrollbarState::default()
-    //         .position(position)
-    //         .content_length(content_length);
-    //     Scrollbar::default()
-    //         .orientation(ScrollbarOrientation::HorizontalTop)
-    //         .begin_symbol(Some("<"))
-    //         .end_symbol(Some(">"))
-    //         .track_symbol(Some("-"))
-    //         .thumb_symbol("#")
-    //         .render(buffer.area, &mut buffer, &mut state);
-    //     assert_eq!(
-    //         buffer,
-    //         Buffer::with_lines(vec![expected]),
-    //         "{}",
-    //         assertion_message,
-    //     );
-    // }
-    //
-    // #[rstest]
-    // #[case("█████═════", 0, 10, "position_0")]
-    // #[case("═█████════", 1, 10, "position_1")]
-    // #[case("═█████════", 2, 10, "position_2")]
-    // #[case("══█████═══", 3, 10, "position_3")]
-    // #[case("══█████═══", 4, 10, "position_4")]
-    // #[case("═══█████══", 5, 10, "position_5")]
-    // #[case("═══█████══", 6, 10, "position_6")]
-    // #[case("════█████═", 7, 10, "position_7")]
-    // #[case("════█████═", 8, 10, "position_8")]
-    // #[case("═════█████", 9, 10, "position_9")]
-    // #[case("═════█████", 100, 10, "position_out_of_bounds")]
-    // fn render_scrollbar_twoline_horizontal(
-    //     #[case] expected: &str,
-    //     #[case] position: usize,
-    //     #[case] content_length: usize,
-    //     #[case] assertion_message: &str,
-    // ) {
-    //     let size = expected.width() as u16;
-    //     let mut buffer = Buffer::empty(Rect::new(0, 0, size, 2));
-    //     let mut state = ScrollbarState::default()
-    //         .position(position)
-    //         .content_length(content_length);
-    //     Scrollbar::default()
-    //         .orientation(ScrollbarOrientation::HorizontalBottom)
-    //         .begin_symbol(None)
-    //         .end_symbol(None)
-    //         .render(buffer.area, &mut buffer, &mut state);
-    //     let empty_string: String = " ".repeat(size as usize);
-    //     assert_eq!(
-    //         buffer,
-    //         Buffer::with_lines(vec![&empty_string, expected]),
-    //         "{}",
-    //         assertion_message
-    //     );
-    //
-    //     let mut buffer = Buffer::empty(Rect::new(0, 0, size, 2));
-    //     let mut state = ScrollbarState::default()
-    //         .position(position)
-    //         .content_length(content_length);
-    //     Scrollbar::default()
-    //         .orientation(ScrollbarOrientation::HorizontalTop)
-    //         .begin_symbol(None)
-    //         .end_symbol(None)
-    //         .render(buffer.area, &mut buffer, &mut state);
-    //     let empty_string: String = " ".repeat(size as usize);
-    //     assert_eq!(
-    //         buffer,
-    //         Buffer::with_lines(vec![expected, &empty_string]),
-    //         "{}",
-    //         assertion_message
-    //     );
-    // }
-    //
-    // #[rstest]
-    // #[case("<####---->", 0, 10, "position_0")]
-    // #[case("<#####--->", 1, 10, "position_1")]
-    // #[case("<-####--->", 2, 10, "position_2")]
-    // #[case("<-####--->", 3, 10, "position_3")]
-    // #[case("<--####-->", 4, 10, "position_4")]
-    // #[case("<--####-->", 5, 10, "position_5")]
-    // #[case("<---####->", 6, 10, "position_6")]
-    // #[case("<---####->", 7, 10, "position_7")]
-    // #[case("<---#####>", 8, 10, "position_8")]
-    // #[case("<----####>", 9, 10, "position_9")]
-    // #[case("<----####>", 10, 10, "position_one_out_of_bounds")]
-    // fn render_scrollbar_twoline_vertical(
-    //     #[case] expected: &str,
-    //     #[case] position: usize,
-    //     #[case] content_length: usize,
-    //     #[case] assertion_message: &str,
-    // ) {
-    //     let size = expected.width() as u16;
-    //     let mut buffer = Buffer::empty(Rect::new(0, 0, 2, size));
-    //     let mut state = ScrollbarState::default()
-    //         .position(position)
-    //         .content_length(content_length);
-    //     Scrollbar::default()
-    //         .orientation(ScrollbarOrientation::VerticalRight)
-    //         .begin_symbol(Some("<"))
-    //         .end_symbol(Some(">"))
-    //         .track_symbol(Some("-"))
-    //         .thumb_symbol("#")
-    //         .render(buffer.area, &mut buffer, &mut state);
-    //     let empty_string: String = " ".repeat(size as usize);
-    //     let bar = empty_string
-    //         .chars()
-    //         .zip(expected.chars())
-    //         .map(|(a, b)| format!("{a}{b}"))
-    //         .collect_vec();
-    //     assert_eq!(buffer, Buffer::with_lines(bar), "{}", assertion_message);
-    //
-    //     let mut buffer = Buffer::empty(Rect::new(0, 0, 2, size));
-    //     let mut state = ScrollbarState::default()
-    //         .position(position)
-    //         .content_length(content_length);
-    //     Scrollbar::default()
-    //         .orientation(ScrollbarOrientation::VerticalLeft)
-    //         .begin_symbol(Some("<"))
-    //         .end_symbol(Some(">"))
-    //         .track_symbol(Some("-"))
-    //         .thumb_symbol("#")
-    //         .render(buffer.area, &mut buffer, &mut state);
-    //     let empty_string: String = " ".repeat(size as usize);
-    //     let bar = expected
-    //         .chars()
-    //         .zip(empty_string.chars())
-    //         .map(|(a, b)| format!("{a}{b}"))
-    //         .collect_vec();
-    //     assert_eq!(buffer, Buffer::with_lines(bar), "{}", assertion_message);
-    // }
+    #[rstest]
+    #[case("██████████", 0, 10, "position_0")]
+    #[case("██████████", 1, 10, "position_1")]
+    #[case("██████████", 2, 10, "position_2")]
+    #[case("██████████", 3, 10, "position_3")]
+    #[case("██████████", 4, 10, "position_4")]
+    #[case("██████████", 5, 10, "position_5")]
+    #[case("██████████", 6, 10, "position_6")]
+    #[case("██████████", 7, 10, "position_7")]
+    #[case("██████████", 8, 10, "position_8")]
+    #[case("██████████", 9, 10, "position_9")]
+    #[case("██████████", 100, 10, "position_out_of_bounds")]
+    fn render_scrollbar_without_symbols(
+        #[case] expected: &str,
+        #[case] position: usize,
+        #[case] content_length: usize,
+        #[case] assertion_message: &str,
+    ) {
+        let size = expected.width() as u16;
+        let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
+        let mut state = ScrollbarState::default()
+            .position(position)
+            .content_length(content_length);
+        Scrollbar::default()
+            .orientation(ScrollbarOrientation::HorizontalBottom)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .render(buffer.area, &mut buffer, &mut state);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![expected]),
+            "{}",
+            assertion_message
+        );
+    }
+
+    #[rstest]
+    #[case("<######-->", 0, 10, "position_0")]
+    #[case("<######-->", 1, 10, "position_1")]
+    #[case("<######-->", 2, 10, "position_2")]
+    #[case("<-######->", 3, 10, "position_3")]
+    #[case("<-######->", 4, 10, "position_4")]
+    #[case("<-######->", 5, 10, "position_5")]
+    #[case("<-######->", 6, 10, "position_6")]
+    #[case("<-######->", 7, 10, "position_7")]
+    #[case("<--######>", 8, 10, "position_8")]
+    #[case("<--######>", 9, 10, "position_9")]
+    #[case("<--######>", 10, 10, "position_one_out_of_bounds")]
+    #[case("<--######>", 15, 10, "position_few_out_of_bounds")]
+    #[case("<--######>", 500, 10, "position_very_many_out_of_bounds")]
+    fn render_scrollbar_with_symbols(
+        #[case] expected: &str,
+        #[case] position: usize,
+        #[case] content_length: usize,
+        #[case] assertion_message: &str,
+    ) {
+        let size = expected.width() as u16;
+        let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
+        let mut state = ScrollbarState::default()
+            .position(position)
+            .content_length(content_length);
+        Scrollbar::default()
+            .orientation(ScrollbarOrientation::HorizontalTop)
+            .begin_symbol(Some("<"))
+            .end_symbol(Some(">"))
+            .track_symbol(Some("-"))
+            .thumb_symbol("#")
+            .render(buffer.area, &mut buffer, &mut state);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![expected]),
+            "{}",
+            assertion_message,
+        );
+    }
+
+    #[rstest]
+    #[case("██████████", 0, 10, "position_0")]
+    #[case("██████████", 1, 10, "position_1")]
+    #[case("██████████", 2, 10, "position_2")]
+    #[case("██████████", 3, 10, "position_3")]
+    #[case("██████████", 4, 10, "position_4")]
+    #[case("██████████", 5, 10, "position_5")]
+    #[case("██████████", 6, 10, "position_6")]
+    #[case("██████████", 7, 10, "position_7")]
+    #[case("██████████", 8, 10, "position_8")]
+    #[case("██████████", 9, 10, "position_9")]
+    #[case("██████████", 100, 10, "position_out_of_bounds")]
+    fn render_scrollbar_twoline_horizontal(
+        #[case] expected: &str,
+        #[case] position: usize,
+        #[case] content_length: usize,
+        #[case] assertion_message: &str,
+    ) {
+        let size = expected.width() as u16;
+        let mut buffer = Buffer::empty(Rect::new(0, 0, size, 2));
+        let mut state = ScrollbarState::default()
+            .position(position)
+            .content_length(content_length);
+        Scrollbar::default()
+            .orientation(ScrollbarOrientation::HorizontalBottom)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .render(buffer.area, &mut buffer, &mut state);
+        let empty_string: String = " ".repeat(size as usize);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![&empty_string, expected]),
+            "{}",
+            assertion_message
+        );
+
+        let mut buffer = Buffer::empty(Rect::new(0, 0, size, 2));
+        let mut state = ScrollbarState::default()
+            .position(position)
+            .content_length(content_length);
+        Scrollbar::default()
+            .orientation(ScrollbarOrientation::HorizontalTop)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .render(buffer.area, &mut buffer, &mut state);
+        let empty_string: String = " ".repeat(size as usize);
+        assert_eq!(
+            buffer,
+            Buffer::with_lines(vec![expected, &empty_string]),
+            "{}",
+            assertion_message
+        );
+    }
+
+    #[rstest]
+    #[case("<######-->", 0, 10, "position_0")]
+    #[case("<######-->", 1, 10, "position_1")]
+    #[case("<######-->", 2, 10, "position_2")]
+    #[case("<-######->", 3, 10, "position_3")]
+    #[case("<-######->", 4, 10, "position_4")]
+    #[case("<-######->", 5, 10, "position_5")]
+    #[case("<-######->", 6, 10, "position_6")]
+    #[case("<-######->", 7, 10, "position_7")]
+    #[case("<--######>", 8, 10, "position_8")]
+    #[case("<--######>", 9, 10, "position_9")]
+    #[case("<--######>", 10, 10, "position_one_out_of_bounds")]
+    fn render_scrollbar_twoline_vertical(
+        #[case] expected: &str,
+        #[case] position: usize,
+        #[case] content_length: usize,
+        #[case] assertion_message: &str,
+    ) {
+        let size = expected.width() as u16;
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, size));
+        let mut state = ScrollbarState::default()
+            .position(position)
+            .content_length(content_length);
+        Scrollbar::default()
+            .orientation(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("<"))
+            .end_symbol(Some(">"))
+            .track_symbol(Some("-"))
+            .thumb_symbol("#")
+            .render(buffer.area, &mut buffer, &mut state);
+        let empty_string: String = " ".repeat(size as usize);
+        let bar = empty_string
+            .chars()
+            .zip(expected.chars())
+            .map(|(a, b)| format!("{a}{b}"))
+            .collect_vec();
+        assert_eq!(buffer, Buffer::with_lines(bar), "{}", assertion_message);
+
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, size));
+        let mut state = ScrollbarState::default()
+            .position(position)
+            .content_length(content_length);
+        Scrollbar::default()
+            .orientation(ScrollbarOrientation::VerticalLeft)
+            .begin_symbol(Some("<"))
+            .end_symbol(Some(">"))
+            .track_symbol(Some("-"))
+            .thumb_symbol("#")
+            .render(buffer.area, &mut buffer, &mut state);
+        let empty_string: String = " ".repeat(size as usize);
+        let bar = expected
+            .chars()
+            .zip(empty_string.chars())
+            .map(|(a, b)| format!("{a}{b}"))
+            .collect_vec();
+        assert_eq!(buffer, Buffer::with_lines(bar), "{}", assertion_message);
+    }
 }


### PR DESCRIPTION
This PR backports the tests from https://github.com/ratatui-org/ratatui/pull/847
The backported tests are made to pass with the current (i.e. old) implementation, so that a reference can be established for the changes in the new implementation.