### PR TITLE
fix(text): fix panic when rendering out of bounds

### DIFF
--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -587,6 +587,11 @@ mod tests {
 
     use super::*;
 
+    #[fixture]
+    fn small_buf() -> Buffer {
+        Buffer::empty(Rect::new(0, 0, 10, 1))
+    }
+
     #[test]
     fn raw_str() {
         let line = Line::raw("test content");
@@ -832,6 +837,7 @@ mod tests {
         const GREEN: Style = Style::new().fg(Color::Green);
         const ITALIC: Style = Style::new().add_modifier(Modifier::ITALIC);
 
+        #[fixture]
         fn hello_world() -> Line<'static> {
             Line::from(vec![
                 Span::styled("Hello ", BLUE),
@@ -849,6 +855,13 @@ mod tests {
             expected.set_style(Rect::new(0, 0, 6, 1), BLUE);
             expected.set_style(Rect::new(6, 0, 6, 1), GREEN);
             assert_buffer_eq!(buf, expected);
+        }
+
+        #[rstest]
+        fn render_out_of_bounds(hello_world: Line<'static>, mut small_buf: Buffer) {
+            let out_of_bounds = Rect::new(20, 20, 10, 1);
+            hello_world.render(out_of_bounds, &mut small_buf);
+            assert_buffer_eq!(small_buf, Buffer::empty(small_buf.area));
         }
 
         #[test]

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -363,6 +363,7 @@ impl Widget for Span<'_> {
 
 impl WidgetRef for Span<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        let area = area.intersection(buf.area);
         let Rect {
             x: mut current_x,
             y,
@@ -402,7 +403,14 @@ impl std::fmt::Display for Span<'_> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::fixture;
+
     use super::*;
+
+    #[fixture]
+    fn small_buf() -> Buffer {
+        Buffer::empty(Rect::new(0, 0, 10, 1))
+    }
 
     #[test]
     fn default() {
@@ -533,6 +541,8 @@ mod tests {
     }
 
     mod widget {
+        use rstest::rstest;
+
         use super::*;
         use crate::assert_buffer_eq;
 
@@ -548,6 +558,13 @@ mod tests {
                 "   ".into(),
             ])]);
             assert_buffer_eq!(buf, expected);
+        }
+
+        #[rstest]
+        fn render_out_of_bounds(mut small_buf: Buffer) {
+            let out_of_bounds = Rect::new(20, 20, 10, 1);
+            Span::raw("Hello, World!").render(out_of_bounds, &mut small_buf);
+            assert_eq!(small_buf, Buffer::empty(small_buf.area));
         }
 
         /// When the content of the span is longer than the area passed to render, the content

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -559,6 +559,7 @@ impl Widget for Text<'_> {
 
 impl WidgetRef for Text<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        let area = area.intersection(buf.area);
         buf.set_style(area, self.style);
         for (line, row) in self.iter().zip(area.rows()) {
             let line_width = line.width() as u16;
@@ -600,6 +601,11 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use super::*;
+
+    #[fixture]
+    fn small_buf() -> Buffer {
+        Buffer::empty(Rect::new(0, 0, 10, 1))
+    }
 
     #[test]
     fn raw() {
@@ -863,6 +869,13 @@ mod tests {
             let expected_buf = Buffer::with_lines(vec!["foo  "]);
 
             assert_buffer_eq!(buf, expected_buf);
+        }
+
+        #[rstest]
+        fn render_out_of_bounds(mut small_buf: Buffer) {
+            let out_of_bounds_area = Rect::new(20, 20, 10, 1);
+            Text::from("Hello, world!").render(out_of_bounds_area, &mut small_buf);
+            assert_eq!(small_buf, Buffer::empty(small_buf.area));
         }
 
         #[test]


### PR DESCRIPTION
Previously it was possible to cause a panic when rendering to an area
outside of the buffer bounds. Instead this now correctly renders nothing
to the buffer.
