### PR TITLE
perf(layout): const functions

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::missing_const_for_fn)]
+
 mod alignment;
 mod constraint;
 mod corner;

--- a/src/layout/position.rs
+++ b/src/layout/position.rs
@@ -38,7 +38,7 @@ pub struct Position {
 
 impl Position {
     /// Create a new position
-    pub fn new(x: u16, y: u16) -> Self {
+    pub const fn new(x: u16, y: u16) -> Self {
         Position { x, y }
     }
 }

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -245,7 +245,7 @@ impl Rect {
     ///     }
     /// }
     /// ```
-    pub fn rows(self) -> Rows {
+    pub const fn rows(self) -> Rows {
         Rows::new(self)
     }
 
@@ -261,7 +261,7 @@ impl Rect {
     ///     }
     /// }
     /// ```
-    pub fn columns(self) -> Columns {
+    pub const fn columns(self) -> Columns {
         Columns::new(self)
     }
 
@@ -279,7 +279,7 @@ impl Rect {
     ///     }
     /// }
     /// ```
-    pub fn positions(self) -> Positions {
+    pub const fn positions(self) -> Positions {
         Positions::new(self)
     }
 
@@ -292,7 +292,7 @@ impl Rect {
     /// let rect = Rect::new(1, 2, 3, 4);
     /// let position = rect.as_position();
     /// ````
-    pub fn as_position(self) -> Position {
+    pub const fn as_position(self) -> Position {
         Position {
             x: self.x,
             y: self.y,
@@ -300,7 +300,7 @@ impl Rect {
     }
 
     /// Converts the rect into a size struct.
-    pub fn as_size(self) -> Size {
+    pub const fn as_size(self) -> Size {
         Size {
             width: self.width,
             height: self.height,

--- a/src/layout/rect/iter.rs
+++ b/src/layout/rect/iter.rs
@@ -11,7 +11,7 @@ pub struct Rows {
 
 impl Rows {
     /// Creates a new `Rows` iterator.
-    pub fn new(rect: Rect) -> Self {
+    pub const fn new(rect: Rect) -> Self {
         Self {
             rect,
             current_row: rect.y,
@@ -45,7 +45,7 @@ pub struct Columns {
 
 impl Columns {
     /// Creates a new `Columns` iterator.
-    pub fn new(rect: Rect) -> Self {
+    pub const fn new(rect: Rect) -> Self {
         Self {
             rect,
             current_column: rect.x,
@@ -81,7 +81,7 @@ pub struct Positions {
 
 impl Positions {
     /// Creates a new `Positions` iterator.
-    pub fn new(rect: Rect) -> Self {
+    pub const fn new(rect: Rect) -> Self {
         Self {
             rect,
             current_position: Position::new(rect.x, rect.y),

--- a/src/layout/size.rs
+++ b/src/layout/size.rs
@@ -15,7 +15,7 @@ pub struct Size {
 
 impl Size {
     /// Create a new `Size` struct
-    pub fn new(width: u16, height: u16) -> Self {
+    pub const fn new(width: u16, height: u16) -> Self {
         Size { width, height }
     }
 }

--- a/src/widgets/canvas/line.rs
+++ b/src/widgets/canvas/line.rs
@@ -20,7 +20,7 @@ pub struct Line {
 
 impl Line {
     /// Create a new line from `(x1, y1)` to `(x2, y2)` with the given color
-    pub fn new(x1: f64, y1: f64, x2: f64, y2: f64, color: Color) -> Self {
+    pub const fn new(x1: f64, y1: f64, x2: f64, y2: f64, color: Color) -> Self {
         Self {
             x1,
             y1,


### PR DESCRIPTION
The layout can often contain things that are already known at compile time which speeds up things on runtime. Especially as render is called a lot.

With 0.26.0 the `Rect::contains` method is now accepting a Position. While `contains` is `const`, `Position::new` is not which triggered the creation of this PR. I switched to `Position { x, y }`, but the compiler should be able to do the same in `const` with `::new()`.

I added the lint to the layout module, but I don't really know what other plans of this project are in regard to configuring lints. I could also just remove the lint there, but mistakes like the current one will happen again as the code uses a lot of `const` already. Do you have other thoughts on how to configure the lints best?

I observed the [missing_const_for_fn](https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn) clippy lint in other areas of the library too, but it's mostly pointless there. Some Widgets and WidgetStates could get `::new()` implementations which are `const` which would also allow for optimizations there.

Personally I also think that more `clippy::pedantic` and `clippy::nursery` lints could keep the code quality of ratatui consistent. Like in the current case many things are already `const`, but they are forgotten in other places as no lints are ensuring that.