### PR TITLE
refactor(clippy): enable breaking lint checks

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,5 @@
+avoid-breaking-exported-api = false
+
 # https://rust-lang.github.io/rust-clippy/master/index.html#/multiple_crate_versions
 # ratatui -> bitflags v2.3
 # termwiz -> wezterm-blob-leases -> mac_address -> nix -> bitflags v1.3.2

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -119,7 +119,7 @@ impl Rect {
     /// Returns a new `Rect` inside the current one, with the given margin on each side.
     ///
     /// If the margin is larger than the `Rect`, the returned `Rect` will have no area.
-    #[allow(clippy::trivially_copy_pass_by_ref)] // TODO: Breaking change
+    #[allow(clippy::trivially_copy_pass_by_ref)] // See PR #1008
     #[must_use = "method returns the modified value"]
     pub const fn inner(self, margin: &Margin) -> Self {
         let doubled_margin_horizontal = margin.horizontal.saturating_mul(2);

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -119,6 +119,7 @@ impl Rect {
     /// Returns a new `Rect` inside the current one, with the given margin on each side.
     ///
     /// If the margin is larger than the `Rect`, the returned `Rect` will have no area.
+    #[allow(clippy::trivially_copy_pass_by_ref)] // TODO: Breaking change
     #[must_use = "method returns the modified value"]
     pub const fn inner(self, margin: &Margin) -> Self {
         let doubled_margin_horizontal = margin.horizontal.saturating_mul(2);

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -30,6 +30,7 @@ use crate::{prelude::*, widgets::Block};
 /// # See also
 ///
 /// - [`LineGauge`] for a thin progress bar
+#[allow(clippy::struct_field_names)] // gauge_style needs to be differentiated to style
 #[derive(Debug, Clone, PartialEq)]
 pub struct Gauge<'a> {
     block: Option<Block<'a>>,


### PR DESCRIPTION
We need to make sure to not change existing methods without a notice. But at the same time this also finds public additions with mistakes before they are even released which is what I would like to have.

This renames a method and deprecated the old name hinting to a new name. Should this be mentioned somewhere, so it's added to the release notes? It's not breaking because the old method is still there.
