### PR TITLE
refactor: remove pointless default on internal structs

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -304,7 +304,6 @@ impl From<CColor> for Color {
 /// The `ModifierDiff` struct is used to calculate the difference between two `Modifier`
 /// values. This is useful when updating the terminal display, as it allows for more
 /// efficient updates by only sending the necessary changes.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 struct ModifierDiff {
     pub from: Modifier,
     pub to: Modifier,

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -209,16 +209,13 @@ where
         self.writer.flush()
     }
 }
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 struct Fg(Color);
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 struct Bg(Color);
 
 /// The `ModifierDiff` struct is used to calculate the difference between two `Modifier`
 /// values. This is useful when updating the terminal display, as it allows for more
 /// efficient updates by only sending the necessary changes.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 struct ModifierDiff {
     from: Modifier,
     to: Modifier,

--- a/src/widgets/canvas.rs
+++ b/src/widgets/canvas.rs
@@ -55,7 +55,7 @@ pub struct Label<'a> {
 ///
 /// This allows the canvas to be drawn in multiple layers. This is useful if you want to draw
 /// multiple shapes on the canvas in specific order.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug)]
 struct Layer {
     // A string of characters representing the grid. This will be wrapped to the width of the grid
     // when rendering
@@ -97,7 +97,7 @@ trait Grid: Debug {
 ///
 /// This grid type only supports a single foreground color for each 2x4 dots cell. There is no way
 /// to set the individual color of each dot in the braille pattern.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug)]
 struct BrailleGrid {
     /// Width of the grid in number of terminal columns
     width: u16,
@@ -160,7 +160,7 @@ impl Grid for BrailleGrid {
 ///
 /// This makes it possible to draw shapes with a resolution of 1x1 dots per cell. This is useful
 /// when you want to draw shapes with a low resolution.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug)]
 struct CharGrid {
     /// Width of the grid in number of terminal columns
     width: u16,
@@ -232,7 +232,7 @@ impl Grid for CharGrid {
 /// This allows for more flexibility than the `BrailleGrid` which only supports a single
 /// foreground color for each 2x4 dots cell, and the `CharGrid` which only supports a single
 /// character for each cell.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug)]
 struct HalfBlockGrid {
     /// Width of the grid in number of terminal columns
     width: u16,

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -949,19 +949,15 @@ impl WidgetRef for Chart<'_> {
 
         self.block.render_ref(area, buf);
         let chart_area = self.block.inner_if_some(area);
-        if chart_area.is_empty() {
+        let Some(layout) = self.layout(chart_area) else {
             return;
-        }
+        };
+        let graph_area = layout.graph_area;
 
         // Sample the style of the entire widget. This sample will be used to reset the style of
         // the cells that are part of the components put on top of the grah area (i.e legend and
         // axis names).
         let original_style = buf.get(area.left(), area.top()).style();
-
-        let Some(layout) = self.layout(chart_area) else {
-            return;
-        };
-        let graph_area = layout.graph_area;
 
         self.render_x_labels(buf, &layout, chart_area, graph_area);
         self.render_y_labels(buf, &layout, chart_area, graph_area);

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -720,9 +720,14 @@ impl<'a> Chart<'a> {
 
         let graph_width = area.right().saturating_sub(x);
         let graph_height = y.saturating_sub(area.top()).saturating_add(1);
-        if graph_width == 0 || graph_height == 0 {
-            return None;
-        }
+        debug_assert_ne!(
+            graph_width, 0,
+            "Axis and labels should have been hidden due to the small area"
+        );
+        debug_assert_ne!(
+            graph_height, 0,
+            "Axis and labels should have been hidden due to the small area"
+        );
         let graph_area = Rect::new(x, area.top(), graph_width, graph_height);
 
         let mut title_x = None;


### PR DESCRIPTION
See #978

Also remove other derives. They are unused and just slow down compilation.