### PR TITLE
feat: show space constrained UIs conditionally

### DIFF
--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -257,18 +257,18 @@ impl From<Constraint> for ConstraintName {
 
 impl Widget for &App {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let [header_area, instructions_area, legend_area, _, blocks_area] =
+        let [header_area, instructions_area, swap_legend_area, _, blocks_area] =
             area.split(&Layout::vertical([
                 Length(2), // header
                 Length(2), // instructions
-                Length(1), // legend
+                Length(1), // swap key legend
                 Length(1), // gap
                 Fill(1),   // blocks
             ]));
 
         self.header().render(header_area, buf);
         self.instructions().render(instructions_area, buf);
-        self.legend().render(legend_area, buf);
+        self.swap_legend().render(swap_legend_area, buf);
         self.render_layout_blocks(blocks_area, buf);
     }
 }
@@ -292,7 +292,7 @@ impl App {
             .wrap(Wrap { trim: false })
     }
 
-    fn legend(&self) -> impl Widget {
+    fn swap_legend(&self) -> impl Widget {
         #[allow(unstable_name_collisions)]
         Paragraph::new(
             Line::from(
@@ -334,7 +334,8 @@ impl App {
     }
 
     fn render_layout_blocks(&self, area: Rect, buf: &mut Buffer) {
-        let [user_constraints, area] = area.split(&Layout::vertical([Length(3), Fill(1)]));
+        let [user_constraints, area] =
+            area.split(&Layout::vertical([Length(3), Fill(1)]).spacing(1));
 
         self.render_user_constraints_legend(user_constraints, buf);
 

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -339,14 +339,20 @@ impl App {
 
         self.render_user_constraints_legend(user_constraints, buf);
 
-        let [start, center, end, space_around, space_between] =
-            area.split(&Layout::vertical([Length(7); 5]));
+        if area.height > 7 * 5 {
+            let [start, center, end, space_around, space_between] =
+                area.split(&Layout::vertical([Length(7); 5]));
 
-        self.render_layout_block(Flex::Start, start, buf);
-        self.render_layout_block(Flex::Center, center, buf);
-        self.render_layout_block(Flex::End, end, buf);
-        self.render_layout_block(Flex::SpaceAround, space_around, buf);
-        self.render_layout_block(Flex::SpaceBetween, space_between, buf)
+            self.render_layout_block(Flex::Start, start, buf);
+            self.render_layout_block(Flex::Center, center, buf);
+            self.render_layout_block(Flex::End, end, buf);
+            self.render_layout_block(Flex::SpaceAround, space_around, buf);
+            self.render_layout_block(Flex::SpaceBetween, space_between, buf)
+        } else {
+            let [start] = area.split(&Layout::vertical([Length(7)]));
+
+            self.render_layout_block(Flex::Start, start, buf);
+        }
     }
 
     fn render_user_constraints_legend(&self, area: Rect, buf: &mut Buffer) {

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -349,9 +349,15 @@ impl App {
             self.render_layout_block(Flex::SpaceAround, space_around, buf);
             self.render_layout_block(Flex::SpaceBetween, space_between, buf)
         } else {
-            let [start] = area.split(&Layout::vertical([Length(7)]));
-
+            let [start, info] =
+                area.split(&Layout::vertical([Length(7), Length(1)]).flex(Flex::SpaceBetween));
             self.render_layout_block(Flex::Start, start, buf);
+            Line::from(
+                "--- Increase height of terminal to see more flex comparisons ---"
+                    .fg(Self::TEXT_COLOR),
+            )
+            .centered()
+            .render(info, buf);
         }
     }
 


### PR DESCRIPTION
With this PR the constraint explorer demo only shows space constrained UIs instead:

Smallest (15 row height):

<img width="759" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/37a4a027-6c6d-4feb-8104-d732aee298ac">

Small (20 row height):

<img width="759" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/f76e025f-0061-4f09-9c91-2f7b00fcfb9e">

Medium (30 row height):

<img width="758" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/81b070da-1bfb-40c5-9fbc-c1ab44ce422e">

Full (40 row height):

<img width="760" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/7bb8a8c4-1a77-4bbc-a346-c8b5c198c6d3">
