### PR TITLE
fix(scrollbar): dont render on 0 length track

### DIFF
--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -445,7 +445,7 @@ impl<'a> StatefulWidget for Scrollbar<'a> {
     type State = ScrollbarState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        if state.content_length == 0 || area.is_empty() {
+        if state.content_length == 0 || self.track_length_excluding_arrow_heads(area) == 0 {
             return;
         }
 


### PR DESCRIPTION
Fixes a panic when `track_length - 1` is used. (clamp panics on `-1.0` being smaller than `0.0`)

https://github.com/ratatui-org/ratatui/blob/d0067c8815d5244d319934d58a9366c8ad36b3e5/src/widgets/scrollbar.rs#L520

