### PR TITLE
fix(line): render Line::styled correctly inside a paragraph

### DIFF
--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -340,9 +340,7 @@ impl Paragraph<'_> {
         }
 
         let styled = self.text.iter().map(|line| {
-            let graphemes = line
-                .iter()
-                .flat_map(|span| span.styled_graphemes(self.style));
+            let graphemes = line.styled_graphemes(self.style);
             let alignment = line.alignment.unwrap_or(self.alignment);
             (graphemes, alignment)
         });

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -592,6 +592,23 @@ mod test {
     }
 
     #[test]
+    fn test_render_line_styled() {
+        let l0 = Line::raw("unformatted");
+        let l1 = Line::styled("bold text", Style::new().bold());
+        let l2 = Line::styled("cyan text", Style::new().cyan());
+        let l3 = Line::styled("dim text", Style::new().dim());
+        let paragraph = Paragraph::new(vec![l0, l1, l2, l3]);
+
+        let mut expected =
+            Buffer::with_lines(vec!["unformatted", "bold text", "cyan text", "dim text"]);
+        expected.set_style(Rect::new(0, 1, 9, 1), Style::new().bold());
+        expected.set_style(Rect::new(0, 2, 9, 1), Style::new().cyan());
+        expected.set_style(Rect::new(0, 3, 8, 1), Style::new().dim());
+
+        test_case(&paragraph, expected);
+    }
+
+    #[test]
     fn test_render_paragraph_with_block_with_bottom_title_and_border() {
         let block = Block::default()
             .title("Title")

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -609,6 +609,23 @@ mod test {
     }
 
     #[test]
+    fn test_render_line_spans_styled() {
+        let l0 = Line::default().spans(vec![
+            Span::styled("bold", Style::new().bold()),
+            Span::raw(" and "),
+            Span::styled("cyan", Style::new().cyan()),
+        ]);
+        let l1 = Line::default().spans(vec![Span::raw("unformatted")]);
+        let paragraph = Paragraph::new(vec![l0, l1]);
+
+        let mut expected = Buffer::with_lines(vec!["bold and cyan", "unformatted"]);
+        expected.set_style(Rect::new(0, 0, 4, 1), Style::new().bold());
+        expected.set_style(Rect::new(9, 0, 4, 1), Style::new().cyan());
+
+        test_case(&paragraph, expected);
+    }
+
+    #[test]
     fn test_render_paragraph_with_block_with_bottom_title_and_border() {
         let block = Block::default()
             .title("Title")


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

rendering a `Paragraph` with a `Line::styled` ignores the style, but using styled spans with a `Line::default().spans(vec![Span::styled])` works just fine.

the issue seems to be, that the paragraph tries to render the `styled_graphemes` of the `Span`s instead of the `Line` directly

<details>
<summary>repro of the problem</summary>

```rs
fn ui(frame: &mut Frame) {
	let l1 = Line::styled("should be bold", Style::default().bold());
	let l2 = Line::styled("should be colorful", Style::default().cyan());
	let l3 = Line::styled("should be dim", Style::default().dim());

	let lp = Line::default();

	let s1 = vec![Span::styled("but it works with spans", Style::default().cyan())];
	let ls = Line::default().spans(s1);

	let block = Block::default()
		.borders(Borders::ALL)
		.padding(Padding::new(4, 4, 2, 2));
	let paragraph = Paragraph::new(vec![l1, l2, l3, lp, ls]).block(block);

	frame.render_widget(paragraph, frame.size());
}
```

</details>
