### PR TITLE
perf(scrollbar): const creation

### DIFF
--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -133,10 +133,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         Line::from("This is a line".reset()),
         Line::from(vec![
             Span::raw("Masked text: "),
-            Span::styled(
-                Masked::new("password", '*'),
-                Style::default().fg(Color::Red),
-            ),
+            Span::styled(Masked::new("password", '*'), Style::new().fg(Color::Red)),
         ]),
         Line::from("This is a line "),
         Line::from("This is a line   ".red()),
@@ -146,10 +143,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         Line::from("This is a line".reset()),
         Line::from(vec![
             Span::raw("Masked text: "),
-            Span::styled(
-                Masked::new("password", '*'),
-                Style::default().fg(Color::Red),
-            ),
+            Span::styled(Masked::new("password", '*'), Style::new().fg(Color::Red)),
         ]),
     ];
     app.vertical_scroll_state = app.vertical_scroll_state.content_length(text.len());
@@ -157,9 +151,9 @@ fn ui(f: &mut Frame, app: &mut App) {
 
     let create_block = |title: &'static str| Block::bordered().gray().title(title.bold());
 
-    let title = Block::default()
-        .title("Use h j k l or ◄ ▲ ▼ ► to scroll ".bold())
-        .title_alignment(Alignment::Center);
+    let title = Block::new()
+        .title_alignment(Alignment::Center)
+        .title("Use h j k l or ◄ ▲ ▼ ► to scroll ".bold());
     f.render_widget(title, chunks[0]);
 
     let paragraph = Paragraph::new(text.clone())
@@ -168,8 +162,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         .scroll((app.vertical_scroll as u16, 0));
     f.render_widget(paragraph, chunks[1]);
     f.render_stateful_widget(
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::VerticalRight)
+        Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(Some("↑"))
             .end_symbol(Some("↓")),
         chunks[1],
@@ -184,8 +177,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         .scroll((app.vertical_scroll as u16, 0));
     f.render_widget(paragraph, chunks[2]);
     f.render_stateful_widget(
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::VerticalLeft)
+        Scrollbar::new(ScrollbarOrientation::VerticalLeft)
             .symbols(scrollbar::VERTICAL)
             .begin_symbol(None)
             .track_symbol(None)
@@ -205,8 +197,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         .scroll((0, app.horizontal_scroll as u16));
     f.render_widget(paragraph, chunks[3]);
     f.render_stateful_widget(
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalBottom)
+        Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .thumb_symbol("🬋")
             .end_symbol(None),
         chunks[3].inner(&Margin {
@@ -224,8 +215,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         .scroll((0, app.horizontal_scroll as u16));
     f.render_widget(paragraph, chunks[4]);
     f.render_stateful_widget(
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalBottom)
+        Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .thumb_symbol("░")
             .track_symbol(Some("─")),
         chunks[4].inner(&Margin {

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -153,21 +153,32 @@ impl<'a> Default for Scrollbar<'a> {
 }
 
 impl<'a> Scrollbar<'a> {
-    /// Creates a new scrollbar with the given position.
+    /// Creates a new scrollbar with the given orientation.
     ///
-    /// Most of the time you'll want [`ScrollbarOrientation::VerticalLeft`] or
+    /// Most of the time you'll want [`ScrollbarOrientation::VerticalRight`] or
     /// [`ScrollbarOrientation::HorizontalBottom`]. See [`ScrollbarOrientation`] for more options.
     #[must_use = "creates the Scrollbar"]
     pub const fn new(orientation: ScrollbarOrientation) -> Self {
+        let symbols = if orientation.is_vertical() {
+            DOUBLE_VERTICAL
+        } else {
+            DOUBLE_HORIZONTAL
+        };
+        Self::new_with_symbols(orientation, &symbols)
+    }
+
+    /// Creates a new scrollbar with the given orientation and symbol set.
+    #[must_use = "creates the Scrollbar"]
+    const fn new_with_symbols(orientation: ScrollbarOrientation, symbols: &Set) -> Self {
         Self {
             orientation,
-            thumb_symbol: DOUBLE_VERTICAL.thumb,
+            thumb_symbol: symbols.thumb,
             thumb_style: Style::new(),
-            track_symbol: Some(DOUBLE_VERTICAL.track),
+            track_symbol: Some(symbols.track),
             track_style: Style::new(),
-            begin_symbol: Some(DOUBLE_VERTICAL.begin),
+            begin_symbol: Some(symbols.begin),
             begin_style: Style::new(),
-            end_symbol: Some(DOUBLE_VERTICAL.end),
+            end_symbol: Some(symbols.end),
             end_style: Style::new(),
         }
     }
@@ -183,12 +194,12 @@ impl<'a> Scrollbar<'a> {
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn orientation(mut self, orientation: ScrollbarOrientation) -> Self {
         self.orientation = orientation;
-        let set = if self.orientation.is_vertical() {
+        let symbols = if self.orientation.is_vertical() {
             DOUBLE_VERTICAL
         } else {
             DOUBLE_HORIZONTAL
         };
-        self.symbols(set)
+        self.symbols(symbols)
     }
 
     /// Sets the orientation and symbols for the scrollbar from a [`Set`].
@@ -201,10 +212,10 @@ impl<'a> Scrollbar<'a> {
     pub const fn orientation_and_symbol(
         mut self,
         orientation: ScrollbarOrientation,
-        set: Set,
+        symbols: Set,
     ) -> Self {
         self.orientation = orientation;
-        self.symbols(set)
+        self.symbols(symbols)
     }
 
     /// Sets the symbol that represents the thumb of the scrollbar.
@@ -327,16 +338,16 @@ impl<'a> Scrollbar<'a> {
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[allow(clippy::needless_pass_by_value)] // Breaking change
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub const fn symbols(mut self, symbol: Set) -> Self {
-        self.thumb_symbol = symbol.thumb;
+    pub const fn symbols(mut self, symbols: Set) -> Self {
+        self.thumb_symbol = symbols.thumb;
         if self.track_symbol.is_some() {
-            self.track_symbol = Some(symbol.track);
+            self.track_symbol = Some(symbols.track);
         }
         if self.begin_symbol.is_some() {
-            self.begin_symbol = Some(symbol.begin);
+            self.begin_symbol = Some(symbols.begin);
         }
         if self.end_symbol.is_some() {
-            self.end_symbol = Some(symbol.end);
+            self.end_symbol = Some(symbols.end);
         }
         self
     }

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -119,7 +119,7 @@ pub enum ScrollbarOrientation {
 ///
 /// If you don't have multi-line content, you can leave the `viewport_content_length` set to the
 /// default and it'll use the track size as a `viewport_content_length`.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollbarState {
     /// The total length of the scrollable content.
@@ -148,17 +148,7 @@ pub enum ScrollDirection {
 
 impl<'a> Default for Scrollbar<'a> {
     fn default() -> Self {
-        Self {
-            orientation: ScrollbarOrientation::default(),
-            thumb_symbol: DOUBLE_VERTICAL.thumb,
-            thumb_style: Style::default(),
-            track_symbol: Some(DOUBLE_VERTICAL.track),
-            track_style: Style::default(),
-            begin_symbol: Some(DOUBLE_VERTICAL.begin),
-            begin_style: Style::default(),
-            end_symbol: Some(DOUBLE_VERTICAL.end),
-            end_style: Style::default(),
-        }
+        Self::new(ScrollbarOrientation::default())
     }
 }
 
@@ -167,8 +157,19 @@ impl<'a> Scrollbar<'a> {
     ///
     /// Most of the time you'll want [`ScrollbarOrientation::VerticalLeft`] or
     /// [`ScrollbarOrientation::HorizontalBottom`]. See [`ScrollbarOrientation`] for more options.
-    pub fn new(orientation: ScrollbarOrientation) -> Self {
-        Self::default().orientation(orientation)
+    #[must_use = "creates the Scrollbar"]
+    pub const fn new(orientation: ScrollbarOrientation) -> Self {
+        Self {
+            orientation,
+            thumb_symbol: DOUBLE_VERTICAL.thumb,
+            thumb_style: Style::new(),
+            track_symbol: Some(DOUBLE_VERTICAL.track),
+            track_style: Style::new(),
+            begin_symbol: Some(DOUBLE_VERTICAL.begin),
+            begin_style: Style::new(),
+            end_symbol: Some(DOUBLE_VERTICAL.end),
+            end_style: Style::new(),
+        }
     }
 
     /// Sets the position of the scrollbar.
@@ -180,7 +181,7 @@ impl<'a> Scrollbar<'a> {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn orientation(mut self, orientation: ScrollbarOrientation) -> Self {
+    pub const fn orientation(mut self, orientation: ScrollbarOrientation) -> Self {
         self.orientation = orientation;
         let set = if self.orientation.is_vertical() {
             DOUBLE_VERTICAL
@@ -197,7 +198,11 @@ impl<'a> Scrollbar<'a> {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn orientation_and_symbol(mut self, orientation: ScrollbarOrientation, set: Set) -> Self {
+    pub const fn orientation_and_symbol(
+        mut self,
+        orientation: ScrollbarOrientation,
+        set: Set,
+    ) -> Self {
         self.orientation = orientation;
         self.symbols(set)
     }
@@ -209,7 +214,7 @@ impl<'a> Scrollbar<'a> {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn thumb_symbol(mut self, thumb_symbol: &'a str) -> Self {
+    pub const fn thumb_symbol(mut self, thumb_symbol: &'a str) -> Self {
         self.thumb_symbol = thumb_symbol;
         self
     }
@@ -235,7 +240,7 @@ impl<'a> Scrollbar<'a> {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn track_symbol(mut self, track_symbol: Option<&'a str>) -> Self {
+    pub const fn track_symbol(mut self, track_symbol: Option<&'a str>) -> Self {
         self.track_symbol = track_symbol;
         self
     }
@@ -260,7 +265,7 @@ impl<'a> Scrollbar<'a> {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn begin_symbol(mut self, begin_symbol: Option<&'a str>) -> Self {
+    pub const fn begin_symbol(mut self, begin_symbol: Option<&'a str>) -> Self {
         self.begin_symbol = begin_symbol;
         self
     }
@@ -285,7 +290,7 @@ impl<'a> Scrollbar<'a> {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn end_symbol(mut self, end_symbol: Option<&'a str>) -> Self {
+    pub const fn end_symbol(mut self, end_symbol: Option<&'a str>) -> Self {
         self.end_symbol = end_symbol;
         self
     }
@@ -315,13 +320,14 @@ impl<'a> Scrollbar<'a> {
     /// └─────────── begin
     /// ```
     ///
-    /// Only sets begin_symbol, end_symbol and track_symbol if they already contain a value.
+    /// Only sets `begin_symbol`, `end_symbol` and `track_symbol` if they already contain a value.
     /// If they were set to `None` explicitly, this function will respect that choice. Use their
     /// respective setters to change their value.
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
+    #[allow(clippy::needless_pass_by_value)] // Breaking change
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn symbols(mut self, symbol: Set) -> Self {
+    pub const fn symbols(mut self, symbol: Set) -> Self {
         self.thumb_symbol = symbol.thumb;
         if self.track_symbol.is_some() {
             self.track_symbol = Some(symbol.track);
@@ -361,15 +367,23 @@ impl<'a> Scrollbar<'a> {
     }
 }
 
+impl Default for ScrollbarState {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
 impl ScrollbarState {
-    /// Constructs a new ScrollbarState with the specified content length.
+    /// Constructs a new [`ScrollbarState`] with the specified content length.
     ///
     /// `content_length` is the total number of element, that can be scrolled. See
     /// [`ScrollbarState`] for more details.
-    pub fn new(content_length: usize) -> Self {
+    #[must_use = "creates the ScrollbarState"]
+    pub const fn new(content_length: usize) -> Self {
         Self {
             content_length,
-            ..Default::default()
+            position: 0,
+            viewport_content_length: 0,
         }
     }
 
@@ -379,7 +393,7 @@ impl ScrollbarState {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn position(mut self, position: usize) -> Self {
+    pub const fn position(mut self, position: usize) -> Self {
         self.position = position;
         self
     }
@@ -391,7 +405,7 @@ impl ScrollbarState {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn content_length(mut self, content_length: usize) -> Self {
+    pub const fn content_length(mut self, content_length: usize) -> Self {
         self.content_length = content_length;
         self
     }
@@ -400,7 +414,7 @@ impl ScrollbarState {
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn viewport_content_length(mut self, viewport_content_length: usize) -> Self {
+    pub const fn viewport_content_length(mut self, viewport_content_length: usize) -> Self {
         self.viewport_content_length = viewport_content_length;
         self
     }
@@ -415,7 +429,7 @@ impl ScrollbarState {
         self.position = self
             .position
             .saturating_add(1)
-            .min(self.content_length.saturating_sub(1))
+            .min(self.content_length.saturating_sub(1));
     }
 
     /// Sets the scroll position to the start of the scrollable content.
@@ -425,7 +439,7 @@ impl ScrollbarState {
 
     /// Sets the scroll position to the end of the scrollable content.
     pub fn last(&mut self) {
-        self.position = self.content_length.saturating_sub(1)
+        self.position = self.content_length.saturating_sub(1);
     }
 
     /// Changes the scroll position based on the provided [`ScrollDirection`].
@@ -466,7 +480,7 @@ impl Scrollbar<'_> {
     fn bar_symbols(
         &self,
         area: Rect,
-        state: &mut ScrollbarState,
+        state: &ScrollbarState,
     ) -> impl Iterator<Item = Option<(&str, Style)>> {
         let (track_start_len, thumb_len, track_end_len) = self.part_lengths(area, state);
 
@@ -492,12 +506,12 @@ impl Scrollbar<'_> {
     ///
     /// The scrollbar has 3 parts of note:
     /// - `<═══█████═══════>`: full scrollbar
-    /// - ` ═══             `: track start part
-    /// - `    █████        `: thumb part part
-    /// - `         ═══════ `: track end part
+    /// - ` ═══             `: track start
+    /// - `    █████        `: thumb
+    /// - `         ═══════ `: track end
     ///
     /// This method returns the length of the start, thumb, and end as a tuple.
-    fn part_lengths(&self, area: Rect, state: &mut ScrollbarState) -> (usize, usize, usize) {
+    fn part_lengths(&self, area: Rect, state: &ScrollbarState) -> (usize, usize, usize) {
         let track_length = self.track_length_excluding_arrow_heads(area) as f64;
         let viewport_length = self.viewport_length(state, area) as f64;
 
@@ -544,9 +558,9 @@ impl Scrollbar<'_> {
     /// <═══█████═══════>
     /// ```
     fn track_length_excluding_arrow_heads(&self, area: Rect) -> u16 {
-        let start_len = self.begin_symbol.map(|s| s.width() as u16).unwrap_or(0);
-        let end_len = self.end_symbol.map(|s| s.width() as u16).unwrap_or(0);
-        let arrows_len = start_len + end_len;
+        let start_len = self.begin_symbol.map_or(0, |s| s.width() as u16);
+        let end_len = self.end_symbol.map_or(0, |s| s.width() as u16);
+        let arrows_len = start_len.saturating_add(end_len);
         if self.orientation.is_vertical() {
             area.height.saturating_sub(arrows_len)
         } else {
@@ -554,26 +568,27 @@ impl Scrollbar<'_> {
         }
     }
 
-    fn viewport_length(&self, state: &ScrollbarState, area: Rect) -> u16 {
+    const fn viewport_length(&self, state: &ScrollbarState, area: Rect) -> usize {
         if state.viewport_content_length != 0 {
-            return state.viewport_content_length as u16;
-        }
-        if self.orientation.is_vertical() {
-            area.height
+            state.viewport_content_length
+        } else if self.orientation.is_vertical() {
+            area.height as usize
         } else {
-            area.width
+            area.width as usize
         }
     }
 }
 
 impl ScrollbarOrientation {
     /// Returns `true` if the scrollbar is vertical.
-    pub fn is_vertical(&self) -> bool {
+    #[must_use = "returns the requested kind of the scrollbar"]
+    pub const fn is_vertical(&self) -> bool {
         matches!(self, Self::VerticalRight | Self::VerticalLeft)
     }
 
     /// Returns `true` if the scrollbar is horizontal.
-    pub fn is_horizontal(&self) -> bool {
+    #[must_use = "returns the requested kind of the scrollbar"]
+    pub const fn is_horizontal(&self) -> bool {
         matches!(self, Self::HorizontalBottom | Self::HorizontalTop)
     }
 }
@@ -628,8 +643,7 @@ mod tests {
 
     #[fixture]
     fn scrollbar_no_arrows() -> Scrollbar<'static> {
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalTop)
+        Scrollbar::new(ScrollbarOrientation::HorizontalTop)
             .begin_symbol(None)
             .end_symbol(None)
             .track_symbol(Some("-"))
@@ -647,9 +661,7 @@ mod tests {
         scrollbar_no_arrows: Scrollbar,
     ) {
         let mut buffer = Buffer::empty(Rect::new(0, 0, expected.width() as u16, 1));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
+        let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
     }
@@ -673,9 +685,7 @@ mod tests {
         scrollbar_no_arrows: Scrollbar,
     ) {
         let mut buffer = Buffer::empty(Rect::new(0, 0, expected.width() as u16, 1));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
+        let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
     }
@@ -691,9 +701,7 @@ mod tests {
     ) {
         let size = expected.width();
         let mut buffer = Buffer::empty(Rect::new(0, 0, size as u16, 1));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
+        let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
     }
@@ -711,9 +719,7 @@ mod tests {
     ) {
         let size = expected.width();
         let mut buffer = Buffer::empty(Rect::new(0, 0, size as u16, 1));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
+        let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
     }
@@ -730,9 +736,7 @@ mod tests {
     ) {
         let size = expected.width();
         let mut buffer = Buffer::empty(Rect::new(0, 0, size as u16, 1));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
+        let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
     }
@@ -757,19 +761,15 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalBottom)
+        let mut state = ScrollbarState::new(content_length).position(position);
+        Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .begin_symbol(None)
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
         assert_eq!(
             buffer,
             Buffer::with_lines(vec![expected]),
-            "{}",
-            assertion_message
+            "{assertion_message}",
         );
     }
 
@@ -793,11 +793,8 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalBottom)
+        let mut state = ScrollbarState::new(content_length).position(position);
+        Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .track_symbol(None)
             .begin_symbol(None)
             .end_symbol(None)
@@ -805,8 +802,7 @@ mod tests {
         assert_eq!(
             buffer,
             Buffer::with_lines(vec![expected]),
-            "{}",
-            assertion_message
+            "{assertion_message}",
         );
     }
 
@@ -833,11 +829,8 @@ mod tests {
         let width = buffer.area.width as usize;
         let s = "";
         Text::from(format!("{s:-^width$}")).render(buffer.area, &mut buffer);
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalBottom)
+        let mut state = ScrollbarState::new(content_length).position(position);
+        Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .track_symbol(None)
             .begin_symbol(None)
             .end_symbol(None)
@@ -845,8 +838,7 @@ mod tests {
         assert_eq!(
             buffer,
             Buffer::with_lines(vec![expected]),
-            "{}",
-            assertion_message
+            "{assertion_message}",
         );
     }
 
@@ -872,11 +864,8 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalTop)
+        let mut state = ScrollbarState::new(content_length).position(position);
+        Scrollbar::new(ScrollbarOrientation::HorizontalTop)
             .begin_symbol(Some("<"))
             .end_symbol(Some(">"))
             .track_symbol(Some("-"))
@@ -885,8 +874,7 @@ mod tests {
         assert_eq!(
             buffer,
             Buffer::with_lines(vec![expected]),
-            "{}",
-            assertion_message,
+            "{assertion_message}",
         );
     }
 
@@ -910,15 +898,12 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 2));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalBottom)
+        let mut state = ScrollbarState::new(content_length).position(position);
+        Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .begin_symbol(None)
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
-        let empty_string: String = " ".repeat(size as usize);
+        let empty_string = " ".repeat(size as usize);
         assert_eq!(
             buffer,
             Buffer::with_lines(vec![&empty_string, expected]),
@@ -946,15 +931,12 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 2));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::HorizontalTop)
+        let mut state = ScrollbarState::new(content_length).position(position);
+        Scrollbar::new(ScrollbarOrientation::HorizontalTop)
             .begin_symbol(None)
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
-        let empty_string: String = " ".repeat(size as usize);
+        let empty_string = " ".repeat(size as usize);
         assert_eq!(
             buffer,
             Buffer::with_lines(vec![expected, &empty_string]),
@@ -982,11 +964,8 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, 5, size));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::VerticalLeft)
+        let mut state = ScrollbarState::new(content_length).position(position);
+        Scrollbar::new(ScrollbarOrientation::VerticalLeft)
             .begin_symbol(Some("<"))
             .end_symbol(Some(">"))
             .track_symbol(Some("-"))
@@ -1016,11 +995,8 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, 5, size));
-        let mut state = ScrollbarState::default()
-            .position(position)
-            .content_length(content_length);
-        Scrollbar::default()
-            .orientation(ScrollbarOrientation::VerticalRight)
+        let mut state = ScrollbarState::new(content_length).position(position);
+        Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(Some("<"))
             .end_symbol(Some(">"))
             .track_symbol(Some("-"))
@@ -1051,9 +1027,8 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
-        let mut state = ScrollbarState::default()
+        let mut state = ScrollbarState::new(content_length)
             .position(position)
-            .content_length(content_length)
             .viewport_content_length(2);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}");
@@ -1082,9 +1057,8 @@ mod tests {
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
-        let mut state = ScrollbarState::default()
+        let mut state = ScrollbarState::new(content_length)
             .position(position)
-            .content_length(content_length)
             .viewport_content_length(2);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}");


### PR DESCRIPTION
While doing other things in the Scrollbar widget I used a bunch of lints to improve things. A bunch of `const fn` allow for more performance and `Default` now uses the `const` new implementations.

For simplicity reasons I created `Scrollbar::new_with_symbols` for a cleaner `new` without calling `orientation()` on new.