### PR TITLE
feat(constraints): Rename `Constraint::Proportional` to `Constraint::Fill`

### DIFF
--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -38,7 +38,7 @@ const LENGTH_COLOR: Color = tailwind::SLATE.c700;
 const PERCENTAGE_COLOR: Color = tailwind::SLATE.c800;
 const RATIO_COLOR: Color = tailwind::SLATE.c900;
 // priority 4
-const PROPORTIONAL_COLOR: Color = tailwind::SLATE.c950;
+const FILL_COLOR: Color = tailwind::SLATE.c950;
 
 #[derive(Default, Clone, Copy)]
 struct App {
@@ -60,7 +60,7 @@ enum SelectedTab {
     Length,
     Percentage,
     Ratio,
-    Proportional,
+    Fill,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -165,7 +165,7 @@ impl Widget for App {
         let [tabs, axis, demo] = area.split(&Layout::vertical([
             Constraint::Fixed(3),
             Constraint::Fixed(3),
-            Proportional(0),
+            Fill(0),
         ]));
 
         self.render_tabs(tabs, buf);
@@ -272,7 +272,7 @@ impl SelectedTab {
             Length => 4,
             Percentage => 5,
             Ratio => 4,
-            Proportional => 2,
+            Fill => 2,
             Min => 5,
             Max => 5,
         }
@@ -286,7 +286,7 @@ impl SelectedTab {
             Length => LENGTH_COLOR,
             Percentage => PERCENTAGE_COLOR,
             Ratio => RATIO_COLOR,
-            Proportional => PROPORTIONAL_COLOR,
+            Fill => FILL_COLOR,
             Min => MIN_COLOR,
             Max => MAX_COLOR,
         };
@@ -301,7 +301,7 @@ impl Widget for SelectedTab {
             SelectedTab::Length => self.render_length_example(area, buf),
             SelectedTab::Percentage => self.render_percentage_example(area, buf),
             SelectedTab::Ratio => self.render_ratio_example(area, buf),
-            SelectedTab::Proportional => self.render_proportional_example(area, buf),
+            SelectedTab::Fill => self.render_fill_example(area, buf),
             SelectedTab::Min => self.render_min_example(area, buf),
             SelectedTab::Max => self.render_max_example(area, buf),
         }
@@ -313,17 +313,11 @@ impl SelectedTab {
         let [example1, example2, example3, example4, _] =
             area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 5]));
 
-        Example::new(&[Fixed(40), Proportional(0)]).render(example1, buf);
-        Example::new(&[Fixed(20), Fixed(20), Proportional(0)]).render(example2, buf);
+        Example::new(&[Fixed(40), Fill(0)]).render(example1, buf);
+        Example::new(&[Fixed(20), Fixed(20), Fill(0)]).render(example2, buf);
         Example::new(&[Fixed(20), Min(20), Max(20)]).render(example3, buf);
-        Example::new(&[
-            Length(20),
-            Percentage(20),
-            Ratio(1, 5),
-            Proportional(1),
-            Fixed(15),
-        ])
-        .render(example4, buf);
+        Example::new(&[Length(20), Percentage(20), Ratio(1, 5), Fill(1), Fixed(15)])
+            .render(example4, buf);
     }
 
     fn render_length_example(&self, area: Rect, buf: &mut Buffer) {
@@ -340,11 +334,11 @@ impl SelectedTab {
         let [example1, example2, example3, example4, example5, _] =
             area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 6]));
 
-        Example::new(&[Percentage(75), Proportional(0)]).render(example1, buf);
-        Example::new(&[Percentage(25), Proportional(0)]).render(example2, buf);
+        Example::new(&[Percentage(75), Fill(0)]).render(example1, buf);
+        Example::new(&[Percentage(25), Fill(0)]).render(example2, buf);
         Example::new(&[Percentage(50), Min(20)]).render(example3, buf);
         Example::new(&[Percentage(0), Max(0)]).render(example4, buf);
