### PR TITLE
feat: Constraint Explorer example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,11 @@ required-features = ["crossterm"]
 doc-scrape-examples = true
 
 [[example]]
+name = "constraint-explorer"
+required-features = ["crossterm"]
+doc-scrape-examples = true
+
+[[example]]
 name = "list"
 required-features = ["crossterm"]
 doc-scrape-examples = true

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -124,6 +124,12 @@ impl App {
             Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                 Char('q') | Esc => self.exit(),
                 Char('s') | Enter => self.toggle_edit(),
+                Char('1') => self.swap_constraint(ConstraintName::Min),
+                Char('2') => self.swap_constraint(ConstraintName::Max),
+                Char('3') => self.swap_constraint(ConstraintName::Length),
+                Char('4') => self.swap_constraint(ConstraintName::Percentage),
+                Char('5') => self.swap_constraint(ConstraintName::Ratio),
+                Char('6') => self.swap_constraint(ConstraintName::Fill),
                 _ => self.handle_mode_events(key),
             },
             _ => {}
@@ -238,6 +244,20 @@ impl App {
         }
     }
 
+    fn swap_constraint(&mut self, name: ConstraintName) {
+        // save the editor state
+        let constraint = match name {
+            ConstraintName::Length => Length(self.value),
+            ConstraintName::Percentage => Percentage(self.value),
+            ConstraintName::Min => Min(self.value),
+            ConstraintName::Max => Max(self.value),
+            ConstraintName::Fill => Fill(self.value),
+            ConstraintName::Ratio => Ratio(1, self.value as u32),
+        };
+        self.constraints[self.selected_index] = constraint;
+        self.mode = AppMode::Select;
+    }
+
     // edits if in select mode, selects if in edit mode
     fn toggle_edit(&mut self) {
         if self.constraints.is_empty() {
@@ -341,7 +361,7 @@ impl App {
             Length(1),
         ]));
 
-        format!("{:?}", flex).bold().render(label, buf);
+        format!("Flex::{:?}", flex).bold().render(label, buf);
 
         let (blocks, spacers) = Layout::horizontal(&self.constraints)
             .flex(flex)

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -314,7 +314,11 @@ impl App {
             ]
             .iter()
             .enumerate()
