### PR TITLE
docs(examples): update list example and list.tape

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,8 +1,4 @@
-use std::{
-    error::Error,
-    io,
-    time::{Duration, Instant},
-};
+use std::{error::Error, io};
 
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
@@ -12,21 +8,58 @@ use crossterm::{
 use ratatui::{prelude::*, style::palette::tailwind, widgets::*};
 
 const TODO_HEADER_BG: Color = tailwind::BLUE.c950;
-const BG: Color = tailwind::SLATE.c950;
 const NORMAL_ROW_COLOR: Color = tailwind::SLATE.c950;
 const ALT_ROW_COLOR: Color = tailwind::SLATE.c900;
 const SELECTED_STYLE_FG: Color = tailwind::BLUE.c300;
 const TEXT_COLOR: Color = tailwind::SLATE.c200;
 const COMPLETED_TEXT_COLOR: Color = tailwind::GREEN.c600;
 
-struct StatefulList<T> {
+struct TodoItem {
+    todo: String,
+    info: String,
+    status: bool,
+}
+
+impl TodoItem {
+    fn styled_list_item(&self, index: usize) -> ListItem {
+        let bg_color = match index % 2 {
+            0 => NORMAL_ROW_COLOR,
+            _ => ALT_ROW_COLOR,
+        };
+        let (style, todo_str) = match self.status {
+            true => (
+                Style::default().fg(COMPLETED_TEXT_COLOR).bg(bg_color),
+                " ✓ ".to_string() + &self.todo,
+            ),
+            false => (
+                Style::default().fg(TEXT_COLOR).bg(bg_color),
+                " ☐ ".to_string() + &self.todo,
+            ),
+        };
+        ListItem::new(Line::from(todo_str)).style(style)
+    }
+
+    fn from_vec(vec: Vec<(&str, &str, bool)>) -> Vec<Self> {
+        let mut result_vec = vec![];
+        for item in vec {
+            result_vec.push(TodoItem {
+                todo: item.0.to_string(),
+                info: item.1.to_string(),
+                status: item.2,
+            })
+        }
+        result_vec
+    }
+}
+
+struct StatefulList {
     state: ListState,
-    items: Vec<T>,
+    items: Vec<TodoItem>,
     last_selected: Option<usize>,
 }
 
-impl<T> StatefulList<T> {
-    fn with_items(items: Vec<T>) -> StatefulList<T> {
+impl StatefulList {
+    fn with_items(items: Vec<TodoItem>) -> StatefulList {
         StatefulList {
             state: ListState::default(),
             items,
@@ -76,53 +109,29 @@ impl<T> StatefulList<T> {
 ///
 /// Check the event handling at the bottom to see how to change the state on incoming events.
 /// Check the drawing logic for items on how to specify the highlighting style for selected items.
-struct App<'a> {
-    items: StatefulList<(&'a str, &'a str, bool)>,
-    events: Vec<String>,
+struct App {
+    items: StatefulList,
 }
 
-impl<'a> App<'a> {
+impl App {
     /// Changes the status of the selected list item
     fn change_status(&mut self) {
         if let Some(i) = self.items.state.selected() {
-            self.items.items[i].2 = !&self.items.items[i].2
+            self.items.items[i].status = !&self.items.items[i].status
         }
     }
 
-    fn new() -> App<'a> {
+    fn new() -> App {
         App {
-            items: StatefulList::with_items(vec![
+            items: StatefulList::with_items(TodoItem::from_vec(vec![
                 ("Rewrite everything with Rust!", "I can't hold my inner voice. He tells me to rewrite the complete universe with Rust", false),
                 ("Rewrite all of your tui apps with Ratatui", "Yes, you heard that right. Go and replace your tui with Ratatui.", true),
                 ("Pet your cat", "Minnak loves to be pet by you! Don't forget to pet and give some treats!", false),
                 ("Walk with your dog", "Max is bored, go walk with him!", false),
                 ("Pay the bills", "Pay the train subscription!!!", true),
                 ("Refactor list example", "If you see this info that means I completed this task!", true),
-            ]),
-            events: Self::create_random_events()
+            ])),
         }
-    }
-
-    /// This only exists to simulate some kind of "progress"
-    fn on_tick(&mut self) {
-        let event = self.events.remove(0);
-        self.events.push(event);
-    }
-
-    fn create_random_events() -> Vec<String> {
-        let mut events_vec = vec![];
-        for _ in 0..50 {
-            let event = match rand::random::<u8>() % 5 {
-                0 => "INFO".into(),
-                1 => "CRITICAL".into(),
-                2 => "WARNING".into(),
-                3 => "PANIC!".into(),
-                4 => "ERROR".into(),
-                _ => unreachable!(),
-            };
-            events_vec.push(event)
-        }
-        events_vec
     }
 }
 
@@ -135,9 +144,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     // create app and run it
-    let tick_rate = Duration::from_millis(250);
     let app = App::new();
-    let res = run_app(&mut terminal, app, tick_rate);
+    let res = run_app(&mut terminal, app);
 
     // restore terminal
     disable_raw_mode()?;
@@ -155,34 +163,22 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    tick_rate: Duration,
-) -> io::Result<()> {
-    let mut last_tick = Instant::now();
+fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
     loop {
         terminal.draw(|f| ui(f, &mut app))?;
 
-        let timeout = tick_rate.saturating_sub(last_tick.elapsed());
-        if crossterm::event::poll(timeout)? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press {
-                    use KeyCode::*;
-                    match key.code {
-                        Char('q') | Esc => return Ok(()),
-                        Char('h') | Left => app.items.unselect(),
-                        Char('j') | Down => app.items.next(),
-                        Char('k') | Up => app.items.previous(),
-                        Char('l') | Right | Enter => app.change_status(),
-                        _ => {}
-                    }
+        if let Event::Key(key) = event::read()? {
+            if key.kind == KeyEventKind::Press {
+                use KeyCode::*;
+                match key.code {
+                    Char('q') | Esc => return Ok(()),
+                    Char('h') | Left => app.items.unselect(),
+                    Char('j') | Down => app.items.next(),
+                    Char('k') | Up => app.items.previous(),
+                    Char('l') | Right | Enter => app.change_status(),
+                    _ => {}
                 }
             }
-        }
-        if last_tick.elapsed() >= tick_rate {
-            app.on_tick();
-            last_tick = Instant::now();
         }
     }
 }
@@ -192,27 +188,22 @@ fn ui(f: &mut Frame, app: &mut App) {
     let vertical = Layout::vertical([Constraint::Length(2), Constraint::Percentage(100)]);
     let [header_area, rest_area] = f.size().split(&vertical);
 
-    // Create two chunks with equal horizontal screen space
-    let horizontal = Layout::horizontal([Constraint::Percentage(50), Constraint::Max(15)]);
-    let [item_list_area, event_list_area] = rest_area.split(&horizontal);
-
     // Create two chunks with equal vertical screen space. One for the list and the other for the
     // info block.
     let vertical = Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)]);
-    let [upper_item_list_area, lower_item_list_area] = item_list_area.split(&vertical);
+    let [upper_item_list_area, lower_item_list_area] = rest_area.split(&vertical);
 
     let header = Block::default()
         .title("Use j k or ↓ ↑ to move, h or ← to unselect, l → to change status.")
         .title_alignment(Alignment::Center);
     f.render_widget(header, header_area);
 
-    render_todo(f, app, &[upper_item_list_area, lower_item_list_area]);
-
-    render_events_list(f, app, event_list_area)
+    render_todo(f, app, upper_item_list_area);
+    render_info(f, app, lower_item_list_area);
 }
 
-// Renders todo list and info part
-fn render_todo(f: &mut Frame, app: &mut App, area: &[Rect; 2]) {
+// Renders todo list (upper part)
+fn render_todo(f: &mut Frame, app: &mut App, area: Rect) {
     // We create two blocks, one is for the header (outer) and the other is for list (inner).
     let outer_block = Block::default()
         .borders(Borders::NONE)
@@ -226,7 +217,7 @@ fn render_todo(f: &mut Frame, app: &mut App, area: &[Rect; 2]) {
         .bg(NORMAL_ROW_COLOR);
 
     // We get the inner area from outer_block. We'll use this area later to render the table.
-    let outer_area = area[0];
+    let outer_area = area;
     let inner_area = outer_block.inner(outer_area);
 
     // We can render the header in outer_area.
@@ -238,23 +229,7 @@ fn render_todo(f: &mut Frame, app: &mut App, area: &[Rect; 2]) {
         .items
         .iter()
         .enumerate()
-        .map(|(i, (todo, _info, status))| {
-            let bg_color = match i % 2 {
-                0 => NORMAL_ROW_COLOR,
-                _ => ALT_ROW_COLOR,
-            };
-            let (style, todo_str) = match status {
-                true => (
-                    Style::default().fg(COMPLETED_TEXT_COLOR).bg(bg_color),
-                    " ✓ ".to_string() + todo,
-                ),
-                false => (
-                    Style::default().fg(TEXT_COLOR).bg(bg_color),
-                    " ☐ ".to_string() + todo,
-                ),
-            };
-            ListItem::new(Line::from(todo_str)).style(style)
-        })
+        .map(|(i, todo_item)| todo_item.styled_list_item(i))
         .collect();
 
     // Create a List from all list items and highlight the currently selected one
@@ -266,15 +241,20 @@ fn render_todo(f: &mut Frame, app: &mut App, area: &[Rect; 2]) {
                 .add_modifier(Modifier::REVERSED)
                 .fg(SELECTED_STYLE_FG),
         )
-        .highlight_symbol(">");
+        .highlight_symbol(">")
+        .highlight_spacing(HighlightSpacing::Always);
 
     // We can now render the item list
     f.render_stateful_widget(items, inner_area, &mut app.items.state);
+}
 
+// Renders info block (lower part)
+fn render_info(f: &mut Frame, app: &mut App, area: Rect) {
+    // We get the info depending on the item's state.
     let info = if let Some(i) = app.items.state.selected() {
-        match app.items.items[i].2 {
-            true => "✓ DONE: ".to_string() + app.items.items[i].1,
-            false => "TODO: ".to_string() + app.items.items[i].1,
+        match app.items.items[i].status {
+            true => "✓ DONE: ".to_string() + &app.items.items[i].info,
+            false => "TODO: ".to_string() + &app.items.items[i].info,
         }
     } else {
         "Nothing to see here...".to_string()
@@ -294,7 +274,7 @@ fn render_todo(f: &mut Frame, app: &mut App, area: &[Rect; 2]) {
 
     // This is a similar process to what we did for list. outer_info_area will be used for header
     // inner_info_area will be used for the list info.
-    let outer_info_area = area[1];
+    let outer_info_area = area;
     let inner_info_area = outer_info_block.inner(outer_info_area);
 
     // We can render the header. Inner info will be rendered later
@@ -307,40 +287,4 @@ fn render_todo(f: &mut Frame, app: &mut App, area: &[Rect; 2]) {
 
     // We can now render the item info
     f.render_widget(info_paragraph, inner_info_area);
-}
-
-// Renders event list
-fn render_events_list(f: &mut Frame, app: &App, area: Rect) {
-    let events: Vec<ListItem> = app
-        .events
-        .iter()
-        .rev()
-        .map(|level| {
-            // sets event_style to the tailwind color depending on its level
-            let event_style = match level.as_str() {
-                "CRITICAL" => Style::default().fg(tailwind::RED.c800),
-                "ERROR" => Style::default().fg(tailwind::RED.c600),
-                "WARNING" => Style::default().fg(tailwind::YELLOW.c600),
-                "INFO" => Style::default().fg(tailwind::BLUE.c700),
-                "PANIC!" => Style::default().fg(tailwind::ORANGE.c600),
-                _ => Style::default(),
-            };
-
-            // Creates a list item with styled span
-            ListItem::new(Span::styled(level, event_style))
-        })
-        .collect();
-    let events_list = List::new(events)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .fg(TEXT_COLOR)
-                .bg(BG)
-                .title("Events List")
-                .title_alignment(Alignment::Center),
-        )
-        .direction(ListDirection::BottomToTop);
-
-    // Renders the event table to the right side of the screen.
-    f.render_widget(events_list, area);
 }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -149,16 +149,13 @@ impl App<'_> {
 
 impl Widget for &mut App<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // Create a space for header, todo list and the footer. I want to took your attention
-        // to the third constraint and the rect. I put them as a dead space for better look
-        // purposes. Yes with this way there is a line wasted but this looks better in front.
+        // Create a space for header, todo list and the footer.
         let vertical = Layout::vertical([
             Constraint::Length(2),
             Constraint::Min(0),
-            Constraint::Length(1),
-            Constraint::Length(1),
+            Constraint::Length(2),
         ]);
-        let [header_area, rest_area, _dead_space, footer_area] = area.split(&vertical);
+        let [header_area, rest_area, footer_area] = area.split(&vertical);
 
         // Create two chunks with equal vertical screen space. One for the list and the other for
         // the info block.
@@ -268,9 +265,11 @@ impl App<'_> {
     }
 
     fn render_footer(&self, area: Rect, buf: &mut Buffer) {
-        Paragraph::new("Use ↓↑ to move, ← to unselect, → to change status, g/G to go top/bottom.")
-            .alignment(Alignment::Center)
-            .render(area, buf);
+        Paragraph::new(
+            "\nUse ↓↑ to move, ← to unselect, → to change status, g/G to go top/bottom.",
+        )
+        .alignment(Alignment::Center)
+        .render(area, buf);
     }
 }
 

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -13,7 +13,7 @@ const NORMAL_ROW_COLOR: Color = tailwind::SLATE.c950;
 const ALT_ROW_COLOR: Color = tailwind::SLATE.c900;
 const SELECTED_STYLE_FG: Color = tailwind::BLUE.c300;
 const TEXT_COLOR: Color = tailwind::SLATE.c200;
-const COMPLETED_TEXT_COLOR: Color = tailwind::GREEN.c600;
+const COMPLETED_TEXT_COLOR: Color = tailwind::GREEN.c500;
 
 #[derive(Copy, Clone)]
 enum Status {

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -325,14 +325,14 @@ impl TodoItem<'_> {
             _ => ALT_ROW_COLOR,
         };
         let line = match self.status {
-            Status::Todo => Line::styled(format!(" ☐ {}", self.todo), (TEXT_COLOR, bg_color)),
+            Status::Todo => Line::styled(format!(" ☐ {}", self.todo), TEXT_COLOR),
             Status::Completed => Line::styled(
                 format!(" ✓ {}", self.todo),
                 (COMPLETED_TEXT_COLOR, bg_color),
             ),
         };
 
-        ListItem::new(line)
+        ListItem::new(line).bg(bg_color)
     }
 }
 

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -82,6 +82,13 @@ struct App<'a> {
 }
 
 impl<'a> App<'a> {
+    /// Changes the status of the selected list item
+    fn change_status(&mut self) {
+        if let Some(i) = self.items.state.selected() {
+            self.items.items[i].2 = !&self.items.items[i].2
+        }
+    }
+
     fn new() -> App<'a> {
         App {
             items: StatefulList::with_items(vec![
@@ -93,13 +100,6 @@ impl<'a> App<'a> {
                 ("Refactor list example", "If you see this info that means I completed this task!", true),
             ]),
             events: Self::create_random_events()
-        }
-    }
-
-    /// Changes the satis of the item list
-    fn change_status(&mut self) {
-        if let Some(i) = self.items.state.selected() {
-            self.items.items[i].2 = !&self.items.items[i].2
         }
     }
 
@@ -316,8 +316,8 @@ fn render_events_list(f: &mut Frame, app: &App, area: Rect) {
         .iter()
         .rev()
         .map(|level| {
-            // sets s to the tailwind color depending on its level
-            let s = match level.as_str() {
+            // sets event_style to the tailwind color depending on its level
+            let event_style = match level.as_str() {
                 "CRITICAL" => Style::default().fg(tailwind::RED.c800),
                 "ERROR" => Style::default().fg(tailwind::RED.c600),
                 "WARNING" => Style::default().fg(tailwind::YELLOW.c600),
@@ -327,7 +327,7 @@ fn render_events_list(f: &mut Frame, app: &App, area: Rect) {
             };
 
             // Creates a list item with styled span
-            ListItem::new(Span::styled(level, s))
+            ListItem::new(Span::styled(level, event_style))
         })
         .collect();
     let events_list = List::new(events)

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,9 +1,10 @@
-use std::{error::Error, io};
+use std::{error::Error, io, io::stdout};
 
+use color_eyre::config::HookBuilder;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
-    execute,
+    event::{self, Event, KeyCode, KeyEventKind},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
 };
 use ratatui::{prelude::*, style::palette::tailwind, widgets::*};
 
@@ -14,60 +15,270 @@ const SELECTED_STYLE_FG: Color = tailwind::BLUE.c300;
 const TEXT_COLOR: Color = tailwind::SLATE.c200;
 const COMPLETED_TEXT_COLOR: Color = tailwind::GREEN.c600;
 
+#[derive(Copy, Clone)]
 enum Status {
     Todo,
     Completed,
 }
 
-struct TodoItem {
-    todo: String,
-    info: String,
+struct TodoItem<'a> {
+    todo: &'a str,
+    info: &'a str,
     status: Status,
 }
 
-impl TodoItem {
-    fn styled_list_item(&self, index: usize) -> ListItem {
-        let bg_color = match index % 2 {
-            0 => NORMAL_ROW_COLOR,
-            _ => ALT_ROW_COLOR,
-        };
-        let (style, todo_str) = match self.status {
-            Status::Completed => (
-                Style::default().fg(COMPLETED_TEXT_COLOR).bg(bg_color),
-                " ✓ ".to_string() + &self.todo,
-            ),
-            Status::Todo => (
-                Style::default().fg(TEXT_COLOR).bg(bg_color),
-                " ☐ ".to_string() + &self.todo,
-            ),
-        };
-        ListItem::new(Line::from(todo_str)).style(style)
-    }
-
-    fn from_vec(vec: Vec<(&str, &str, Status)>) -> Vec<Self> {
-        let mut result_vec = vec![];
-        for item in vec {
-            result_vec.push(TodoItem {
-                todo: item.0.to_string(),
-                info: item.1.to_string(),
-                status: item.2,
-            })
-        }
-        result_vec
-    }
-}
-
-struct StatefulList {
+struct StatefulList<'a> {
     state: ListState,
-    items: Vec<TodoItem>,
+    items: Vec<TodoItem<'a>>,
     last_selected: Option<usize>,
 }
 
-impl StatefulList {
-    fn with_items(items: Vec<TodoItem>) -> StatefulList {
+/// This struct holds the current state of the app. In particular, it has the `items` field which is
+/// a wrapper around `ListState`. Keeping track of the items state let us render the associated
+/// widget with its state and have access to features such as natural scrolling.
+///
+/// Check the event handling at the bottom to see how to change the state on incoming events.
+/// Check the drawing logic for items on how to specify the highlighting style for selected items.
+struct App<'a> {
+    items: StatefulList<'a>,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // setup terminal
+    init_error_hooks()?;
+    let terminal = init_terminal()?;
+
+    // create app and run it
+    App::new().run(terminal)?;
+
+    restore_terminal()?;
+
+    Ok(())
+}
+
+fn init_error_hooks() -> color_eyre::Result<()> {
+    let (panic, error) = HookBuilder::default().into_hooks();
+    let panic = panic.into_panic_hook();
+    let error = error.into_eyre_hook();
+    color_eyre::eyre::set_hook(Box::new(move |e| {
+        let _ = restore_terminal();
+        error(e)
+    }))?;
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = restore_terminal();
+        panic(info)
+    }));
+    Ok(())
+}
+
+fn init_terminal() -> color_eyre::Result<Terminal<impl Backend>> {
+    enable_raw_mode()?;
+    stdout().execute(EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout());
+    let terminal = Terminal::new(backend)?;
+    Ok(terminal)
+}
+
+fn restore_terminal() -> color_eyre::Result<()> {
+    disable_raw_mode()?;
+    stdout().execute(LeaveAlternateScreen)?;
+    Ok(())
+}
+
+impl App<'_> {
+    fn new<'a>() -> App<'a> {
+        App {
+            items: StatefulList::with_items([
+                ("Rewrite everything with Rust!", "I can't hold my inner voice. He tells me to rewrite the complete universe with Rust", Status::Todo),
+                ("Rewrite all of your tui apps with Ratatui", "Yes, you heard that right. Go and replace your tui with Ratatui.", Status::Completed),
+                ("Pet your cat", "Minnak loves to be pet by you! Don't forget to pet and give some treats!", Status::Todo),
+                ("Walk with your dog", "Max is bored, go walk with him!", Status::Todo),
+                ("Pay the bills", "Pay the train subscription!!!", Status::Completed),
+                ("Refactor list example", "If you see this info that means I completed this task!", Status::Completed),
+            ]),
+        }
+    }
+
+    /// Changes the status of the selected list item
+    fn change_status(&mut self) {
+        if let Some(i) = self.items.state.selected() {
+            self.items.items[i].status = match self.items.items[i].status {
+                Status::Completed => Status::Todo,
+                Status::Todo => Status::Completed,
+            }
+        }
+    }
+
+    fn go_top(&mut self) {
+        self.items.state.select(Some(0))
+    }
+
+    fn go_bottom(&mut self) {
+        self.items.state.select(Some(self.items.items.len() - 1))
+    }
+}
+
+impl App<'_> {
+    fn run(&mut self, mut terminal: Terminal<impl Backend>) -> io::Result<()> {
+        loop {
+            self.draw(&mut terminal)?;
+
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press {
+                    use KeyCode::*;
+                    match key.code {
+                        Char('q') | Esc => return Ok(()),
+                        Char('h') | Left => self.items.unselect(),
+                        Char('j') | Down => self.items.next(),
+                        Char('k') | Up => self.items.previous(),
+                        Char('l') | Right | Enter => self.change_status(),
+                        Char('g') => self.go_top(),
+                        Char('G') => self.go_bottom(),
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    fn draw(&mut self, terminal: &mut Terminal<impl Backend>) -> io::Result<()> {
+        terminal.draw(|f| f.render_widget(self, f.size()))?;
+        Ok(())
+    }
+}
+
+impl Widget for &mut App<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        // Create a space for header, todo list and the footer. I want to took your attention
+        // to the third constraint and the rect. I put them as a dead space for better look
+        // purposes. Yes with this way there is a line wasted but this looks better in front.
+        let vertical = Layout::vertical([
+            Constraint::Length(2),
+            Constraint::Min(0),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ]);
+        let [header_area, rest_area, _dead_space, footer_area] = area.split(&vertical);
+
+        // Create two chunks with equal vertical screen space. One for the list and the other for
+        // the info block.
+        let vertical = Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)]);
+        let [upper_item_list_area, lower_item_list_area] = rest_area.split(&vertical);
+
+        self.render_title(header_area, buf);
+        self.render_todo(upper_item_list_area, buf);
+        self.render_info(lower_item_list_area, buf);
+        self.render_footer(footer_area, buf);
+    }
+}
+
+impl App<'_> {
+    fn render_title(&self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new("Ratatui List Example")
+            .bold()
+            .alignment(Alignment::Center)
+            .render(area, buf);
+    }
+
+    fn render_todo(&mut self, area: Rect, buf: &mut Buffer) {
+        // We create two blocks, one is for the header (outer) and the other is for list (inner).
+        let outer_block = Block::default()
+            .borders(Borders::NONE)
+            .fg(TEXT_COLOR)
+            .bg(TODO_HEADER_BG)
+            .title("TODO List")
+            .title_alignment(Alignment::Center);
+        let inner_block = Block::default()
+            .borders(Borders::NONE)
+            .fg(TEXT_COLOR)
+            .bg(NORMAL_ROW_COLOR);
+
+        // We get the inner area from outer_block. We'll use this area later to render the table.
+        let outer_area = area;
+        let inner_area = outer_block.inner(outer_area);
+
+        // We can render the header in outer_area.
+        outer_block.render(outer_area, buf);
+
+        // Iterate through all elements in the `items` and stylize them.
+        let items: Vec<ListItem> = self
+            .items
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, todo_item)| todo_item.to_list_item(i))
+            .collect();
+
+        // Create a List from all list items and highlight the currently selected one
+        let items = List::new(items)
+            .block(inner_block)
+            .highlight_style(
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::REVERSED)
+                    .fg(SELECTED_STYLE_FG),
+            )
+            .highlight_symbol(">")
+            .highlight_spacing(HighlightSpacing::Always);
+
+        // We can now render the item list
+        // (look careful we are using StatefulWidget's render.)
+        // ratatui::widgets::StatefulWidget::render as stateful_render
+        StatefulWidget::render(items, inner_area, buf, &mut self.items.state);
+    }
+
+    fn render_info(&self, area: Rect, buf: &mut Buffer) {
+        // We get the info depending on the item's state.
+        let info = if let Some(i) = self.items.state.selected() {
+            match self.items.items[i].status {
+                Status::Completed => "✓ DONE: ".to_string() + self.items.items[i].info,
+                Status::Todo => "TODO: ".to_string() + self.items.items[i].info,
+            }
+        } else {
+            "Nothing to see here...".to_string()
+        };
+
+        // We show the list item's info under the list in this paragraph
+        let outer_info_block = Block::default()
+            .borders(Borders::NONE)
+            .fg(TEXT_COLOR)
+            .bg(TODO_HEADER_BG)
+            .title("TODO Info")
+            .title_alignment(Alignment::Center);
+        let inner_info_block = Block::default()
+            .borders(Borders::NONE)
+            .bg(NORMAL_ROW_COLOR)
+            .padding(Padding::horizontal(1));
+
+        // This is a similar process to what we did for list. outer_info_area will be used for
+        // header inner_info_area will be used for the list info.
+        let outer_info_area = area;
+        let inner_info_area = outer_info_block.inner(outer_info_area);
+
+        // We can render the header. Inner info will be rendered later
+        outer_info_block.render(outer_info_area, buf);
+
+        let info_paragraph = Paragraph::new(info)
+            .block(inner_info_block)
+            .fg(TEXT_COLOR)
+            .wrap(Wrap { trim: false });
+
+        // We can now render the item info
+        info_paragraph.render(inner_info_area, buf);
+    }
+
+    fn render_footer(&self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new("Use ↓↑ to move, ← to unselect, → to change status, g/G to go top/bottom.")
+            .alignment(Alignment::Center)
+            .render(area, buf);
+    }
+}
+
+impl StatefulList<'_> {
+    fn with_items<'a>(items: [(&'a str, &'a str, Status); 6]) -> StatefulList<'a> {
         StatefulList {
             state: ListState::default(),
-            items,
+            items: items.iter().map(TodoItem::from).collect(),
             last_selected: None,
         }
     }
@@ -108,191 +319,30 @@ impl StatefulList {
     }
 }
 
