### PR TITLE
feat: add Block::title_top and Block::title_top_bottom

### DIFF
--- a/src/widgets/block/title.rs
+++ b/src/widgets/block/title.rs
@@ -115,18 +115,25 @@ where
     T: Into<Line<'a>>,
 {
     fn from(value: T) -> Self {
-        Self::default().content(value.into())
+        let content = value.into();
+        let alignment = content.alignment;
+        Self {
+            content,
+            alignment,
+            position: None,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use strum::ParseError;
 
     use super::*;
 
     #[test]
-    fn position_tostring() {
+    fn position_to_string() {
         assert_eq!(Position::Top.to_string(), "Top");
         assert_eq!(Position::Bottom.to_string(), "Bottom");
     }
@@ -136,5 +143,25 @@ mod tests {
         assert_eq!("Top".parse::<Position>(), Ok(Position::Top));
         assert_eq!("Bottom".parse::<Position>(), Ok(Position::Bottom));
         assert_eq!("".parse::<Position>(), Err(ParseError::VariantNotFound));
+    }
+
+    #[test]
+    fn title_from_line() {
+        let title = Title::from(Line::raw("Title"));
+        assert_eq!(title.content, Line::from("Title"));
+        assert_eq!(title.alignment, None);
+        assert_eq!(title.position, None);
+    }
+
+    #[rstest]
+    #[case::left(Alignment::Left)]
+    #[case::center(Alignment::Center)]
+    #[case::right(Alignment::Right)]
+    fn title_from_line_with_alignment(#[case] alignment: Alignment) {
+        let line = Line::raw("Title").alignment(alignment);
+        let title = Title::from(line.clone());
+        assert_eq!(title.content, line);
+        assert_eq!(title.alignment, Some(alignment));
+        assert_eq!(title.position, None);
     }
 }


### PR DESCRIPTION
This adds the ability to add titles to the top and bottom of a block
without having to use the `Title` struct (which will be removed in a
future release - likely v0.28.0).

Fixes a subtle bug if the title was created from a right aligned Line
and was also right aligned. The title would be rendered one cell too far
to the right.

```rust
Block::bordered()
    .title_top(Line::raw("A").left_aligned())
    .title_top(Line::raw("B").centered())
    .title_top(Line::raw("C").right_aligned())
    .title_bottom(Line::raw("D").left_aligned())
    .title_bottom(Line::raw("E").centered())
    .title_bottom(Line::raw("F").right_aligned())
    .render(buffer.area, &mut buffer);
// renders
"┌A─────B─────C┐",
"│             │",
"└D─────E─────F┘",
```

Addresses part of https://github.com/ratatui-org/ratatui/issues/738

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
