### PR TITLE
fix: scrollbar thumb not visible on long lists

### DIFF
--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -1064,4 +1064,33 @@ mod tests {
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}");
     }
+
+    #[rstest]
+    #[case("#----", 0, 100, "position_0")]
+    #[case("#----", 10, 100, "position_10")]
+    #[case("-#---", 20, 100, "position_20")]
+    #[case("-#---", 30, 100, "position_30")]
+    #[case("--#--", 40, 100, "position_40")]
+    #[case("--#--", 50, 100, "position_50")]
+    #[case("---#-", 60, 100, "position_60")]
+    #[case("---#-", 70, 100, "position_70")]
+    #[case("----#", 80, 100, "position_80")]
+    #[case("----#", 90, 100, "position_90")]
+    #[case("----#", 100, 100, "position_one_out_of_bounds")]
+    fn thumb_visible_on_very_small_track(
+        #[case] expected: &str,
+        #[case] position: usize,
+        #[case] content_length: usize,
+        #[case] description: &str,
+        scrollbar_no_arrows: Scrollbar,
+    ) {
+        let size = expected.width() as u16;
+        let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
+        let mut state = ScrollbarState::default()
+            .position(position)
+            .content_length(content_length)
+            .viewport_content_length(2);
+        scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
+        assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}");
+    }
 }

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -501,13 +501,12 @@ impl Scrollbar<'_> {
         let track_len = self.track_length_excluding_arrow_heads(area) as usize;
         let viewport_len = self.viewport_length(state, area) as usize;
 
-        let content_length = state.content_length;
         // Clamp the position to show at least one line of the content
-        // Note: content_length is != 0 because otherwise render() returns immediately
+        // Note: state.content_length is != 0 because otherwise render() returns immediately
         let position = state.position.min(state.content_length - 1);
 
         // vscode style scrolling behavior (allow scrolling past end of content)
-        let scrollable_content_len = content_length + viewport_len - 1;
+        let scrollable_content_len = state.content_length + viewport_len - 1;
 
         // Calculate the thumb start (inclusive) and end (exclusive) positions, with rounding
         // and ensuring there is at least one visible thumb character.


### PR DESCRIPTION
## The problem
When displaying somewhat-long lists, the `Scrollbar` widget might not display a single thumb character, and only the track will be visible. Here are some GIFs showing the issue:
![before_vertical](https://github.com/ratatui-org/ratatui/assets/32400648/c0628984-a50a-46f4-b4af-58d876e5134d)
![before_horizontal](https://github.com/ratatui-org/ratatui/assets/32400648/7f4ffb24-59ee-45a9-83b7-2a93c717f5c3)

The code to reproduce this issue was based off the scrollbar example and can be found in [this pastebin](https://pastebin.com/x4DzthcF).

## This PR
I fixed this issue by converting the logic in the `part_lengths` function to use integer calculations instead of floating-point (the only reason for the use of floating point seemed to be the rounding after division, which can be done in integers by replacing `(a / b).round() as usize` with `(a + b/2) / b`) and then doing a bit of clamping. The result of the previous test is as shown in these GIFs:
![after_vertical](https://github.com/ratatui-org/ratatui/assets/32400648/850dcf96-3430-4d1d-b9d9-8ff63941d2f4)
![after_horizontal](https://github.com/ratatui-org/ratatui/assets/32400648/ae1e8272-8b65-431e-bc03-a09ef1870ea8)
