### PR TITLE
chore: allow Buffer::with_lines to accept IntoIterator

### DIFF
--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -71,9 +71,10 @@ impl Buffer {
     }
 
     /// Returns a Buffer containing the given lines
-    pub fn with_lines<'a, S>(lines: Vec<S>) -> Buffer
+    pub fn with_lines<'a, Iter>(lines: Iter) -> Buffer
     where
-        S: Into<Line<'a>>,
+        Iter: IntoIterator,
+        Iter::Item: Into<Line<'a>>,
     {
         let lines = lines.into_iter().map(Into::into).collect::<Vec<_>>();
         let height = lines.len() as u16;

--- a/src/widgets/canvas.rs
+++ b/src/widgets/canvas.rs
@@ -807,7 +807,7 @@ mod tests {
             .x_bounds([0.0, 10.0])
             .y_bounds([0.0, 10.0])
             .render(area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(expected.lines().collect()));
+        assert_eq!(buf, Buffer::with_lines(expected.lines()));
     }
 
     #[test]

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -578,7 +578,6 @@ impl ScrollbarOrientation {
 mod tests {
     use std::str::FromStr;
 
-    use itertools::Itertools;
     use rstest::{fixture, rstest};
     use strum::ParseError;
     use unicode_width::UnicodeWidthStr;
@@ -912,7 +911,7 @@ mod tests {
             .track_symbol(Some("-"))
             .thumb_symbol("#")
             .render(buffer.area, &mut buffer, &mut state);
-        let bar = expected.chars().map(|c| format!("{c}    ")).collect_vec();
+        let bar = expected.chars().map(|c| format!("{c}    "));
         assert_eq!(buffer, Buffer::with_lines(bar), "{description}");
     }
 
@@ -946,7 +945,7 @@ mod tests {
             .track_symbol(Some("-"))
             .thumb_symbol("#")
             .render(buffer.area, &mut buffer, &mut state);
-        let bar = expected.chars().map(|c| format!("    {c}")).collect_vec();
+        let bar = expected.chars().map(|c| format!("    {c}"));
         assert_eq!(buffer, Buffer::with_lines(bar), "{description}");
     }
 

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -104,7 +104,7 @@ const DEFAULT_STATE_REPR: &str = r#"{
 fn default_state_serialize() {
     let mut state = AppState::default();
 
-    let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER.to_vec());
+    let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER);
     assert_buffer(&mut state, &expected);
 
     let state = serde_json::to_string_pretty(&state).unwrap();
@@ -113,7 +113,7 @@ fn default_state_serialize() {
 
 #[test]
 fn default_state_deserialize() {
-    let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER.to_vec());
+    let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER);
     let mut state: AppState = serde_json::from_str(DEFAULT_STATE_REPR).unwrap();
     assert_buffer(&mut state, &expected);
 }
@@ -146,7 +146,7 @@ fn selected_state_serialize() {
     let mut state = AppState::default();
     state.select(1);
 
-    let expected = Buffer::with_lines(SELECTED_STATE_BUFFER.to_vec());
+    let expected = Buffer::with_lines(SELECTED_STATE_BUFFER);
     assert_buffer(&mut state, &expected);
 
     let state = serde_json::to_string_pretty(&state).unwrap();
@@ -155,7 +155,7 @@ fn selected_state_serialize() {
 
 #[test]
 fn selected_state_deserialize() {
-    let expected = Buffer::with_lines(SELECTED_STATE_BUFFER.to_vec());
+    let expected = Buffer::with_lines(SELECTED_STATE_BUFFER);
     let mut state: AppState = serde_json::from_str(SELECTED_STATE_REPR).unwrap();
     assert_buffer(&mut state, &expected);
 }
@@ -189,7 +189,7 @@ fn scrolled_state_serialize() {
     let mut state = AppState::default();
     state.select(8);
 
-    let expected = Buffer::with_lines(SCROLLED_STATE_BUFFER.to_vec());
+    let expected = Buffer::with_lines(SCROLLED_STATE_BUFFER);
     assert_buffer(&mut state, &expected);
 
     let state = serde_json::to_string_pretty(&state).unwrap();
@@ -198,7 +198,7 @@ fn scrolled_state_serialize() {
 
 #[test]
 fn scrolled_state_deserialize() {
-    let expected = Buffer::with_lines(SCROLLED_STATE_BUFFER.to_vec());
+    let expected = Buffer::with_lines(SCROLLED_STATE_BUFFER);
     let mut state: AppState = serde_json::from_str(SCROLLED_STATE_REPR).unwrap();
     assert_buffer(&mut state, &expected);
 }

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -26,7 +26,6 @@ where
             f.render_widget(chart, f.size());
         })
         .unwrap();
-    let lines = lines.into_iter().map(|l| l.into()).collect();
     let expected = Buffer::with_lines(lines);
     terminal.backend().assert_buffer(&expected);
 }


### PR DESCRIPTION
This can make it easier to use `Buffer::with_lines` with iterators that
don't necessarily produce a `Vec`. For example, this allows using
`Buffer::with_lines` with `&[&str]` directly, without having to call
`collect` on it first.