-            .map(|(i, name)| format!("  {i}: {name}  ").fg(SLATE.c200).bg(name.color()))
+            .map(|(i, name)| {
+                format!("  {i}: {name}  ", i = i + 1)
+                    .fg(SLATE.c200)
+                    .bg(name.color())
+            })
             .intersperse(Span::from(" "))
             .collect_vec(),
         ))

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -541,8 +541,8 @@ impl ConstraintName {
             Self::Percentage => STONE.c600,
             Self::Ratio => STONE.c700,
             Self::Fill => STONE.c800,
-            Self::Min => BLUE.c600,
-            Self::Max => BLUE.c500,
+            Self::Min => INDIGO.c600,
+            Self::Max => INDIGO.c500,
         }
     }
 }

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -1,0 +1,377 @@
+//! # [Ratatui] Flex example
+//!
+//! The latest version of this example is available in the [examples] folder in the repository.
+//!
+//! Please note that the examples are designed to be run against the `main` branch of the Github
+//! repository. This means that you may not be able to compile with the latest release version on
+//! crates.io, or the one that you have installed locally.
+//!
+//! See the [examples readme] for more information on finding examples that match the version of the
+//! library you are using.
+//!
+//! [Ratatui]: https://github.com/ratatui-org/ratatui
+//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+
+use std::io::{self, stdout};
+
+use color_eyre::{config::HookBuilder, Result};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use ratatui::{
+    layout::{Constraint::*, Flex},
+    prelude::*,
+    style::palette::tailwind,
+    symbols::line,
+    widgets::*,
+};
+use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
+
+// priority 2
+const MIN_COLOR: Color = tailwind::BLUE.c900;
+const MAX_COLOR: Color = tailwind::BLUE.c800;
+// priority 3
+const LENGTH_COLOR: Color = tailwind::SLATE.c700;
+const PERCENTAGE_COLOR: Color = tailwind::SLATE.c800;
+const RATIO_COLOR: Color = tailwind::SLATE.c900;
+// priority 4
+const FILL_COLOR: Color = tailwind::SLATE.c950;
+
+fn color_for_constraint(constraint: Constraint) -> Color {
+    match constraint {
+        Constraint::Min(_) => MIN_COLOR,
+        Constraint::Max(_) => MAX_COLOR,
+        Constraint::Length(_) => LENGTH_COLOR,
+        Constraint::Percentage(_) => PERCENTAGE_COLOR,
+        Constraint::Ratio(_, _) => RATIO_COLOR,
+        Constraint::Fill(_) => FILL_COLOR,
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, EnumIter, FromRepr, Display)]
+enum SelectedConstraint {
+    #[default]
+    Length,
+    Percentage,
+    Ratio,
+    Min,
+    Max,
+    Fill,
+}
+
+impl SelectedConstraint {
+    /// Get the previous tab, if there is no previous tab return the current tab.
+    fn prev(&self) -> Self {
+        let current_index: usize = *self as usize;
+        let previous_index = current_index.saturating_sub(1);
+        Self::from_repr(previous_index).unwrap_or(*self)
+    }
+
+    /// Get the next tab, if there is no next tab return the current tab.
+    fn next(&self) -> Self {
+        let current_index = *self as usize;
+        let next_index = current_index.saturating_add(1);
+        Self::from_repr(next_index).unwrap_or(*self)
+    }
+
+    fn to_tab_title(value: Self) -> Line<'static> {
+        use SelectedConstraint::*;
+        let text = format!("  {value}  ");
+        let color = match value {
+            Length => LENGTH_COLOR,
+            Percentage => PERCENTAGE_COLOR,
+            Ratio => RATIO_COLOR,
+            Fill => FILL_COLOR,
+            Min => MIN_COLOR,
+            Max => MAX_COLOR,
+        };
+        text.fg(tailwind::SLATE.c200).bg(color).into()
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum AppState {
+    #[default]
+    Running,
+    Quit,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum PromptState {
+    #[default]
+    SelectConstraint,
+    PromptConstraintDetails(SelectedConstraint),
+}
+
+#[derive(Default, Clone)]
+struct App {
+    spacing: u16,
+    state: AppState,
+    selected_constraint: SelectedConstraint,
+    current: Constraint,
+    flex: Flex,
+    constraints: Vec<Constraint>,
+    prompt_state: PromptState,
+}
+
+impl App {
+    fn run(&mut self, mut terminal: Terminal<impl Backend>) -> Result<()> {
+        self.draw(&mut terminal)?;
+        while self.is_running() {
+            self.handle_events()?;
+            self.draw(&mut terminal)?;
+        }
+        Ok(())
+    }
+
+    fn is_running(&self) -> bool {
+        self.state == AppState::Running
+    }
+
+    fn draw(&self, terminal: &mut Terminal<impl Backend>) -> io::Result<()> {
+        terminal.draw(|frame| frame.render_widget(self, frame.size()))?;
+        Ok(())
+    }
+
+    fn handle_events(&mut self) -> Result<()> {
+        use KeyCode::*;
+        match event::read()? {
+            Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
+                Char('q') | Esc => self.quit(),
+                Char('+') => self.increment_spacing(),
+                Char('-') => self.decrement_spacing(),
+                Char('l') => self.next(),
+                Char('h') => self.prev(),
+                Enter => match self.prompt_state {
+                    PromptState::SelectConstraint => self.prompt(),
+                    PromptState::PromptConstraintDetails(selection) => self.confirm(selection),
+                },
+                _ => (),
+            },
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn increment_spacing(&mut self) {
+        self.spacing = self.spacing.saturating_add(1);
+    }
+
+    fn decrement_spacing(&mut self) {
+        self.spacing = self.spacing.saturating_sub(1);
+    }
+
+    fn next(&mut self) {
+        self.selected_constraint = self.selected_constraint.next();
+    }
+
+    fn prev(&mut self) {
+        self.selected_constraint = self.selected_constraint.prev();
+    }
+
+    fn prompt(&mut self) {
+        self.prompt_state = PromptState::PromptConstraintDetails(self.selected_constraint);
+    }
+
+    fn confirm(&mut self, selection: SelectedConstraint) {
+        use SelectedConstraint::*;
+        let c = match selection {
+            Length => Constraint::Length(10),
+            Percentage => Constraint::Percentage(10),
+            Ratio => Constraint::Ratio(1, 10),
+            Min => Constraint::Min(10),
+            Max => Constraint::Max(10),
+            Fill => Constraint::Fill(1),
+        };
+        self.constraints.push(c);
+        self.prompt_state = PromptState::SelectConstraint;
+    }
+
+    fn quit(&mut self) {
+        self.state = AppState::Quit;
+    }
+}
+
+impl Widget for &App {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let layout = Layout::vertical([Length(3), Length(1), Fill(0)]).spacing(2);
+        let [tabs, axis, demo] = area.split(&layout);
+        self.render_tabs(tabs, buf);
+        let scroll_needed = self.render_demo(demo, buf);
+        let axis_width = if scroll_needed {
+            axis.width.saturating_sub(1)
+        } else {
+            axis.width
+        };
+        let spacing = self.spacing;
+        self.axis(axis_width, spacing).render(axis, buf);
+        match self.prompt_state {
+            PromptState::PromptConstraintDetails(selected) => {
+                let [area] = area.split(&Layout::vertical([Percentage(50)]).flex(Flex::Center));
+                let [area] = area.split(&Layout::horizontal([Percentage(50)]).flex(Flex::Center));
+                self.render_prompt(area, buf);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl App {
+    /// a bar like `<----- 80 px (gap: 2 px)? ----->`
+    fn axis(&self, width: u16, spacing: u16) -> impl Widget {
+        let width = width as usize;
+        // only show gap when spacing is not zero
+        let label = if spacing != 0 {
+            format!("{} px (gap: {} px)", width, spacing)
+        } else {
+            format!("{} px", width)
+        };
+        let bar_width = width.saturating_sub(2); // we want to `<` and `>` at the ends
+        let width_bar = format!("<{label:-^bar_width$}>");
+        Paragraph::new(width_bar.dark_gray()).centered()
+    }
+
+    fn render_tabs(&self, area: Rect, buf: &mut Buffer) {
+        let titles = SelectedConstraint::iter().map(SelectedConstraint::to_tab_title);
+        let block = Block::new()
+            .title("Constraints ".bold())
+            .title(" Use h l or ◄ ► to change tab and j k or ▲ ▼  to scroll");
+        Tabs::new(titles)
+            .block(block)
+            .highlight_style(Modifier::REVERSED)
+            .select(self.selected_constraint as usize)
+            .padding("", "")
+            .divider(" ")
+            .render(area, buf);
+    }
+
+    fn render_prompt(&self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+        Paragraph::new("Input")
+            .style(Style::reset().dark_gray())
+            .alignment(Alignment::Center)
+            .block(Block::bordered())
+            .render(area, buf);
+    }
+
+    fn render_demo(&self, area: Rect, buf: &mut Buffer) -> bool {
+        let height = 4;
+        let area = Rect::new(area.x, area.y, area.width, height);
+
+        let (blocks, spacers) = Layout::horizontal(&self.constraints)
+            .flex(self.flex)
+            .spacing(self.spacing)
+            .split_with_spacers(area);
+
+        for (block, constraint) in blocks.iter().zip(&self.constraints) {
+            self.illustration(*constraint, block.width)
+                .render(*block, buf);
+        }
+
+        for spacer in spacers.iter() {
+            self.render_spacer(*spacer, buf);
+        }
+
+        false
+    }
+
+    fn render_spacer(&self, spacer: Rect, buf: &mut Buffer) {
+        if spacer.width > 1 {
+            let corners_only = symbols::border::Set {
+                top_left: line::NORMAL.top_left,
+                top_right: line::NORMAL.top_right,
+                bottom_left: line::NORMAL.bottom_left,
+                bottom_right: line::NORMAL.bottom_right,
+                vertical_left: " ",
+                vertical_right: " ",
+                horizontal_top: " ",
+                horizontal_bottom: " ",
+            };
+            Block::bordered()
+                .border_set(corners_only)
+                .border_style(Style::reset().dark_gray())
+                .render(spacer, buf);
+        } else {
+            Paragraph::new(Text::from(vec![
+                Line::from(""),
+                Line::from("│"),
+                Line::from("│"),
+                Line::from(""),
+            ]))
+            .style(Style::reset().dark_gray())
+            .render(spacer, buf);
+        }
+        let width = spacer.width;
+        let label = if width > 4 {
+            format!("{width} px")
+        } else if width > 2 {
+            format!("{width}")
+        } else {
+            "".to_string()
+        };
+        let text = Text::from(vec![
+            Line::raw(""),
+            Line::raw(""),
+            Line::styled(label, Style::reset().dark_gray()),
+        ]);
+        Paragraph::new(text)
+            .style(Style::reset().dark_gray())
+            .alignment(Alignment::Center)
+            .render(spacer, buf);
+    }
+
+    fn illustration(&self, constraint: Constraint, width: u16) -> Paragraph {
+        let main_color = color_for_constraint(constraint);
+        let fg_color = Color::White;
+        let title = format!("{constraint}");
+        let content = format!("{width} px");
+        let text = format!("{title}\n{content}");
+        let block = Block::bordered()
+            .border_set(symbols::border::QUADRANT_OUTSIDE)
+            .border_style(Style::reset().fg(main_color).reversed())
+            .style(Style::default().fg(fg_color).bg(main_color));
+        Paragraph::new(text).centered().block(block)
+    }
+}
+
+fn init_error_hooks() -> Result<()> {
+    let (panic, error) = HookBuilder::default().into_hooks();
+    let panic = panic.into_panic_hook();
+    let error = error.into_eyre_hook();
+    color_eyre::eyre::set_hook(Box::new(move |e| {
+        let _ = restore_terminal();
+        error(e)
+    }))?;
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = restore_terminal();
+        panic(info)
+    }));
+    Ok(())
+}
+
+fn init_terminal() -> Result<Terminal<impl Backend>> {
+    enable_raw_mode()?;
+    stdout().execute(EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout());
+    let terminal = Terminal::new(backend)?;
+    Ok(terminal)
+}
+
+fn restore_terminal() -> Result<()> {
+    disable_raw_mode()?;
+    stdout().execute(LeaveAlternateScreen)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    // assuming the user changes spacing about a 100 times or so
+    init_error_hooks()?;
+    let terminal = init_terminal()?;
+    App::default().run(terminal)?;
+
+    restore_terminal()?;
+    Ok(())
+}

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -288,7 +288,10 @@ impl App {
 
     fn instructions(&self) -> impl Widget {
         let text = "◄ ►: select, ▲ ▼: edit, 1-6: swap, a: add, x: delete, q: quit, + -: spacing";
-        Paragraph::new(text.fg(Self::TEXT_COLOR).to_centered_line()).wrap(Wrap { trim: false })
+        Paragraph::new(text)
+            .fg(Self::TEXT_COLOR)
+            .centered()
+            .wrap(Wrap { trim: false })
     }
 
     fn legend(&self) -> impl Widget {

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -1,4 +1,4 @@
-//! # [Ratatui] Flex example
+//! # [Ratatui] Constraint explorer example
 //!
 //! The latest version of this example is available in the [examples] folder in the repository.
 //!
@@ -17,79 +17,26 @@ use std::io::{self, stdout};
 
 use color_eyre::{config::HookBuilder, Result};
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
 use ratatui::{
     layout::{Constraint::*, Flex},
     prelude::*,
-    style::palette::tailwind,
+    style::palette::tailwind::*,
     symbols::line,
     widgets::*,
 };
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
-// priority 2
-const MIN_COLOR: Color = tailwind::BLUE.c900;
-const MAX_COLOR: Color = tailwind::BLUE.c800;
-// priority 3
-const LENGTH_COLOR: Color = tailwind::SLATE.c700;
-const PERCENTAGE_COLOR: Color = tailwind::SLATE.c800;
-const RATIO_COLOR: Color = tailwind::SLATE.c900;
-// priority 4
-const FILL_COLOR: Color = tailwind::SLATE.c950;
-
-fn color_for_constraint(constraint: Constraint) -> Color {
-    match constraint {
-        Constraint::Min(_) => MIN_COLOR,
-        Constraint::Max(_) => MAX_COLOR,
-        Constraint::Length(_) => LENGTH_COLOR,
-        Constraint::Percentage(_) => PERCENTAGE_COLOR,
-        Constraint::Ratio(_, _) => RATIO_COLOR,
-        Constraint::Fill(_) => FILL_COLOR,
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, EnumIter, FromRepr, Display)]
-enum SelectedConstraint {
-    #[default]
-    Length,
-    Percentage,
-    Ratio,
-    Min,
-    Max,
-    Fill,
-}
-
-impl SelectedConstraint {
-    /// Get the previous tab, if there is no previous tab return the current tab.
-    fn prev(&self) -> Self {
-        let current_index: usize = *self as usize;
-        let previous_index = current_index.saturating_sub(1);
-        Self::from_repr(previous_index).unwrap_or(*self)
-    }
-
-    /// Get the next tab, if there is no next tab return the current tab.
-    fn next(&self) -> Self {
-        let current_index = *self as usize;
-        let next_index = current_index.saturating_add(1);
-        Self::from_repr(next_index).unwrap_or(*self)
-    }
-
-    fn to_tab_title(value: Self) -> Line<'static> {
-        use SelectedConstraint::*;
-        let text = format!("  {value}  ");
-        let color = match value {
-            Length => LENGTH_COLOR,
-            Percentage => PERCENTAGE_COLOR,
-            Ratio => RATIO_COLOR,
-            Fill => FILL_COLOR,
-            Min => MIN_COLOR,
-            Max => MAX_COLOR,
-        };
-        text.fg(tailwind::SLATE.c200).bg(color).into()
-    }
+#[derive(Default, Clone)]
+struct App {
+    state: AppState,
+    layout_blocks: LayoutBlocks,
+    // TODO: move this to a separate editing struct
+    prompt_state: PromptState,
+    selected_constraint: ConstraintName,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -103,26 +50,35 @@ enum AppState {
 enum PromptState {
     #[default]
     SelectConstraint,
-    PromptConstraintDetails(SelectedConstraint),
+    PromptConstraintDetails(ConstraintName),
 }
 
-#[derive(Default, Clone)]
-struct App {
-    spacing: u16,
-    state: AppState,
-    selected_constraint: SelectedConstraint,
-    current: Constraint,
-    flex: Flex,
-    constraints: Vec<Constraint>,
-    prompt_state: PromptState,
+/// A variant of [`Constraint`] that can be rendered as a tab.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, EnumIter, FromRepr, Display)]
+enum ConstraintName {
+    #[default]
+    Length,
+    Percentage,
+    Ratio,
+    Min,
+    Max,
+    Fill,
 }
 
+fn main() -> Result<()> {
+    init_error_hooks()?;
+    let terminal = init_terminal()?;
+    App::default().run(terminal)?;
+    restore_terminal()?;
+    Ok(())
+}
+
+// App behaviour
 impl App {
     fn run(&mut self, mut terminal: Terminal<impl Backend>) -> Result<()> {
-        self.draw(&mut terminal)?;
         while self.is_running() {
-            self.handle_events()?;
             self.draw(&mut terminal)?;
+            self.handle_events()?;
         }
         Ok(())
     }
@@ -141,19 +97,228 @@ impl App {
         match event::read()? {
             Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                 Char('q') | Esc => self.quit(),
-                Char('+') => self.increment_spacing(),
-                Char('-') => self.decrement_spacing(),
-                Char('l') => self.next(),
-                Char('h') => self.prev(),
+                Char('h') => self.prev_constraint(),
+                Char('l') => self.next_constraint(),
                 Enter => match self.prompt_state {
                     PromptState::SelectConstraint => self.prompt(),
                     PromptState::PromptConstraintDetails(selection) => self.confirm(selection),
                 },
-                _ => (),
+                _ => self.layout_blocks.handle_key_event(key),
             },
             _ => {}
         }
         Ok(())
+    }
+
+    fn next_constraint(&mut self) {
+        self.selected_constraint = self.selected_constraint.next();
+    }
+
+    fn prev_constraint(&mut self) {
+        self.selected_constraint = self.selected_constraint.prev();
+    }
+
+    fn prompt(&mut self) {
+        self.prompt_state = PromptState::PromptConstraintDetails(self.selected_constraint);
+    }
+
+    fn confirm(&mut self, selection: ConstraintName) {
+        use ConstraintName::*;
+        let c = match selection {
+            Length => Constraint::Length(10),
+            Percentage => Constraint::Percentage(10),
+            Ratio => Constraint::Ratio(1, 10),
+            Min => Constraint::Min(10),
+            Max => Constraint::Max(10),
+            Fill => Constraint::Fill(1),
+        };
+        self.layout_blocks.constraints.push(c);
+        self.prompt_state = PromptState::SelectConstraint;
+    }
+
+    fn quit(&mut self) {
+        self.state = AppState::Quit;
+    }
+}
+
+// ConstraintName behaviour
+impl ConstraintName {
+    /// Get the previous tab, if there is no previous tab return the current tab.
+    fn prev(&self) -> Self {
+        let current_index: usize = *self as usize;
+        let previous_index = current_index.saturating_sub(1);
+        Self::from_repr(previous_index).unwrap_or(*self)
+    }
+
+    /// Get the next tab, if there is no next tab return the current tab.
+    fn next(&self) -> Self {
+        let current_index = *self as usize;
+        let next_index = current_index.saturating_add(1);
+        Self::from_repr(next_index).unwrap_or(*self)
+    }
+}
+
+impl From<Constraint> for ConstraintName {
+    fn from(constraint: Constraint) -> Self {
+        use Constraint::*;
+        match constraint {
+            Length(_) => ConstraintName::Length,
+            Percentage(_) => ConstraintName::Percentage,
+            Ratio(_, _) => ConstraintName::Ratio,
+            Min(_) => ConstraintName::Min,
+            Max(_) => ConstraintName::Max,
+            Fill(_) => ConstraintName::Fill,
+        }
+    }
+}
+
+impl Widget for &App {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let [header, demo, instructions, tabs] = area.split(&Layout::vertical([
+            Length(1),
+            Length(6),
+            Length(1),
+            Fill(0),
+        ]));
+
+        self.header().render(header, buf);
+        self.layout_blocks.render(demo, buf);
+        self.instructions().render(instructions, buf);
+        self.tabs().render(tabs, buf);
+
+        if let PromptState::PromptConstraintDetails(_selected) = self.prompt_state {
+            let [area] = area.split(&Layout::vertical([Percentage(50)]).flex(Flex::Center));
+            let [area] = area.split(&Layout::horizontal([Percentage(50)]).flex(Flex::Center));
+            self.render_prompt(area, buf);
+        }
+    }
+}
+
+// App rendering
+impl App {
+    const HEADER_COLOR: Color = SLATE.c200;
+    const TEXT_COLOR: Color = SLATE.c400;
+
+    fn header(&self) -> impl Widget {
+        let text = "Constraint Explorer";
+        text.bold().fg(Self::HEADER_COLOR).to_centered_line()
+    }
+
+    fn instructions(&self) -> impl Widget {
+        let text = "◄ ►: select constraint, e: edit, i: insert, d: delete, q: quit";
+        text.fg(Self::TEXT_COLOR).to_centered_line()
+    }
+
+    fn tabs(&self) -> impl Widget {
+        let titles = ConstraintName::iter().map(ConstraintName::to_tab_title);
+        Tabs::new(titles)
+            .highlight_style(Modifier::REVERSED)
+            .select(self.selected_constraint as usize)
+            .padding("", "")
+            .divider(" ")
+    }
+
+    fn render_prompt(&self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+        Paragraph::new("Input")
+            .style(Self::TEXT_COLOR)
+            .alignment(Alignment::Center)
+            .block(Block::bordered())
+            .render(area, buf);
+    }
+}
+
+impl ConstraintName {
+    fn to_tab_title(self) -> Line<'static> {
+        format!("  {self}  ").fg(SLATE.c200).bg(self.color()).into()
+    }
+
+    fn color(&self) -> Color {
+        match self {
+            Self::Length => SLATE.c700,
+            Self::Percentage => SLATE.c800,
+            Self::Ratio => SLATE.c900,
+            Self::Fill => SLATE.c950,
+            Self::Min => BLUE.c900,
+            Self::Max => BLUE.c800,
+        }
+    }
+}
+
+/// A widget that renders a set of [`ConstraintBlock`]s and [`SpacerBlock`]s with an axis that shows
+/// the width of the layout. E.g.: `<----- 80 px (gap: 2 px) ----->`
+///
+/// TODO: make this a stateful widget and store the constraints and spacing in it rather than in
+/// the app
+#[derive(Debug, Default, Clone)]
+struct LayoutBlocks {
+    constraints: Vec<Constraint>,
+    flex: Flex,
+    spacing: u16,
+    selected_index: usize,
+}
+
+impl Widget for &LayoutBlocks {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let [axis_area, layout_area, arrows] =
+            area.split(&Layout::vertical([Length(1), Fill(0), Length(1)]));
+
+        self.axis(axis_area.width).render(axis_area, buf);
+
+        let (blocks, spacers) = Layout::horizontal(&self.constraints)
+            .flex(self.flex)
+            .spacing(self.spacing)
+            .split_with_spacers(layout_area);
+
+        for (area, constraint) in blocks.iter().zip(self.constraints.iter()) {
+            ConstraintBlock::new(*constraint).render(*area, buf);
+        }
+
+        for area in spacers.iter() {
+            SpacerBlock.render(*area, buf);
+        }
+
+        if let Some(block) = blocks.get(self.selected_index) {
+            let arrow_area = Rect {
+                x: block.x,
+                y: arrows.y,
+                width: block.width,
+                height: arrows.height,
+            };
+            LayoutBlocks::cursor(block.width).render(arrow_area, buf);
+        }
+    }
+}
+
+impl LayoutBlocks {
+    const AXIS_COLOR: Color = SLATE.c300;
+
+    fn handle_key_event(&mut self, key: KeyEvent) {
+        use KeyCode::*;
+        match key.code {
+            // TODO move this keyboard handling into layout blocks
+            Char('+') => self.increment_spacing(),
+            Char('-') => self.decrement_spacing(),
+            Left => self.prev_block(),
+            Right => self.next_block(),
+            _ => (),
+        }
+    }
+    /// select the next block with wrap around
+    fn next_block(&mut self) {
+        if self.constraints.is_empty() {
+            return;
+        }
+        self.selected_index = (self.selected_index + 1) % self.constraints.len();
+    }
+
+    /// select the previous block with wrap around
+    fn prev_block(&mut self) {
+        if self.constraints.is_empty() {
+            return;
+        }
+        self.selected_index =
+            (self.selected_index + self.constraints.len() - 1) % self.constraints.len();
     }
 
     fn increment_spacing(&mut self) {
@@ -164,176 +329,140 @@ impl App {
         self.spacing = self.spacing.saturating_sub(1);
     }
 
-    fn next(&mut self) {
-        self.selected_constraint = self.selected_constraint.next();
-    }
-
-    fn prev(&mut self) {
-        self.selected_constraint = self.selected_constraint.prev();
-    }
-
-    fn prompt(&mut self) {
-        self.prompt_state = PromptState::PromptConstraintDetails(self.selected_constraint);
-    }
-
-    fn confirm(&mut self, selection: SelectedConstraint) {
-        use SelectedConstraint::*;
-        let c = match selection {
-            Length => Constraint::Length(10),
-            Percentage => Constraint::Percentage(10),
-            Ratio => Constraint::Ratio(1, 10),
-            Min => Constraint::Min(10),
-            Max => Constraint::Max(10),
-            Fill => Constraint::Fill(1),
-        };
-        self.constraints.push(c);
-        self.prompt_state = PromptState::SelectConstraint;
-    }
-
-    fn quit(&mut self) {
-        self.state = AppState::Quit;
-    }
-}
-
-impl Widget for &App {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        let layout = Layout::vertical([Length(3), Length(1), Fill(0)]).spacing(2);
-        let [tabs, axis, demo] = area.split(&layout);
-        self.render_tabs(tabs, buf);
-        let scroll_needed = self.render_demo(demo, buf);
-        let axis_width = if scroll_needed {
-            axis.width.saturating_sub(1)
-        } else {
-            axis.width
-        };
-        let spacing = self.spacing;
-        self.axis(axis_width, spacing).render(axis, buf);
-        match self.prompt_state {
-            PromptState::PromptConstraintDetails(selected) => {
-                let [area] = area.split(&Layout::vertical([Percentage(50)]).flex(Flex::Center));
-                let [area] = area.split(&Layout::horizontal([Percentage(50)]).flex(Flex::Center));
-                self.render_prompt(area, buf);
-            }
-            _ => {}
-        }
-    }
-}
-
-impl App {
-    /// a bar like `<----- 80 px (gap: 2 px)? ----->`
-    fn axis(&self, width: u16, spacing: u16) -> impl Widget {
-        let width = width as usize;
-        // only show gap when spacing is not zero
-        let label = if spacing != 0 {
-            format!("{} px (gap: {} px)", width, spacing)
+    /// A bar like `<----- 80 px (gap: 2 px) ----->`
+    ///
+    /// Only shows the gap when spacing is not zero
+    fn axis(&self, width: u16) -> impl Widget {
+        let label = if self.spacing != 0 {
+            format!("{} px (gap: {} px)", width, self.spacing)
         } else {
             format!("{} px", width)
         };
-        let bar_width = width.saturating_sub(2); // we want to `<` and `>` at the ends
+        let bar_width = width.saturating_sub(2) as usize; // we want to `<` and `>` at the ends
         let width_bar = format!("<{label:-^bar_width$}>");
-        Paragraph::new(width_bar.dark_gray()).centered()
+        Paragraph::new(width_bar).fg(Self::AXIS_COLOR).centered()
     }
 
-    fn render_tabs(&self, area: Rect, buf: &mut Buffer) {
-        let titles = SelectedConstraint::iter().map(SelectedConstraint::to_tab_title);
-        let block = Block::new()
-            .title("Constraints ".bold())
-            .title(" Use h l or ◄ ► to change tab and j k or ▲ ▼  to scroll");
-        Tabs::new(titles)
-            .block(block)
-            .highlight_style(Modifier::REVERSED)
-            .select(self.selected_constraint as usize)
-            .padding("", "")
-            .divider(" ")
-            .render(area, buf);
+    /// A cursor like `└───┬───┘` that points to the selected block
+    fn cursor(width: u16) -> impl Widget {
+        let repeat = width.saturating_sub(2) as usize;
+        let mid = "┬";
+        let arrow = format!("└{mid:─^repeat$}┘");
+        Paragraph::new(arrow).fg(LayoutBlocks::AXIS_COLOR)
     }
+}
 
-    fn render_prompt(&self, area: Rect, buf: &mut Buffer) {
-        Clear.render(area, buf);
-        Paragraph::new("Input")
-            .style(Style::reset().dark_gray())
-            .alignment(Alignment::Center)
-            .block(Block::bordered())
-            .render(area, buf);
-    }
+/// A widget that renders a [`Constraint`] as a block. E.g.:
+/// ```plain
+/// ┌──────────────┐
+/// │  Length(16)  │
+/// │     16px     │
+/// └──────────────┘
+/// ```
+struct ConstraintBlock {
+    constraint: Constraint,
+}
 
-    fn render_demo(&self, area: Rect, buf: &mut Buffer) -> bool {
-        let height = 4;
-        let area = Rect::new(area.x, area.y, area.width, height);
-
-        let (blocks, spacers) = Layout::horizontal(&self.constraints)
-            .flex(self.flex)
-            .spacing(self.spacing)
-            .split_with_spacers(area);
-
-        for (block, constraint) in blocks.iter().zip(&self.constraints) {
-            self.illustration(*constraint, block.width)
-                .render(*block, buf);
-        }
-
-        for spacer in spacers.iter() {
-            self.render_spacer(*spacer, buf);
-        }
-
-        false
-    }
-
-    fn render_spacer(&self, spacer: Rect, buf: &mut Buffer) {
-        if spacer.width > 1 {
-            let corners_only = symbols::border::Set {
-                top_left: line::NORMAL.top_left,
-                top_right: line::NORMAL.top_right,
-                bottom_left: line::NORMAL.bottom_left,
-                bottom_right: line::NORMAL.bottom_right,
-                vertical_left: " ",
-                vertical_right: " ",
-                horizontal_top: " ",
-                horizontal_bottom: " ",
-            };
-            Block::bordered()
-                .border_set(corners_only)
-                .border_style(Style::reset().dark_gray())
-                .render(spacer, buf);
-        } else {
-            Paragraph::new(Text::from(vec![
-                Line::from(""),
-                Line::from("│"),
-                Line::from("│"),
-                Line::from(""),
-            ]))
-            .style(Style::reset().dark_gray())
-            .render(spacer, buf);
-        }
-        let width = spacer.width;
-        let label = if width > 4 {
-            format!("{width} px")
-        } else if width > 2 {
-            format!("{width}")
-        } else {
-            "".to_string()
-        };
-        let text = Text::from(vec![
-            Line::raw(""),
-            Line::raw(""),
-            Line::styled(label, Style::reset().dark_gray()),
-        ]);
-        Paragraph::new(text)
-            .style(Style::reset().dark_gray())
-            .alignment(Alignment::Center)
-            .render(spacer, buf);
-    }
-
-    fn illustration(&self, constraint: Constraint, width: u16) -> Paragraph {
-        let main_color = color_for_constraint(constraint);
-        let fg_color = Color::White;
-        let title = format!("{constraint}");
-        let content = format!("{width} px");
-        let text = format!("{title}\n{content}");
+impl Widget for ConstraintBlock {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let main_color = ConstraintName::from(self.constraint).color();
+        let label = self.label(area.width);
         let block = Block::bordered()
             .border_set(symbols::border::QUADRANT_OUTSIDE)
             .border_style(Style::reset().fg(main_color).reversed())
-            .style(Style::default().fg(fg_color).bg(main_color));
-        Paragraph::new(text).centered().block(block)
+            .style(Style::default().fg(Self::TEXT_COLOR).bg(main_color));
+        Paragraph::new(label)
+            .centered()
+            .block(block)
+            .render(area, buf);
+    }
+}
+
+impl ConstraintBlock {
+    const TEXT_COLOR: Color = SLATE.c200;
+
+    fn new(constraint: Constraint) -> Self {
+        Self { constraint }
+    }
+
+    fn label(&self, width: u16) -> String {
+        let long_width = format!("{} px", width);
+        let short_width = format!("{}", width);
+        // border takes up 2 columns
+        let available_space = width.saturating_sub(2) as usize;
+        let width_label = if long_width.len() < available_space {
+            long_width
+        } else if short_width.len() < available_space {
+            short_width
+        } else {
+            "".to_string()
+        };
+        format!("{}\n{}", self.constraint, width_label)
+    }
+}
+
+/// A widget that renders a spacer with a label indicating the width of the spacer. E.g.:
+///
+/// ```plain
+/// ┌      ┐
+///   8 px
+/// └      ┘
+/// ```
+struct SpacerBlock;
+
+impl Widget for SpacerBlock {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width > 1 {
+            Self::block().render(area, buf);
+        } else {
+            Self::line().render(area, buf);
+        }
+        let row = area.rows().nth(2).unwrap_or_default();
+        Self::label(area.width).render(row, buf);
+    }
+}
+
+impl SpacerBlock {
+    const TEXT_COLOR: Color = SLATE.c400;
+    const BORDER_COLOR: Color = SLATE.c600;
+
+    fn block() -> impl Widget {
+        let corners_only = symbols::border::Set {
+            top_left: line::NORMAL.top_left,
+            top_right: line::NORMAL.top_right,
+            bottom_left: line::NORMAL.bottom_left,
+            bottom_right: line::NORMAL.bottom_right,
+            vertical_left: " ",
+            vertical_right: " ",
+            horizontal_top: " ",
+            horizontal_bottom: " ",
+        };
+        Block::bordered()
+            .border_set(corners_only)
+            .border_style(Self::BORDER_COLOR)
+    }
+
+    fn line() -> impl Widget {
+        Paragraph::new(Text::from(vec![
+            Line::from(""),
+            Line::from("│"),
+            Line::from("│"),
+            Line::from(""),
+        ]))
+        .style(Self::BORDER_COLOR)
+    }
+
+    fn label(width: u16) -> impl Widget {
+        let long_label = format!("{width} px");
+        let short_label = format!("{width}");
+        let label = if long_label.len() < width as usize {
+            long_label
+        } else if short_label.len() < width as usize {
+            short_label
+        } else {
+            "".to_string()
+        };
+        Line::styled(label, Self::TEXT_COLOR).centered()
     }
 }
 
@@ -363,15 +492,5 @@ fn init_terminal() -> Result<Terminal<impl Backend>> {
 fn restore_terminal() -> Result<()> {
     disable_raw_mode()?;
     stdout().execute(LeaveAlternateScreen)?;
-    Ok(())
-}
-
-fn main() -> Result<()> {
-    // assuming the user changes spacing about a 100 times or so
-    init_error_hooks()?;
-    let terminal = init_terminal()?;
-    App::default().run(terminal)?;
-
-    restore_terminal()?;
     Ok(())
 }

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -530,8 +530,8 @@ impl ConstraintName {
             Self::Percentage => SLATE.c800,
             Self::Ratio => SLATE.c900,
             Self::Fill => SLATE.c950,
-            Self::Min => BLUE.c900,
-            Self::Max => BLUE.c800,
+            Self::Min => BLUE.c800,
+            Self::Max => BLUE.c900,
         }
     }
 
@@ -541,8 +541,8 @@ impl ConstraintName {
             Self::Percentage => STONE.c600,
             Self::Ratio => STONE.c700,
             Self::Fill => STONE.c800,
-            Self::Min => INDIGO.c600,
-            Self::Max => INDIGO.c500,
+            Self::Min => INDIGO.c500,
+            Self::Max => INDIGO.c600,
         }
     }
 }

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -30,27 +30,25 @@ use ratatui::{
 };
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
-#[derive(Default, Clone)]
+#[derive(Default)]
 struct App {
-    state: AppState,
+    mode: AppMode,
     layout_blocks: LayoutBlocks,
-    // TODO: move this to a separate editing struct
-    prompt_state: PromptState,
-    selected_constraint: ConstraintName,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-enum AppState {
+#[derive(Debug, Default, PartialEq, Eq)]
+enum AppMode {
     #[default]
-    Running,
+    Select,
+    Edit(ConstraintEditor),
     Quit,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-enum PromptState {
-    #[default]
-    SelectConstraint,
-    PromptConstraintDetails(ConstraintName),
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ConstraintEditor {
+    constraint_type: ConstraintName,
+    value1: String,
+    value2: String,
 }
 
 /// A variant of [`Constraint`] that can be rendered as a tab.
@@ -64,6 +62,36 @@ enum ConstraintName {
     Max,
     Fill,
 }
+
+/// A widget that renders a set of [`ConstraintBlock`]s and [`SpacerBlock`]s with an axis that shows
+/// the width of the layout. E.g.: `<----- 80 px (gap: 2 px) ----->`
+#[derive(Debug, Default, Clone)]
+struct LayoutBlocks {
+    constraints: Vec<Constraint>,
+    flex: Flex,
+    spacing: u16,
+    selected_index: usize,
+}
+
+/// A widget that renders a [`Constraint`] as a block. E.g.:
+/// ```plain
+/// ┌──────────────┐
+/// │  Length(16)  │
+/// │     16px     │
+/// └──────────────┘
+/// ```
+struct ConstraintBlock {
+    constraint: Constraint,
+}
+
+/// A widget that renders a spacer with a label indicating the width of the spacer. E.g.:
+///
+/// ```plain
+/// ┌      ┐
+///   8 px
+/// └      ┘
+/// ```
+struct SpacerBlock;
 
 fn main() -> Result<()> {
     init_error_hooks()?;
@@ -84,7 +112,7 @@ impl App {
     }
 
     fn is_running(&self) -> bool {
-        self.state == AppState::Running
+        self.mode != AppMode::Quit
     }
 
     fn draw(&self, terminal: &mut Terminal<impl Backend>) -> io::Result<()> {
@@ -96,61 +124,61 @@ impl App {
         use KeyCode::*;
         match event::read()? {
             Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
-                Char('q') | Esc => self.quit(),
-                Char('h') => self.prev_constraint(),
-                Char('l') => self.next_constraint(),
-                Enter => match self.prompt_state {
-                    PromptState::SelectConstraint => self.prompt(),
-                    PromptState::PromptConstraintDetails(selection) => self.confirm(selection),
-                },
-                _ => self.layout_blocks.handle_key_event(key),
+                Char('q') | Esc => self.exit(),
+                Char('e') | Enter => self.toggle_edit(),
+                _ => self.handle_child_events(key),
             },
             _ => {}
         }
         Ok(())
     }
 
-    fn next_constraint(&mut self) {
-        self.selected_constraint = self.selected_constraint.next();
+    fn handle_child_events(&mut self, key: KeyEvent) {
+        match &mut self.mode {
+            AppMode::Select => self.layout_blocks.handle_key_event(key),
+            AppMode::Edit(editor) => editor.handle_key_event(key),
+            AppMode::Quit => {}
+        }
     }
 
-    fn prev_constraint(&mut self) {
-        self.selected_constraint = self.selected_constraint.prev();
+    // exits edit mode or the app
+    fn exit(&mut self) {
+        self.mode = match self.mode {
+            // ignore the editor state and move back to select mode
+            AppMode::Edit(_) => AppMode::Select,
+            _ => AppMode::Quit,
+        }
     }
 
-    fn prompt(&mut self) {
-        self.prompt_state = PromptState::PromptConstraintDetails(self.selected_constraint);
-    }
-
-    fn confirm(&mut self, selection: ConstraintName) {
-        use ConstraintName::*;
-        let c = match selection {
-            Length => Constraint::Length(10),
-            Percentage => Constraint::Percentage(10),
-            Ratio => Constraint::Ratio(1, 10),
-            Min => Constraint::Min(10),
-            Max => Constraint::Max(10),
-            Fill => Constraint::Fill(1),
-        };
-        self.layout_blocks.constraints.push(c);
-        self.prompt_state = PromptState::SelectConstraint;
-    }
-
-    fn quit(&mut self) {
-        self.state = AppState::Quit;
+    // edits if in select mode, selects if in edit mode
+    fn toggle_edit(&mut self) {
+        if self.layout_blocks.constraints.is_empty() {
+            return;
+        }
+        match &self.mode {
+            AppMode::Select => {
+                // move into edit mode
+                let selected = self.layout_blocks.selected_constraint().unwrap().clone();
+                self.mode = AppMode::Edit(ConstraintEditor::from(selected));
+            }
+            AppMode::Edit(editor) => {
+                // save the editor state
+                let constraint = Constraint::from(editor);
+                self.layout_blocks.constraints[self.layout_blocks.selected_index] = constraint;
+            }
+            AppMode::Quit => {}
+        }
     }
 }
 
 // ConstraintName behaviour
 impl ConstraintName {
-    /// Get the previous tab, if there is no previous tab return the current tab.
     fn prev(&self) -> Self {
         let current_index: usize = *self as usize;
         let previous_index = current_index.saturating_sub(1);
         Self::from_repr(previous_index).unwrap_or(*self)
     }
 
-    /// Get the next tab, if there is no next tab return the current tab.
     fn next(&self) -> Self {
         let current_index = *self as usize;
         let next_index = current_index.saturating_add(1);
@@ -174,22 +202,19 @@ impl From<Constraint> for ConstraintName {
 
 impl Widget for &App {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let [header, demo, instructions, tabs] = area.split(&Layout::vertical([
-            Length(1),
-            Length(6),
-            Length(1),
-            Fill(0),
-        ]));
+        let [header_area, instructions_area, blocks_area, editor_area] =
+            area.split(&Layout::vertical([
+                Length(1),
+                Length(1),
+                Length(6),
+                Fill(0),
+            ]));
 
-        self.header().render(header, buf);
-        self.layout_blocks.render(demo, buf);
-        self.instructions().render(instructions, buf);
-        self.tabs().render(tabs, buf);
-
-        if let PromptState::PromptConstraintDetails(_selected) = self.prompt_state {
-            let [area] = area.split(&Layout::vertical([Percentage(50)]).flex(Flex::Center));
-            let [area] = area.split(&Layout::horizontal([Percentage(50)]).flex(Flex::Center));
-            self.render_prompt(area, buf);
+        self.header().render(header_area, buf);
+        self.instructions().render(instructions_area, buf);
+        self.layout_blocks.render(blocks_area, buf);
+        if let AppMode::Edit(editor) = &self.mode {
+            editor.render(editor_area, buf);
         }
     }
 }
@@ -208,54 +233,6 @@ impl App {
         let text = "◄ ►: select constraint, e: edit, i: insert, d: delete, q: quit";
         text.fg(Self::TEXT_COLOR).to_centered_line()
     }
-
-    fn tabs(&self) -> impl Widget {
-        let titles = ConstraintName::iter().map(ConstraintName::to_tab_title);
-        Tabs::new(titles)
-            .highlight_style(Modifier::REVERSED)
-            .select(self.selected_constraint as usize)
-            .padding("", "")
-            .divider(" ")
-    }
-
-    fn render_prompt(&self, area: Rect, buf: &mut Buffer) {
-        Clear.render(area, buf);
-        Paragraph::new("Input")
-            .style(Self::TEXT_COLOR)
-            .alignment(Alignment::Center)
-            .block(Block::bordered())
-            .render(area, buf);
-    }
-}
-
-impl ConstraintName {
-    fn to_tab_title(self) -> Line<'static> {
-        format!("  {self}  ").fg(SLATE.c200).bg(self.color()).into()
-    }
-
-    fn color(&self) -> Color {
-        match self {
-            Self::Length => SLATE.c700,
-            Self::Percentage => SLATE.c800,
-            Self::Ratio => SLATE.c900,
-            Self::Fill => SLATE.c950,
-            Self::Min => BLUE.c900,
-            Self::Max => BLUE.c800,
-        }
-    }
-}
-
-/// A widget that renders a set of [`ConstraintBlock`]s and [`SpacerBlock`]s with an axis that shows
-/// the width of the layout. E.g.: `<----- 80 px (gap: 2 px) ----->`
-///
-/// TODO: make this a stateful widget and store the constraints and spacing in it rather than in
-/// the app
-#[derive(Debug, Default, Clone)]
-struct LayoutBlocks {
-    constraints: Vec<Constraint>,
-    flex: Flex,
-    spacing: u16,
-    selected_index: usize,
 }
 
 impl Widget for &LayoutBlocks {
@@ -296,11 +273,13 @@ impl LayoutBlocks {
     fn handle_key_event(&mut self, key: KeyEvent) {
         use KeyCode::*;
         match key.code {
-            // TODO move this keyboard handling into layout blocks
             Char('+') => self.increment_spacing(),
             Char('-') => self.decrement_spacing(),
             Left => self.prev_block(),
             Right => self.next_block(),
+            Char('d') => self.delete_block(),
+            // TODO does this belong in the app so that we can edit the selected block?
+            Char('i') => self.insert_block(),
             _ => (),
         }
     }
@@ -309,7 +288,8 @@ impl LayoutBlocks {
         if self.constraints.is_empty() {
             return;
         }
-        self.selected_index = (self.selected_index + 1) % self.constraints.len();
+        let len = self.constraints.len();
+        self.selected_index = (self.selected_index + 1) % len;
     }
 
     /// select the previous block with wrap around
@@ -317,8 +297,28 @@ impl LayoutBlocks {
         if self.constraints.is_empty() {
             return;
         }
-        self.selected_index =
-            (self.selected_index + self.constraints.len() - 1) % self.constraints.len();
+        let len = self.constraints.len();
+        self.selected_index = (self.selected_index + self.constraints.len() - 1) % len;
+    }
+
+    /// delete the selected block
+    fn delete_block(&mut self) {
+        if self.constraints.is_empty() {
+            return;
+        }
+        self.constraints.remove(self.selected_index);
+        self.selected_index = self.selected_index.saturating_sub(1);
+    }
+
+    /// insert a block after the selected block
+    fn insert_block(&mut self) {
+        let index = self
+            .selected_index
+            .saturating_add(1)
+            .min(self.constraints.len());
+        let constraint = Constraint::Length(12);
+        self.constraints.insert(index, constraint);
+        self.selected_index = index;
     }
 
     fn increment_spacing(&mut self) {
@@ -343,24 +343,15 @@ impl LayoutBlocks {
         Paragraph::new(width_bar).fg(Self::AXIS_COLOR).centered()
     }
 
-    /// A cursor like `└───┬───┘` that points to the selected block
+    /// A cursor like `└─────┘` that points to the selected block
     fn cursor(width: u16) -> impl Widget {
-        let repeat = width.saturating_sub(2) as usize;
-        let mid = "┬";
-        let arrow = format!("└{mid:─^repeat$}┘");
-        Paragraph::new(arrow).fg(LayoutBlocks::AXIS_COLOR)
+        let cursor = format!("└{}┘", "─".repeat(width.saturating_sub(2) as usize));
+        Paragraph::new(cursor).fg(LayoutBlocks::AXIS_COLOR)
     }
-}
 
-/// A widget that renders a [`Constraint`] as a block. E.g.:
-/// ```plain
-/// ┌──────────────┐
-/// │  Length(16)  │
-/// │     16px     │
-/// └──────────────┘
-/// ```
-struct ConstraintBlock {
-    constraint: Constraint,
+    fn selected_constraint(&self) -> Option<&Constraint> {
+        self.constraints.get(self.selected_index)
+    }
 }
 
 impl Widget for ConstraintBlock {
@@ -400,15 +391,6 @@ impl ConstraintBlock {
         format!("{}\n{}", self.constraint, width_label)
     }
 }
-
-/// A widget that renders a spacer with a label indicating the width of the spacer. E.g.:
-///
-/// ```plain
-/// ┌      ┐
-///   8 px
-/// └      ┘
-/// ```
-struct SpacerBlock;
 
 impl Widget for SpacerBlock {
     fn render(self, area: Rect, buf: &mut Buffer) {
@@ -466,6 +448,138 @@ impl SpacerBlock {
     }
 }
 
+impl Widget for &ConstraintEditor {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let [labels, values] = area.split(&Layout::horizontal([Length(17), Fill(0)]));
+
+        let vertical = Layout::vertical([Length(1), Length(1), Length(1)]);
+
+        // labels
+        let [constraint_type, value1, value2] = labels.split(&vertical);
+        Line::from("Constraint Type:").render(constraint_type, buf);
+        match self.constraint_type {
+            ConstraintName::Ratio => {
+                Line::from("Numerator:").render(value1, buf);
+                Line::from("Denominator:").render(value2, buf);
+            }
+            _ => Line::from("Length:").render(value1, buf),
+        }
+
+        // values
+        let [constraint_type, value1, value2] = values.split(&vertical);
+        self.constraint_types().render(constraint_type, buf);
+        match self.constraint_type {
+            ConstraintName::Ratio => {
+                Paragraph::new(self.value1.as_str())
+                    .style(ConstraintEditor::TEXT_COLOR)
+                    .render(value1, buf);
+                Paragraph::new(self.value2.as_str())
+                    .style(ConstraintEditor::TEXT_COLOR)
+                    .render(value2, buf);
+            }
+            _ => {
+                Paragraph::new(self.value1.as_str())
+                    .style(ConstraintEditor::TEXT_COLOR)
+                    .render(value1, buf);
+            }
+        }
+    }
+}
+
+// TODO handle focus and editing values
+impl ConstraintEditor {
+    const TEXT_COLOR: Color = SLATE.c400;
+
+    fn constraint_types(&self) -> impl Widget {
+        let titles = ConstraintName::iter().map(ConstraintName::to_tab_title);
+        Tabs::new(titles)
+            .highlight_style(Modifier::REVERSED)
+            .select(self.constraint_type as usize)
+            .padding("", "")
+            .divider(" ")
+    }
+
+    fn handle_key_event(&mut self, key: KeyEvent) {
+        use KeyCode::*;
+        match key.code {
+            Left => self.prev_constraint(),
+            Right => self.next_constraint(),
+            _ => (),
+        }
+    }
+
+    fn next_constraint(&mut self) {
+        self.constraint_type = self.constraint_type.next();
+    }
+
+    fn prev_constraint(&mut self) {
+        self.constraint_type = self.constraint_type.prev();
+    }
+}
+
+impl From<Constraint> for ConstraintEditor {
+    fn from(constraint: Constraint) -> Self {
+        use Constraint::*;
+        let constraint_name = ConstraintName::from(constraint);
+        let value = match constraint {
+            Length(value) => value.to_string(),
+            Percentage(value) => value.to_string(),
+            Ratio(value, _) => value.to_string(),
+            Min(value) => value.to_string(),
+            Max(value) => value.to_string(),
+            Fill(value) => value.to_string(),
+        };
+        let value2 = match constraint {
+            Ratio(_, value) => value.to_string(),
+            _ => "".to_string(),
+        };
+        Self {
+            constraint_type: constraint_name,
+            value1: value,
+            value2,
+        }
+    }
+}
+
+impl From<&ConstraintEditor> for Constraint {
+    fn from(editor: &ConstraintEditor) -> Self {
+        use Constraint::*;
+        if editor.constraint_type == ConstraintName::Ratio {
+            // ratio uses u32 values
+            Ratio(
+                editor.value1.parse().unwrap_or_default(),
+                editor.value2.parse().unwrap_or_default(),
+            )
+        } else {
+            let value = editor.value1.parse().unwrap_or_default();
+            match editor.constraint_type {
+                ConstraintName::Length => Length(value),
+                ConstraintName::Percentage => Percentage(value),
+                ConstraintName::Min => Min(value),
+                ConstraintName::Max => Max(value),
+                ConstraintName::Fill => Fill(value),
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+impl ConstraintName {
+    fn to_tab_title(self) -> Line<'static> {
+        format!("  {self}  ").fg(SLATE.c200).bg(self.color()).into()
+    }
+
+    fn color(&self) -> Color {
+        match self {
+            Self::Length => SLATE.c700,
+            Self::Percentage => SLATE.c800,
+            Self::Ratio => SLATE.c900,
+            Self::Fill => SLATE.c950,
+            Self::Min => BLUE.c900,
+            Self::Max => BLUE.c800,
+        }
+    }
+}
 fn init_error_hooks() -> Result<()> {
     let (panic, error) = HookBuilder::default().into_hooks();
     let panic = panic.into_panic_hook();

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -537,12 +537,12 @@ impl ConstraintName {
 
     fn lighter_color(&self) -> Color {
         match self {
-            Self::Length => SLATE.c500,
-            Self::Percentage => SLATE.c600,
-            Self::Ratio => SLATE.c700,
-            Self::Fill => SLATE.c800,
-            Self::Min => BLUE.c700,
-            Self::Max => BLUE.c600,
+            Self::Length => STONE.c500,
+            Self::Percentage => STONE.c600,
+            Self::Ratio => STONE.c700,
+            Self::Fill => STONE.c800,
+            Self::Min => BLUE.c600,
+            Self::Max => BLUE.c500,
         }
     }
 }

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -541,8 +541,8 @@ impl ConstraintName {
             Self::Percentage => STONE.c600,
             Self::Ratio => STONE.c700,
             Self::Fill => STONE.c800,
-            Self::Min => INDIGO.c500,
-            Self::Max => INDIGO.c600,
+            Self::Min => SKY.c600,
+            Self::Max => SKY.c700,
         }
     }
 }


### PR DESCRIPTION
Here's a constraint explorer demo put together with @joshka 

https://github.com/ratatui-org/ratatui/assets/1813121/08d7d8f6-d013-44b4-8331-f4eee3589cce

It allows users to interactive explore how the constraints behave with respect to each other and compare that across flex modes. It allows users to swap constraints out for other constraints, increment or decrement the values, add and remove constraints, and add spacing

It is also a good example for how to structure a simple TUI with several Ratatui code patterns that are useful for refactoring.

Fixes: https://github.com/ratatui-org/ratatui/issues/792