### PR TITLE
fix(list): highlight symbol when using a  multi-bytes char

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -895,7 +895,7 @@ impl StatefulWidgetRef for List<'_> {
             let is_selected = state.selected.map_or(false, |s| s == i);
 
             let item_area = if selection_spacing {
-                let highlight_symbol_width = self.highlight_symbol.unwrap_or("").len() as u16;
+                let highlight_symbol_width = self.highlight_symbol.unwrap_or("").width() as u16;
                 Rect {
                     x: row_area.x + highlight_symbol_width,
                     width: row_area.width - highlight_symbol_width,

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -53,6 +53,38 @@ fn widgets_list_should_highlight_the_selected_item() {
 }
 
 #[test]
+fn widgets_list_should_highlight_the_selected_item_wide_symbol() {
+    let backend = TestBackend::new(10, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut state = ListState::default();
+
+    let wide_symbol = "▶  ";
+
+    state.select(Some(1));
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let items = vec![
+                ListItem::new("Item 1"),
+                ListItem::new("Item 2"),
+                ListItem::new("Item 3"),
+            ];
+            let list = List::new(items)
+                .highlight_style(Style::default().bg(Color::Yellow))
+                .highlight_symbol(wide_symbol);
+            f.render_stateful_widget(list, size, &mut state);
+        })
+        .unwrap();
+
+    let mut expected = Buffer::with_lines(vec!["   Item 1 ", "▶  Item 2 ", "   Item 3 "]);
+
+    for x in 0..10 {
+        expected.get_mut(x, 1).set_bg(Color::Yellow);
+    }
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
 fn widgets_list_should_truncate_items() {
     let backend = TestBackend::new(10, 2);
     let mut terminal = Terminal::new(backend).unwrap();


### PR DESCRIPTION
ratatui v0.26.0 brought a regression in the List widget, in which the highlight symbol width was incorrectly calculated - specifically when the highlight symbol was a multi-char character, e.g. `▶`.

I have also added a single additional test to check the output when such a multi-byte char is used for the highlight symbol.