### PR TITLE
feat: impl Widget for `&str` and `String`

### DIFF
--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -417,6 +417,30 @@ pub trait StatefulWidgetRef {
 //     }
 // }
 
+impl Widget for &str {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        self.render_ref(area, buf);
+    }
+}
+
+impl WidgetRef for &str {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        buf.set_string(area.x, area.y, self, crate::style::Style::default())
+    }
+}
+
+impl Widget for String {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        self.render_ref(area, buf);
+    }
+}
+
+impl WidgetRef for String {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        buf.set_string(area.x, area.y, self, crate::style::Style::default())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::{fixture, rstest};

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -70,6 +70,7 @@ use crate::{buffer::Buffer, layout::Rect};
 /// used where backwards compatibility is required (all the internal widgets use this approach).
 ///
 /// A blanket implementation of `Widget` for `&W` where `W` implements `WidgetRef` is provided.
+/// Widget is also implemented for `&str` and `String` types.
 ///
 /// # Examples
 ///

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -417,24 +417,45 @@ pub trait StatefulWidgetRef {
 //     }
 // }
 
+/// Renders a string slice as a widget.
+///
+/// This implementation allows a string slice (`&str`) to act as a widget, meaning it can be drawn
+/// onto a [`Buffer`] in a specified [`Rect`]. The slice represents a static string which can be
+/// rendered by reference, thereby avoiding the need for string cloning or ownership transfer when
+/// drawing the text to the screen.
 impl Widget for &str {
     fn render(self, area: Rect, buf: &mut Buffer) {
         self.render_ref(area, buf);
     }
 }
 
+/// Provides the ability to render a string slice by reference.
+///
+/// This trait implementation ensures that a string slice, which is an immutable view over a
+/// `String`, can be drawn on demand without requiring ownership of the string itself. It utilizes
+/// the default text style when rendering onto the provided [`Buffer`] at the position defined by
+/// [`Rect`].
 impl WidgetRef for &str {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         buf.set_string(area.x, area.y, self, crate::style::Style::default())
     }
 }
 
+/// Renders a `String` object as a widget.
+///
+/// This implementation enables an owned `String` to be treated as a widget, which can be rendered
+/// on a [`Buffer`] within the bounds of a given [`Rect`].
 impl Widget for String {
     fn render(self, area: Rect, buf: &mut Buffer) {
         self.render_ref(area, buf);
     }
 }
 
+/// Provides the ability to render a `String` by reference.
+///
+/// This trait allows for a `String` to be rendered onto the [`Buffer`], similarly using the default
+/// style settings. It ensures that an owned `String` can be rendered efficiently by reference,
+/// without the need to give up ownership of the underlying text.
 impl WidgetRef for String {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         buf.set_string(area.x, area.y, self, crate::style::Style::default())
@@ -584,5 +605,43 @@ mod tests {
         let widget: Option<Greeting> = None;
         widget.render_ref(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["                    "]));
+    }
+
+    #[rstest]
+    fn str_render(mut buf: Buffer) {
+        let widget = "hello world";
+        widget.render_ref(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+
+        let widget = "hello world";
+        widget.render(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+
+        let widget = Some("hello world");
+        widget.render(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+
+        let widget = Some("hello world");
+        widget.render_ref(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+    }
+
+    #[rstest]
+    fn string_render(mut buf: Buffer) {
+        let widget = "hello world".to_string();
+        widget.render_ref(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+
+        let widget = "hello world".to_string();
+        widget.render(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+
+        let widget = Some("hello world".to_string());
+        widget.render(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+
+        let widget = Some("hello world".to_string());
+        widget.render_ref(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
     }
 }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -614,38 +614,70 @@ mod tests {
     #[rstest]
     fn str_render() {
         let mut buf = single_line_buffer();
-        "hello world".render_ref(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+        "hello world".render(buf.area, &mut buf);
+        assert_eq!(
+            buf,
+            Buffer::with_lines(["hello world         "]),
+            "str.render()"
+        );
 
         let mut buf = single_line_buffer();
-        "hello world".render(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+        "hello world".render_ref(buf.area, &mut buf);
+        assert_eq!(
+            buf,
+            Buffer::with_lines(["hello world         "]),
+            "str.render_ref()"
+        );
 
         let mut buf = single_line_buffer();
         Some("hello world").render(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+        assert_eq!(
+            buf,
+            Buffer::with_lines(["hello world         "]),
+            "Some(str).render()"
+        );
 
         let mut buf = single_line_buffer();
         Some("hello world").render_ref(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+        assert_eq!(
+            buf,
+            Buffer::with_lines(["hello world         "]),
+            "Some(str).render_ref()"
+        );
     }
 
     #[rstest]
     fn string_render() {
         let mut buf = single_line_buffer();
-        String::from("hello world").render_ref(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+        String::from("hello world").render(buf.area, &mut buf);
+        assert_eq!(
+            buf,
+            Buffer::with_lines(["hello world         "]),
+            "string.render()"
+        );
 
         let mut buf = single_line_buffer();
-        String::from("hello world").render(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+        String::from("hello world").render_ref(buf.area, &mut buf);
+        assert_eq!(
+            buf,
+            Buffer::with_lines(["hello world         "]),
+            "string.render_ref()"
+        );
 
         let mut buf = single_line_buffer();
         Some(String::from("hello world")).render(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+        assert_eq!(
+            buf,
+            Buffer::with_lines(["hello world         "]),
+            "string.render()"
+        );
 
         let mut buf = single_line_buffer();
         Some(String::from("hello world")).render_ref(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+        assert_eq!(
+            buf,
+            Buffer::with_lines(["hello world         "]),
+            "Some(string).render_ref()"
+        );
     }
 }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -608,77 +608,51 @@ mod tests {
         assert_eq!(buf, Buffer::with_lines(["                    "]));
     }
 
-    fn single_line_buffer() -> Buffer {
-        Buffer::empty(Rect::new(0, 0, 20, 1))
-    }
-
     #[rstest]
-    fn str_render() {
-        let mut buf = single_line_buffer();
+    fn str_render(mut buf: Buffer) {
         "hello world".render(buf.area, &mut buf);
-        assert_eq!(
-            buf,
-            Buffer::with_lines(["hello world         "]),
-            "str.render()"
-        );
-
-        let mut buf = single_line_buffer();
-        "hello world".render_ref(buf.area, &mut buf);
-        assert_eq!(
-            buf,
-            Buffer::with_lines(["hello world         "]),
-            "str.render_ref()"
-        );
-
-        let mut buf = single_line_buffer();
-        Some("hello world").render(buf.area, &mut buf);
-        assert_eq!(
-            buf,
-            Buffer::with_lines(["hello world         "]),
-            "Some(str).render()"
-        );
-
-        let mut buf = single_line_buffer();
-        Some("hello world").render_ref(buf.area, &mut buf);
-        assert_eq!(
-            buf,
-            Buffer::with_lines(["hello world         "]),
-            "Some(str).render_ref()"
-        );
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
     }
 
     #[rstest]
-    fn string_render() {
-        let mut buf = single_line_buffer();
+    fn str_render_ref(mut buf: Buffer) {
+        "hello world".render_ref(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+    }
+
+    #[rstest]
+    fn str_option_render(mut buf: Buffer) {
+        Some("hello world").render(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+    }
+
+    #[rstest]
+    fn str_option_render_ref(mut buf: Buffer) {
+        Some("hello world").render_ref(buf.area, &mut buf);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+    }
+
+    #[rstest]
+    fn string_render(mut buf: Buffer) {
         String::from("hello world").render(buf.area, &mut buf);
-        assert_eq!(
-            buf,
-            Buffer::with_lines(["hello world         "]),
-            "string.render()"
-        );
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+    }
 
-        let mut buf = single_line_buffer();
+    #[rstest]
+    fn string_render_ref(mut buf: Buffer) {
         String::from("hello world").render_ref(buf.area, &mut buf);
-        assert_eq!(
-            buf,
-            Buffer::with_lines(["hello world         "]),
-            "string.render_ref()"
-        );
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+    }
 
-        let mut buf = single_line_buffer();
+    #[rstest]
+    fn string_option_render(mut buf: Buffer) {
         Some(String::from("hello world")).render(buf.area, &mut buf);
-        assert_eq!(
-            buf,
-            Buffer::with_lines(["hello world         "]),
-            "string.render()"
-        );
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
+    }
 
-        let mut buf = single_line_buffer();
+    #[rstest]
+    fn string_option_render_ref(mut buf: Buffer) {
         Some(String::from("hello world")).render_ref(buf.area, &mut buf);
-        assert_eq!(
-            buf,
-            Buffer::with_lines(["hello world         "]),
-            "Some(string).render_ref()"
-        );
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]),);
     }
 }

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -607,41 +607,45 @@ mod tests {
         assert_eq!(buf, Buffer::with_lines(["                    "]));
     }
 
+    fn single_line_buffer() -> Buffer {
+        Buffer::empty(Rect::new(0, 0, 20, 1))
+    }
+
     #[rstest]
-    fn str_render(mut buf: Buffer) {
-        let widget = "hello world";
-        widget.render_ref(buf.area, &mut buf);
+    fn str_render() {
+        let mut buf = single_line_buffer();
+        "hello world".render_ref(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["hello world         "]));
 
-        let widget = "hello world";
-        widget.render(buf.area, &mut buf);
+        let mut buf = single_line_buffer();
+        "hello world".render(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["hello world         "]));
 
-        let widget = Some("hello world");
-        widget.render(buf.area, &mut buf);
+        let mut buf = single_line_buffer();
+        Some("hello world").render(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["hello world         "]));
 
-        let widget = Some("hello world");
-        widget.render_ref(buf.area, &mut buf);
+        let mut buf = single_line_buffer();
+        Some("hello world").render_ref(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["hello world         "]));
     }
 
     #[rstest]
-    fn string_render(mut buf: Buffer) {
-        let widget = "hello world".to_string();
-        widget.render_ref(buf.area, &mut buf);
+    fn string_render() {
+        let mut buf = single_line_buffer();
+        String::from("hello world").render_ref(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["hello world         "]));
 
-        let widget = "hello world".to_string();
-        widget.render(buf.area, &mut buf);
+        let mut buf = single_line_buffer();
+        String::from("hello world").render(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["hello world         "]));
 
-        let widget = Some("hello world".to_string());
-        widget.render(buf.area, &mut buf);
+        let mut buf = single_line_buffer();
+        Some(String::from("hello world")).render(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["hello world         "]));
 
-        let widget = Some("hello world".to_string());
-        widget.render_ref(buf.area, &mut buf);
+        let mut buf = single_line_buffer();
+        Some(String::from("hello world")).render_ref(buf.area, &mut buf);
         assert_eq!(buf, Buffer::with_lines(["hello world         "]));
     }
 }


### PR DESCRIPTION
Currently, `f.render_widget("hello world".bold(), area)` works but `f.render_widget("hello world", area)` doesn't. This PR changes that my implementing `Widget` for `&str` and `String`. This makes it easier to render strings with no styles as widgets.

Example usage:

```rust
terminal.draw(|f| f.render_widget("Hello World!", f.size()))?;
```