### PR TITLE
refactor(span): rename to_aligned_line into into_aligned_line

### DIFF
--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -282,7 +282,7 @@ impl App {
 
     fn header() -> impl Widget {
         let text = "Constraint Explorer";
-        text.bold().fg(Self::HEADER_COLOR).to_centered_line()
+        text.bold().fg(Self::HEADER_COLOR).into_centered_line()
     }
 
     fn instructions() -> impl Widget {
@@ -541,7 +541,7 @@ impl SpacerBlock {
     /// A label that says "Spacer" if there is enough space
     fn spacer_label(width: u16) -> impl Widget {
         let label = if width >= 6 { "Spacer" } else { "" };
-        label.fg(Self::TEXT_COLOR).to_centered_line()
+        label.fg(Self::TEXT_COLOR).into_centered_line()
     }
 
     /// A label that says "8 px" if there is enough space

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -282,11 +282,17 @@ impl<'a> Span<'a> {
     ///
     /// ```rust
     /// # use ratatui::prelude::*;
-    /// let l = "Test Content".green().italic().to_left_aligned_line();
+    /// let line = "Test Content".green().italic().into_left_aligned_line();
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn to_left_aligned_line(self) -> Line<'a> {
+    pub fn into_left_aligned_line(self) -> Line<'a> {
         Line::from(self).left_aligned()
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    #[deprecated = "use into_left_aligned_line"]
+    pub fn to_left_aligned_line(self) -> Line<'a> {
+        self.into_left_aligned_line()
     }
 
     /// Converts this Span into a center-aligned [`Line`]
@@ -295,10 +301,17 @@ impl<'a> Span<'a> {
     ///
     /// ```rust
     /// # use ratatui::prelude::*;
-    /// let l = "Test Content".green().italic().to_centered_line();
+    /// let line = "Test Content".green().italic().into_centered_line();
     /// ```
-    pub fn to_centered_line(self) -> Line<'a> {
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn into_centered_line(self) -> Line<'a> {
         Line::from(self).centered()
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    #[deprecated = "use into_centered_line"]
+    pub fn to_centered_line(self) -> Line<'a> {
+        self.into_centered_line()
     }
 
     /// Converts this Span into a right-aligned [`Line`]
@@ -307,10 +320,17 @@ impl<'a> Span<'a> {
     ///
     /// ```rust
     /// # use ratatui::prelude::*;
-    /// let l = "Test Content".green().italic().to_right_aligned_line();
+    /// let line = "Test Content".green().italic().into_right_aligned_line();
     /// ```
-    pub fn to_right_aligned_line(self) -> Line<'a> {
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn into_right_aligned_line(self) -> Line<'a> {
         Line::from(self).right_aligned()
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    #[deprecated = "use into_right_aligned_line"]
+    pub fn to_right_aligned_line(self) -> Line<'a> {
+        self.into_right_aligned_line()
     }
 }
 
@@ -616,21 +636,21 @@ mod tests {
     #[test]
     fn left_aligned() {
         let span = Span::styled("Test Content", Style::new().green().italic());
-        let line = span.to_left_aligned_line();
+        let line = span.into_left_aligned_line();
         assert_eq!(line.alignment, Some(Alignment::Left));
     }
 
     #[test]
     fn centered() {
         let span = Span::styled("Test Content", Style::new().green().italic());
-        let line = span.to_centered_line();
+        let line = span.into_centered_line();
         assert_eq!(line.alignment, Some(Alignment::Center));
     }
 
     #[test]
     fn right_aligned() {
         let span = Span::styled("Test Content", Style::new().green().italic());
-        let line = span.to_right_aligned_line();
+        let line = span.into_right_aligned_line();
         assert_eq!(line.alignment, Some(Alignment::Right));
     }
 }


### PR DESCRIPTION
This deprecates the old methods hinting the new name.

With the Rust method naming conventions this method is an into method consuming the Span. Therefore, it's more consistent to name it into instead of to.