-        Example::new(&[Percentage(0), Proportional(0)]).render(example5, buf);
+        Example::new(&[Percentage(0), Fill(0)]).render(example5, buf);
     }
 
     fn render_ratio_example(&self, area: Rect, buf: &mut Buffer) {
@@ -357,11 +351,11 @@ impl SelectedTab {
         Example::new(&[Ratio(1, 2), Percentage(25), Length(10)]).render(example4, buf);
     }
 
-    fn render_proportional_example(&self, area: Rect, buf: &mut Buffer) {
+    fn render_fill_example(&self, area: Rect, buf: &mut Buffer) {
         let [example1, example2, _] = area.split(&Layout::vertical([Fixed(EXAMPLE_HEIGHT); 3]));
 
-        Example::new(&[Proportional(1), Proportional(2), Proportional(3)]).render(example1, buf);
-        Example::new(&[Proportional(1), Percentage(50), Proportional(1)]).render(example2, buf);
+        Example::new(&[Fill(1), Fill(2), Fill(3)]).render(example1, buf);
+        Example::new(&[Fill(1), Percentage(50), Fill(1)]).render(example2, buf);
     }
 
     fn render_min_example(&self, area: Rect, buf: &mut Buffer) {
@@ -421,7 +415,7 @@ impl Example {
             Constraint::Length(_) => LENGTH_COLOR,
             Constraint::Percentage(_) => PERCENTAGE_COLOR,
             Constraint::Ratio(_, _) => RATIO_COLOR,
-            Constraint::Proportional(_) => PROPORTIONAL_COLOR,
+            Constraint::Fill(_) => FILL_COLOR,
             Constraint::Min(_) => MIN_COLOR,
             Constraint::Max(_) => MAX_COLOR,
         };

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -36,12 +36,12 @@ const EXAMPLE_DATA: &[(&str, &[Constraint])] = &[
         &[Fixed(10), Min(10), Max(10), Percentage(10), Ratio(1,10)],
     ),
     (
-        "Proportional(u16) takes any excess space always",
-        &[Length(20), Percentage(20), Ratio(1, 5), Proportional(1)],
+        "Fill(u16) takes any excess space always",
+        &[Length(20), Percentage(20), Ratio(1, 5), Fill(1)],
     ),
     (
         "Here's all constraints in one line",
-        &[Fixed(10), Min(10), Max(10), Percentage(10), Ratio(1,10), Proportional(1)],
+        &[Fixed(10), Min(10), Max(10), Percentage(10), Ratio(1,10), Fill(1)],
     ),
     (
         "",
@@ -58,12 +58,12 @@ const EXAMPLE_DATA: &[(&str, &[Constraint])] = &[
     ("", &[Length(100), Min(20)]),
     ("`Fixed` is higher priority than `Min/Max`", &[Max(20), Fixed(10)]),
     ("", &[Min(20), Fixed(90)]),
-    ("Proportional is the lowest priority and will fill any excess space", &[Proportional(1), Ratio(1, 4)]),
-    ("Proportional can be used to scale proportionally with other Proportional blocks", &[Proportional(1), Percentage(20), Proportional(2)]),
+    ("Fill is the lowest priority and will fill any excess space", &[Fill(1), Ratio(1, 4)]),
+    ("Fill can be used to scale proportionally with other Fill blocks", &[Fill(1), Percentage(20), Fill(2)]),
     ("", &[Ratio(1, 3), Percentage(20), Ratio(2, 3)]),
     ("StretchLast will stretch the last lowest priority constraint\nStretch will only stretch equal weighted constraints", &[Length(20), Length(15)]),
     ("", &[Percentage(20), Length(15)]),
-    ("`Proportional(u16)` fills up excess space, but is lower priority to spacers.\ni.e. Proportional will only have widths in Flex::Stretch and Flex::StretchLast", &[Proportional(1), Proportional(1)]),
+    ("`Fill(u16)` fills up excess space, but is lower priority to spacers.\ni.e. Fill will only have widths in Flex::Stretch and Flex::StretchLast", &[Fill(1), Fill(1)]),
     ("", &[Length(20), Fixed(20)]),
     (
         "When not using `Flex::Stretch` or `Flex::StretchLast`,\n`Min(u16)` and `Max(u16)` collapse to their lowest values",
@@ -74,21 +74,21 @@ const EXAMPLE_DATA: &[(&str, &[Constraint])] = &[
         &[Max(20)],
     ),
     ("", &[Min(20), Max(20), Length(20), Fixed(20)]),
-    ("", &[Proportional(0), Proportional(0)]),
+    ("", &[Fill(0), Fill(0)]),
     (
-        "`Proportional(1)` can be to scale with respect to other `Proportional(2)`",
-        &[Proportional(1), Proportional(2)],
+        "`Fill(1)` can be to scale with respect to other `Fill(2)`",
+        &[Fill(1), Fill(2)],
     ),
     (
         "",
-        &[Proportional(1), Min(10), Max(10), Proportional(2)],
+        &[Fill(1), Min(10), Max(10), Fill(2)],
     ),
     (
-        "`Proportional(0)` collapses if there are other non-zero `Proportional(_)`\nconstraints. e.g. `[Proportional(0), Proportional(0), Proportional(1)]`:",
+        "`Fill(0)` collapses if there are other non-zero `Fill(_)`\nconstraints. e.g. `[Fill(0), Fill(0), Fill(1)]`:",
         &[
-            Proportional(0),
-            Proportional(0),
-            Proportional(1),
+            Fill(0),
+            Fill(0),
+            Fill(1),
         ],
     ),
 ];
@@ -244,7 +244,7 @@ fn example_height() -> u16 {
 
 impl Widget for App {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let layout = Layout::vertical([Fixed(3), Fixed(1), Proportional(0)]);
+        let layout = Layout::vertical([Fixed(3), Fixed(1), Fill(0)]);
         let [tabs, axis, demo] = area.split(&layout);
         self.tabs().render(tabs, buf);
         let scroll_needed = self.render_demo(demo, buf);
@@ -419,7 +419,7 @@ impl Example {
 impl Widget for Example {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let title_height = get_description_height(&self.description);
-        let layout = Layout::vertical([Fixed(title_height), Proportional(0)]);
+        let layout = Layout::vertical([Fixed(title_height), Fill(0)]);
         let [title, illustrations] = area.split(&layout);
 
         let (blocks, spacers) = Layout::horizontal(&self.constraints)
@@ -518,7 +518,7 @@ fn color_for_constraint(constraint: Constraint) -> Color {
         Constraint::Length(_) => SLATE.c700,
         Constraint::Percentage(_) => SLATE.c800,
         Constraint::Ratio(_, _) => SLATE.c900,
-        Constraint::Proportional(_) => SLATE.c950,
+        Constraint::Fill(_) => SLATE.c950,
     }
 }
 

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -217,7 +217,7 @@ fn constraint_label(constraint: Constraint) -> String {
         Min(n) => format!("{n}"),
         Max(n) => format!("{n}"),
         Percentage(n) => format!("{n}"),
-        Proportional(n) => format!("{n}"),
+        Fill(n) => format!("{n}"),
         Fixed(n) => format!("{n}"),
         Ratio(a, b) => format!("{a}:{b}"),
     }

--- a/src/layout/flex.rs
+++ b/src/layout/flex.rs
@@ -25,9 +25,12 @@ pub enum Flex {
     /// constraints. As a refresher, the priorities of constraints are as follows:
     ///
     /// 1. [`Constraint::Fixed`]
-    /// 2. [`Constraint::Min`] / [`Constraint::Max`]
-    /// 3. [`Constraint::Length`] / [`Constraint::Percentage`] / [`Constraint::Ratio`]
-    /// 4. [`Constraint::Proportional`]
+    /// 2. [`Constraint::Min`]
+    /// 3. [`Constraint::Max`]
+    /// 4. [`Constraint::Length`]
+    /// 5. [`Constraint::Percentage`]
+    /// 6. [`Constraint::Ratio`]
+    /// 7. [`Constraint::Fill`]
     ///
     /// When every constraint is `Length`, the last element gets the excess.
     ///
@@ -81,13 +84,13 @@ pub enum Flex {
     /// ^^^^^^^^^^^^^^^^ EXCESS ^^^^^^^^^^^^^^^^
     /// ```
     ///
-    /// Proportional constraints have the lowest priority amongst all the constraints and hence
+    /// Fill constraints have the lowest priority amongst all the constraints and hence
     /// will always take up any excess space available.
     ///
     /// ```plain
     /// <----------------------------------- 80 px ------------------------------------>
     /// ┌──────20 px───────┐┌──────20 px───────┐┌──────20 px───────┐┌──────20 px───────┐
-    /// │  Proportional(0) ││      Min(20)     ││    Length(20)    ││     Fixed(20)    │
+    /// │      Fill(0)     ││      Min(20)     ││    Length(20)    ││     Fixed(20)    │
     /// └──────────────────┘└──────────────────┘└──────────────────┘└──────────────────┘
     /// ^^^^^^ EXCESS ^^^^^^
     /// ```

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -133,7 +133,7 @@ impl<DS: DateStyler> Monthly<'_, DS> {
         let layout = Layout::vertical([
             Constraint::Length(self.show_month.is_some().into()),
             Constraint::Length(self.show_weekday.is_some().into()),
-            Constraint::Proportional(1),
+            Constraint::Fill(1),
         ]);
         let [month_header, days_header, days_area] = area.split(&layout);
 

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -775,7 +775,7 @@ impl Table<'_> {
         let [_selection_area, columns_area] =
             Rect::new(0, 0, max_width, 1).split(&Layout::horizontal([
                 Constraint::Fixed(selection_width),
-                Constraint::Proportional(0),
+                Constraint::Fill(0),
             ]));
         let rects = Layout::horizontal(widths)
             .flex(self.flex)


### PR DESCRIPTION
`Constraint::Fill` is a more intuitive name for the behavior, and it is shorter.

Resolves #859 
