### PR TITLE
feat(line): impl Styled for Line

### DIFF
--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -2,7 +2,7 @@
 use std::borrow::Cow;
 
 use super::StyledGrapheme;
-use crate::{prelude::*, widgets::Widget};
+use crate::prelude::*;
 
 /// A line of text, consisting of one or more [`Span`]s.
 ///
@@ -443,6 +443,15 @@ impl<'a> From<Line<'a>> for String {
     }
 }
 
+impl<'a, T> FromIterator<T> for Line<'a>
+where
+    T: Into<Span<'a>>,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self::from(iter.into_iter().map(Into::into).collect::<Vec<_>>())
+    }
+}
+
 impl Widget for Line<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         self.render_ref(area, buf);
@@ -488,6 +497,8 @@ impl std::fmt::Display for Line<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::iter;
+
     use rstest::{fixture, rstest};
 
     use super::*;
@@ -623,6 +634,32 @@ mod tests {
         ];
         let line = Line::from(spans.clone());
         assert_eq!(spans, line.spans);
+    }
+
+    #[test]
+    fn from_iter() {
+        let line = Line::from_iter(vec!["Hello".blue(), " world!".green()]);
+        assert_eq!(
+            line.spans,
+            vec![
+                Span::styled("Hello", Style::new().blue()),
+                Span::styled(" world!", Style::new().green()),
+            ]
+        );
+    }
+
+    #[test]
+    fn collect() {
+        let line: Line = iter::once("Hello".blue())
+            .chain(iter::once(" world!".green()))
+            .collect();
+        assert_eq!(
+            line.spans,
+            vec![
+                Span::styled("Hello", Style::new().blue()),
+                Span::styled(" world!", Style::new().green()),
+            ]
+        );
     }
 
     #[test]

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -495,6 +495,18 @@ impl std::fmt::Display for Line<'_> {
     }
 }
 
+impl<'a> Styled for Line<'a> {
+    type Item = Line<'a>;
+
+    fn style(&self) -> Style {
+        self.style
+    }
+
+    fn set_style<S: Into<Style>>(self, style: S) -> Self::Item {
+        self.style(style)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::iter;
@@ -610,6 +622,16 @@ mod tests {
             Line::styled("foobar", Style::default().yellow().on_red().italic()).reset_style();
 
         assert_eq!(Style::reset(), line.style);
+    }
+
+    #[test]
+    fn stylize() {
+        assert_eq!(Line::default().green().style, Color::Green.into());
+        assert_eq!(
+            Line::default().on_green().style,
+            Style::new().bg(Color::Green)
+        );
+        assert_eq!(Line::default().italic().style, Modifier::ITALIC.into());
     }
 
     #[test]

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -4,7 +4,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use super::StyledGrapheme;
-use crate::{prelude::*, widgets::Widget};
+use crate::prelude::*;
 
 /// Represents a part of a line that is contiguous and where all characters share the same style.
 ///

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -419,6 +419,19 @@ impl<'a> From<Vec<Line<'a>>> for Text<'a> {
     }
 }
 
+impl<'a, T> FromIterator<T> for Text<'a>
+where
+    T: Into<Line<'a>>,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let lines = iter.into_iter().map(Into::into).collect();
+        Text {
+            lines,
+            ..Default::default()
+        }
+    }
+}
+
 impl<'a, T> Extend<T> for Text<'a>
 where
     T: Into<Line<'a>>,
@@ -486,6 +499,8 @@ impl<'a> Styled for Text<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::iter;
+
     use rstest::{fixture, rstest};
 
     use super::*;
@@ -595,6 +610,26 @@ mod tests {
             Line::from("The first line"),
             Line::from("The second line"),
         ]);
+        assert_eq!(
+            text.lines,
+            vec![Line::from("The first line"), Line::from("The second line")]
+        );
+    }
+
+    #[test]
+    fn from_iterator() {
+        let text = Text::from_iter(vec!["The first line", "The second line"]);
+        assert_eq!(
+            text.lines,
+            vec![Line::from("The first line"), Line::from("The second line")]
+        );
+    }
+
+    #[test]
+    fn collect() {
+        let text: Text = iter::once("The first line")
+            .chain(iter::once("The second line"))
+            .collect();
         assert_eq!(
             text.lines,
             vec![Line::from("The first line"), Line::from("The second line")]


### PR DESCRIPTION
This adds `FromIterator` impls for `Line` and `Text` that allow creating
`Line` and `Text` instances from iterators of `Span` and `Line`
instances, respectively.

```rust
let line = Line::from_iter(vec!["Hello".blue(), " world!".green()]);
let line: Line = iter::once("Hello".blue())
    .chain(iter::once(" world!".green()))
    .collect();
let text = Text::from_iter(vec!["The first line", "The second line"]);
let text: Text = iter::once("The first line")
    .chain(iter::once("The second line"))
    .collect();
```