### PR TITLE
feat(list): Add Scroll Padding to Lists

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -829,8 +829,6 @@ impl<'a> List<'a> {
             // items to render to be less than we normally would due to the offset pushing us off
             // the end of the list of items. We want to allow the padding value to push us back up
             // to ensure the minimum requested padding items are shown
-            dbg!(last_visible_index);
-            dbg!(self.items.len());
             let mut padding_index = 0;
             while padding_index != padding
                 && last_visible_index == self.items.len()

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -793,42 +793,11 @@ impl<'a> List<'a> {
             let last_valid_index = self.items.len().saturating_sub(1);
             let selected = selected.min(last_valid_index);
 
-            // This handles the case where the user has input an offset that reduces the number of
-            // items to render to be less than we normally would due to the offset pushing us off
-            // the end of the list of items. We want to allow the padding value to push us back up
-            // to ensure the minimum requested padding items are shown
-            let mut scroll_padding_index = 0;
-            while scroll_padding_index != self.scroll_padding
-                && last_visible_index == self.items.len()
-                && height_from_offset < max_height
-                && first_visible_index != 0
-            {
-                scroll_padding_index += 1;
-                let index = first_visible_index - 1;
-                let item = &self.items[index];
-                if item.height() + height_from_offset <= max_height {
-                    first_visible_index -= 1;
-                    height_from_offset += item.height();
-                } else {
-                    break;
-                }
-            }
-
-            // If there isnt enough room for evreything including padding then reduce the padding
-            // value to prevent the list from jumping up and down or pushing the
-            // selected item out of the visible list area
-            let mut scroll_padding = self.scroll_padding.min(
-                last_visible_index
-                    .saturating_sub(first_visible_index)
-                    .saturating_sub(1)
-                    / 2,
-            );
-
-            // The bellow loop handles situations where the list item sizes may not be consistent.
-            // So while it may have appeared acceptable in the check above, when we actually change
-            // the index_to_display it can change it to an item that's big enough to push the
-            // selected item off the viewable area, or possibly cause the flickering issue again.
-            // So to prevent this we're going to reduce the padding value again
+            // The bellow loop handles situations where the list item sizes may not be consistent,
+            // where the offset would have excluded some items that we want to include, or could
+            // cause the offset value to be set to an inconsistent value each time we render.
+            // The padding value will be reduced in case any of these issues would occur
+            let mut scroll_padding = self.scroll_padding;
             while scroll_padding > 0 {
                 let mut height_around_selected = 0;
                 for index in selected.saturating_sub(scroll_padding)

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -87,6 +87,7 @@ const DEFAULT_STATE_BUFFER: [&str; 5] = [
 const DEFAULT_STATE_REPR: &str = r#"{
   "list_state": {
     "offset": 0,
+    "padding": 0,
     "selected": null
   },
   "table_state": {
@@ -118,6 +119,31 @@ fn default_state_deserialize() {
     assert_buffer(&mut state, &expected);
 }
 
+const DEFAULT_STATE_NO_PADDING_REPR: &str = r#"{
+  "list_state": {
+    "offset": 0,
+    "selected": null
+  },
+  "table_state": {
+    "offset": 0,
+    "selected": null
+  },
+  "scrollbar_state": {
+    "content_length": 10,
+    "position": 0,
+    "viewport_content_length": 0
+  }
+}"#;
+
+/// Added this test to cover the situation where someone may have saved ['ListState'] before the
+/// padding value was added
+#[test]
+fn default_state_no_padding_deserialize() {
+    let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER);
+    let mut state: AppState = serde_json::from_str(DEFAULT_STATE_NO_PADDING_REPR).unwrap();
+    assert_buffer(&mut state, &expected);
+}
+
 const SELECTED_STATE_BUFFER: [&str; 5] = [
     "  awa    │  awa     ▲",
     ">>banana │>>banana  █",
@@ -128,6 +154,7 @@ const SELECTED_STATE_BUFFER: [&str; 5] = [
 const SELECTED_STATE_REPR: &str = r#"{
   "list_state": {
     "offset": 0,
+    "padding": 0,
     "selected": 1
   },
   "table_state": {
@@ -171,6 +198,7 @@ const SCROLLED_STATE_BUFFER: [&str; 5] = [
 const SCROLLED_STATE_REPR: &str = r#"{
   "list_state": {
     "offset": 4,
+    "padding": 0,
     "selected": 8
   },
   "table_state": {

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -87,7 +87,6 @@ const DEFAULT_STATE_BUFFER: [&str; 5] = [
 const DEFAULT_STATE_REPR: &str = r#"{
   "list_state": {
     "offset": 0,
-    "padding": 0,
     "selected": null
   },
   "table_state": {
@@ -119,31 +118,6 @@ fn default_state_deserialize() {
     assert_buffer(&mut state, &expected);
 }
 
-const DEFAULT_STATE_NO_PADDING_REPR: &str = r#"{
-  "list_state": {
-    "offset": 0,
-    "selected": null
-  },
-  "table_state": {
-    "offset": 0,
-    "selected": null
-  },
-  "scrollbar_state": {
-    "content_length": 10,
-    "position": 0,
-    "viewport_content_length": 0
-  }
-}"#;
-
-/// Added this test to cover the situation where someone may have saved ['ListState'] before the
-/// padding value was added
-#[test]
-fn default_state_no_padding_deserialize() {
-    let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER);
-    let mut state: AppState = serde_json::from_str(DEFAULT_STATE_NO_PADDING_REPR).unwrap();
-    assert_buffer(&mut state, &expected);
-}
-
 const SELECTED_STATE_BUFFER: [&str; 5] = [
     "  awa    │  awa     ▲",
     ">>banana │>>banana  █",
@@ -154,7 +128,6 @@ const SELECTED_STATE_BUFFER: [&str; 5] = [
 const SELECTED_STATE_REPR: &str = r#"{
   "list_state": {
     "offset": 0,
-    "padding": 0,
     "selected": 1
   },
   "table_state": {
@@ -198,7 +171,6 @@ const SCROLLED_STATE_BUFFER: [&str; 5] = [
 const SCROLLED_STATE_REPR: &str = r#"{
   "list_state": {
     "offset": 4,
-    "padding": 0,
     "selected": 8
   },
   "table_state": {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
This PR introduces scroll padding, which allows the api user to request that a certain number of ListItems be kept visible above and below the currently selected item while scrolling. 

It does this by adjusting the 'index_to_display' value in the List::get_item_bounds function. Reducing the provided padding value if the padding would push the selected item out of the renderable area or if there's not enough room for the requested amount of padding, and correctly handling ListItems of inconsistent sizes. 

I have stored the 'padding' value in the ListState object. Using serde(default) on the parameter to avoid creating a breaking change in relation to user deserialization of existing data. 
I believe the ListState object is the correct place to put this, as if we're not rendering a stateful list then we dont need this value. 

'Padding' almost certainly isnt the correct name for this value, I think 'scroll_padding' is a better option and communicates the behavior to users better. But I'm open to suggestions. I havent yet changed the code to reflect the clearer 'scroll_padding' name. 

Using this new feature would be the same as existing code for manually setting the offset, so any of the following:
```
*state.padding_mut() = 1;
state = state.with_padding(1);
state = ListState::default().with_padding(1);
```
By default the 'padding' value is 0 and would have no impact on existing users without any action on their end. 

I've written unit tests that cover the original unmodified behavior, the new intended behavior, and several troublesome edge cases that came up while I was developing this but was able to resolve. 
Most of the code in this PR is either new test cases, or specifically for handling those edge cases.

Demo of the new behavior(visible on the left side of the gif):
![scroll_padding](https://github.com/ratatui-org/ratatui/assets/30030363/66de2c06-1d5f-41ff-8cf3-09febb7ccdd3)

Comparison of modified and unmodified behavior is shown in the issue this PR was created for.
This PR resolves #955 