### PR TITLE
feat: Make spacing work in `Flex::SpaceAround` and `Flex::SpaceBetween`

### DIFF
--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -264,15 +264,7 @@ impl Widget for App {
         } else {
             axis.width
         };
-        let spacing = if matches!(
-            self.selected_tab,
-            SelectedTab::SpaceBetween | SelectedTab::SpaceAround
-        ) {
-            0
-        } else {
-            self.spacing
-        };
-        self.axis(axis_width, spacing).render(axis, buf);
+        self.axis(axis_width, self.spacing).render(axis, buf);
     }
 }
 

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -1328,7 +1328,7 @@ mod tests {
                 .flex(Flex::SpaceBetween);
             assert_eq!(
                 table.get_columns_widths(62, 0),
-                &[(0, 21), (21, 20), (41, 21)]
+                &[(0, 20), (21, 20), (42, 20)]
             );
         }
 


### PR DESCRIPTION
This PR implements user provided spacing gaps for `SpaceAround` and `SpaceBetween`.

https://github.com/ratatui-org/ratatui/assets/1813121/2e260708-e8a7-48ef-aec7-9cf84b655e91

Now user provided spacing gaps always take priority in all `Flex` modes.