-/// This struct holds the current state of the app. In particular, it has the `items` field which is
-/// a wrapper around `ListState`. Keeping track of the items state let us render the associated
-/// widget with its state and have access to features such as natural scrolling.
-///
-/// Check the event handling at the bottom to see how to change the state on incoming events.
-/// Check the drawing logic for items on how to specify the highlighting style for selected items.
-struct App {
-    items: StatefulList,
-}
+impl TodoItem<'_> {
+    fn to_list_item(&self, index: usize) -> ListItem {
+        let bg_color = match index % 2 {
+            0 => NORMAL_ROW_COLOR,
+            _ => ALT_ROW_COLOR,
+        };
+        let line = match self.status {
+            Status::Todo => Line::styled(format!(" ☐ {}", self.todo), (TEXT_COLOR, bg_color)),
+            Status::Completed => Line::styled(
+                format!(" ✓ {}", self.todo),
+                (COMPLETED_TEXT_COLOR, bg_color),
+            ),
+        };
 
-impl App {
-    /// Changes the status of the selected list item
-    fn change_status(&mut self) {
-        if let Some(i) = self.items.state.selected() {
-            self.items.items[i].status = match self.items.items[i].status {
-                Status::Completed => Status::Todo,
-                Status::Todo => Status::Completed,
-            }
-        }
-    }
-
-    fn new() -> App {
-        App {
-            items: StatefulList::with_items(TodoItem::from_vec(vec![
-                ("Rewrite everything with Rust!", "I can't hold my inner voice. He tells me to rewrite the complete universe with Rust", Status::Todo),
-                ("Rewrite all of your tui apps with Ratatui", "Yes, you heard that right. Go and replace your tui with Ratatui.", Status::Completed),
-                ("Pet your cat", "Minnak loves to be pet by you! Don't forget to pet and give some treats!", Status::Todo),
-                ("Walk with your dog", "Max is bored, go walk with him!", Status::Todo),
-                ("Pay the bills", "Pay the train subscription!!!", Status::Completed),
-                ("Refactor list example", "If you see this info that means I completed this task!", Status::Completed),
-            ])),
-        }
+        ListItem::new(line)
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-
-    // create app and run it
-    let app = App::new();
-    let res = run_app(&mut terminal, app);
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    if let Err(err) = res {
-        println!("{err:?}");
-    }
-
-    Ok(())
-}
-
-fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
-    loop {
-        terminal.draw(|f| ui(f, &mut app))?;
-
-        if let Event::Key(key) = event::read()? {
-            if key.kind == KeyEventKind::Press {
-                use KeyCode::*;
-                match key.code {
-                    Char('q') | Esc => return Ok(()),
-                    Char('h') | Left => app.items.unselect(),
-                    Char('j') | Down => app.items.next(),
-                    Char('k') | Up => app.items.previous(),
-                    Char('l') | Right | Enter => app.change_status(),
-                    _ => {}
-                }
-            }
+impl<'a> From<&(&'a str, &'a str, Status)> for TodoItem<'a> {
+    fn from((todo, info, status): &(&'a str, &'a str, Status)) -> Self {
+        Self {
+            todo,
+            info,
+            status: *status,
         }
     }
-}
-
-fn ui(f: &mut Frame, app: &mut App) {
-    // Create a space for header
-    let vertical = Layout::vertical([Constraint::Length(2), Constraint::Percentage(100)]);
-    let [header_area, rest_area] = f.size().split(&vertical);
-
-    // Create two chunks with equal vertical screen space. One for the list and the other for the
-    // info block.
-    let vertical = Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)]);
-    let [upper_item_list_area, lower_item_list_area] = rest_area.split(&vertical);
-
-    let header = Block::default()
-        .title("Use j k or ↓ ↑ to move, h or ← to unselect, l → to change status.")
-        .title_alignment(Alignment::Center);
-    f.render_widget(header, header_area);
-
-    render_todo(f, app, upper_item_list_area);
-    render_info(f, app, lower_item_list_area);
-}
-
-// Renders todo list (upper part)
-fn render_todo(f: &mut Frame, app: &mut App, area: Rect) {
-    // We create two blocks, one is for the header (outer) and the other is for list (inner).
-    let outer_block = Block::default()
-        .borders(Borders::NONE)
-        .fg(TEXT_COLOR)
-        .bg(TODO_HEADER_BG)
-        .title("TODO List")
-        .title_alignment(Alignment::Center);
-    let inner_block = Block::default()
-        .borders(Borders::NONE)
-        .fg(TEXT_COLOR)
-        .bg(NORMAL_ROW_COLOR);
-
-    // We get the inner area from outer_block. We'll use this area later to render the table.
-    let outer_area = area;
-    let inner_area = outer_block.inner(outer_area);
-
-    // We can render the header in outer_area.
-    f.render_widget(outer_block, outer_area);
-
-    // Iterate through all elements in the `items` and stylize them.
-    let items: Vec<ListItem> = app
-        .items
-        .items
-        .iter()
-        .enumerate()
-        .map(|(i, todo_item)| todo_item.styled_list_item(i))
-        .collect();
-
-    // Create a List from all list items and highlight the currently selected one
-    let items = List::new(items)
-        .block(inner_block)
-        .highlight_style(
-            Style::default()
-                .add_modifier(Modifier::BOLD)
-                .add_modifier(Modifier::REVERSED)
-                .fg(SELECTED_STYLE_FG),
-        )
-        .highlight_symbol(">")
-        .highlight_spacing(HighlightSpacing::Always);
-
-    // We can now render the item list
-    f.render_stateful_widget(items, inner_area, &mut app.items.state);
-}
-
-// Renders info block (lower part)
-fn render_info(f: &mut Frame, app: &mut App, area: Rect) {
-    // We get the info depending on the item's state.
-    let info = if let Some(i) = app.items.state.selected() {
-        match app.items.items[i].status {
-            Status::Completed => "✓ DONE: ".to_string() + &app.items.items[i].info,
-            Status::Todo => "TODO: ".to_string() + &app.items.items[i].info,
-        }
-    } else {
-        "Nothing to see here...".to_string()
-    };
-
-    // We show the list item's info under the list in this paragraph
-    let outer_info_block = Block::default()
-        .borders(Borders::NONE)
-        .fg(TEXT_COLOR)
-        .bg(TODO_HEADER_BG)
-        .title("TODO Info")
-        .title_alignment(Alignment::Center);
-    let inner_info_block = Block::default()
-        .borders(Borders::NONE)
-        .bg(NORMAL_ROW_COLOR)
-        .padding(Padding::horizontal(1));
-
-    // This is a similar process to what we did for list. outer_info_area will be used for header
-    // inner_info_area will be used for the list info.
-    let outer_info_area = area;
-    let inner_info_area = outer_info_block.inner(outer_info_area);
-
-    // We can render the header. Inner info will be rendered later
-    f.render_widget(outer_info_block, outer_info_area);
-
-    let info_paragraph = Paragraph::new(info)
-        .block(inner_info_block)
-        .fg(TEXT_COLOR)
-        .wrap(Wrap { trim: false });
-
-    // We can now render the item info
-    f.render_widget(info_paragraph, inner_info_area);
 }

--- a/examples/list.tape
+++ b/examples/list.tape
@@ -3,7 +3,7 @@
 Output "target/list.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200
-Set Height 550
+Set Height 580
 Hide
 Type "cargo run --example=list --features=crossterm"
 Enter

--- a/examples/list.tape
+++ b/examples/list.tape
@@ -3,13 +3,22 @@
 Output "target/list.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200
-Set Height 600
+Set Height 550
 Hide
 Type "cargo run --example=list --features=crossterm"
 Enter
-Sleep 1s
+Sleep 10s
 Show
-Down@1s 4
-Up@1s 2
+Sleep 2s
+Down@1.5s 3
+Right@1.5s 1
+Sleep 1.5s
+Down@1.5s 3
+Sleep 1.5s
+Up@1s 1
+Sleep 1s
+Right@1.5s 1
+Sleep 1.5s
+Up@1s 4
 Left@1s 1
-Sleep 5s
+Sleep 2s

--- a/examples/list.tape
+++ b/examples/list.tape
@@ -3,7 +3,7 @@
 Output "target/list.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200
-Set Height 580
+Set Height 612
 Hide
 Type "cargo run --example=list --features=crossterm"
 Enter


### PR DESCRIPTION
Issue: https://github.com/ratatui-org/ratatui/issues/846

This PR adds:

for list.rs

- subjectively better-looking front
- change list example to a todo list example
- status of a TODO can be changed, further info can be seen under the list.

for list.tape

- change to get better output from the new code

Here is the new output:

![list](https://github.com/ratatui-org/ratatui/assets/30180366/e6fff3ce-ec2e-404c-aeba-138b8cf605c1)
