### PR TITLE
feat(text): add push methods for text and line

### DIFF
--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -451,6 +451,11 @@ impl<'a> Line<'a> {
     pub fn iter_mut(&mut self) -> std::slice::IterMut<Span<'a>> {
         self.spans.iter_mut()
     }
+
+    /// Adds a span to the line.
+    pub fn push_span(&mut self, span: Span<'a>) {
+        self.spans.push(span);
+    }
 }
 
 impl<'a> IntoIterator for Line<'a> {
@@ -830,6 +835,31 @@ mod tests {
         assert_eq!(format!("{line_from_styled_span}"), "Hello, world!");
     }
 
+    #[test]
+    fn left_aligned() {
+        let line = Line::from("Hello, world!").left_aligned();
+        assert_eq!(line.alignment, Some(Alignment::Left));
+    }
+
+    #[test]
+    fn centered() {
+        let line = Line::from("Hello, world!").centered();
+        assert_eq!(line.alignment, Some(Alignment::Center));
+    }
+
+    #[test]
+    fn right_aligned() {
+        let line = Line::from("Hello, world!").right_aligned();
+        assert_eq!(line.alignment, Some(Alignment::Right));
+    }
+
+    #[test]
+    pub fn push_span() {
+        let mut line = Line::from("Hello, ");
+        line.push_span(Span::raw("world!"));
+        assert_eq!(line.spans, vec![Span::raw("Hello, "), Span::raw("world!")]);
+    }
+
     mod widget {
         use super::*;
         use crate::assert_buffer_eq;
@@ -906,24 +936,6 @@ mod tests {
             expected.set_style(Rect::new(9, 0, 6, 1), GREEN);
             assert_buffer_eq!(buf, expected);
         }
-    }
-
-    #[test]
-    fn left_aligned() {
-        let line = Line::from("Hello, world!").left_aligned();
-        assert_eq!(line.alignment, Some(Alignment::Left));
-    }
-
-    #[test]
-    fn centered() {
-        let line = Line::from("Hello, world!").centered();
-        assert_eq!(line.alignment, Some(Alignment::Center));
-    }
-
-    #[test]
-    fn right_aligned() {
-        let line = Line::from("Hello, world!").right_aligned();
-        assert_eq!(line.alignment, Some(Alignment::Right));
     }
 
     mod iterators {

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -48,6 +48,7 @@ use crate::prelude::*;
 /// - [`Line::reset_style`] resets the style of the line.
 /// - [`Line::width`] returns the unicode width of the content held by this line.
 /// - [`Line::styled_graphemes`] returns an iterator over the graphemes held by this line.
+/// - [`Line::push_span`] adds a span to the line.
 ///
 /// # Compatibility Notes
 ///
@@ -453,8 +454,20 @@ impl<'a> Line<'a> {
     }
 
     /// Adds a span to the line.
-    pub fn push_span(&mut self, span: Span<'a>) {
-        self.spans.push(span);
+    ///
+    /// `span` can be any type that is convertible into a `Span`. For example, you can pass a
+    /// `&str`, a `String`, or a `Span`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::prelude::*;
+    /// let mut line = Line::from("Hello, ");
+    /// line.push_span(Span::raw("world!"));
+    /// line.push_span(" How are you?");
+    /// ```
+    pub fn push_span<T: Into<Span<'a>>>(&mut self, span: T) {
+        self.spans.push(span.into());
     }
 }
 
@@ -855,9 +868,13 @@ mod tests {
 
     #[test]
     pub fn push_span() {
-        let mut line = Line::from("Hello, ");
-        line.push_span(Span::raw("world!"));
-        assert_eq!(line.spans, vec![Span::raw("Hello, "), Span::raw("world!")]);
+        let mut line = Line::from("A");
+        line.push_span(Span::raw("B"));
+        line.push_span("C");
+        assert_eq!(
+            line.spans,
+            vec![Span::raw("A"), Span::raw("B"), Span::raw("C")]
+        );
     }
 
     mod widget {

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -540,6 +540,27 @@ mod tests {
         assert_eq!(format!("{stylized_span}"), "stylized test content");
     }
 
+    #[test]
+    fn left_aligned() {
+        let span = Span::styled("Test Content", Style::new().green().italic());
+        let line = span.into_left_aligned_line();
+        assert_eq!(line.alignment, Some(Alignment::Left));
+    }
+
+    #[test]
+    fn centered() {
+        let span = Span::styled("Test Content", Style::new().green().italic());
+        let line = span.into_centered_line();
+        assert_eq!(line.alignment, Some(Alignment::Center));
+    }
+
+    #[test]
+    fn right_aligned() {
+        let span = Span::styled("Test Content", Style::new().green().italic());
+        let line = span.into_right_aligned_line();
+        assert_eq!(line.alignment, Some(Alignment::Right));
+    }
+
     mod widget {
         use rstest::rstest;
 
@@ -648,26 +669,5 @@ mod tests {
             ])]);
             assert_buffer_eq!(buf, expected);
         }
-    }
-
-    #[test]
-    fn left_aligned() {
-        let span = Span::styled("Test Content", Style::new().green().italic());
-        let line = span.into_left_aligned_line();
-        assert_eq!(line.alignment, Some(Alignment::Left));
-    }
-
-    #[test]
-    fn centered() {
-        let span = Span::styled("Test Content", Style::new().green().italic());
-        let line = span.into_centered_line();
-        assert_eq!(line.alignment, Some(Alignment::Center));
-    }
-
-    #[test]
-    fn right_aligned() {
-        let span = Span::styled("Test Content", Style::new().green().italic());
-        let line = span.into_right_aligned_line();
-        assert_eq!(line.alignment, Some(Alignment::Right));
     }
 }

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -441,6 +441,20 @@ impl<'a> Text<'a> {
     pub fn iter_mut(&mut self) -> std::slice::IterMut<Line<'a>> {
         self.lines.iter_mut()
     }
+
+    /// Adds a line to the text.
+    pub fn push_line(&mut self, line: Line<'a>) {
+        self.lines.push(line);
+    }
+
+    /// Adds a span to the last line of the text.
+    pub fn push_span(&mut self, span: Span<'a>) {
+        if let Some(last) = self.lines.last_mut() {
+            last.push_span(span);
+        } else {
+            self.lines.push(Line::from(span));
+        }
+    }
 }
 
 impl<'a> IntoIterator for Text<'a> {
@@ -854,6 +868,61 @@ mod tests {
         assert_eq!(Text::default().italic().style, Modifier::ITALIC.into());
     }
 
+    #[test]
+    fn left_aligned() {
+        let text = Text::from("Hello, world!").left_aligned();
+        assert_eq!(text.alignment, Some(Alignment::Left));
+    }
+
+    #[test]
+    fn centered() {
+        let text = Text::from("Hello, world!").centered();
+        assert_eq!(text.alignment, Some(Alignment::Center));
+    }
+
+    #[test]
+    fn right_aligned() {
+        let text = Text::from("Hello, world!").right_aligned();
+        assert_eq!(text.alignment, Some(Alignment::Right));
+    }
+
+    #[test]
+    fn push_line() {
+        let mut text = Text::from("Hello, world!");
+        text.push_line(Line::from("How are you?"));
+        assert_eq!(
+            text.lines,
+            vec![Line::from("Hello, world!"), Line::from("How are you?")]
+        );
+    }
+
+    #[test]
+    fn push_line_empty() {
+        let mut text = Text::default();
+        text.push_line(Line::from("Hello, world!"));
+        assert_eq!(text.lines, vec![Line::from("Hello, world!")]);
+    }
+
+    #[test]
+    fn push_span() {
+        let mut text = Text::from("Hello, world!");
+        text.push_span(Span::raw("How are you?"));
+        assert_eq!(
+            text.lines,
+            vec![Line::from(vec![
+                Span::raw("Hello, world!"),
+                Span::raw("How are you?")
+            ])],
+        );
+    }
+
+    #[test]
+    fn push_span_empty() {
+        let mut text = Text::default();
+        text.push_span(Span::raw("Hello, world!"));
+        assert_eq!(text.lines, vec![Line::from(Span::raw("Hello, world!"))],);
+    }
+
     mod widget {
         use super::*;
         use crate::assert_buffer_eq;
@@ -956,24 +1025,6 @@ mod tests {
 
             assert_buffer_eq!(buf, expected);
         }
-    }
-
-    #[test]
-    fn left_aligned() {
-        let text = Text::from("Hello, world!").left_aligned();
-        assert_eq!(text.alignment, Some(Alignment::Left));
-    }
-
-    #[test]
-    fn centered() {
-        let text = Text::from("Hello, world!").centered();
-        assert_eq!(text.alignment, Some(Alignment::Center));
-    }
-
-    #[test]
-    fn right_aligned() {
-        let text = Text::from("Hello, world!").right_aligned();
-        assert_eq!(text.alignment, Some(Alignment::Right));
     }
 
     mod iterators {

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -50,6 +50,8 @@ use crate::prelude::*;
 /// - [`Text::height`] returns the height.
 /// - [`Text::patch_style`] patches the style of this `Text`, adding modifiers from the given style.
 /// - [`Text::reset_style`] resets the style of the `Text`.
+/// - [`Text::push_line`] adds a line to the text.
+/// - [`Text::push_span`] adds a span to the last line of the text.
 ///
 /// # Examples
 ///
@@ -443,12 +445,38 @@ impl<'a> Text<'a> {
     }
 
     /// Adds a line to the text.
-    pub fn push_line(&mut self, line: Line<'a>) {
-        self.lines.push(line);
+    ///
+    /// `line` can be any type that can be converted into a `Line`. For example, you can pass a
+    /// `&str`, a `String`, a `Span`, or a `Line`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::prelude::*;
+    /// let mut text = Text::from("Hello, world!");
+    /// text.push_line(Line::from("How are you?"));
+    /// text.push_line(Span::from("How are you?"));
+    /// text.push_line("How are you?");
+    /// ```
+    pub fn push_line<T: Into<Line<'a>>>(&mut self, line: T) {
+        self.lines.push(line.into());
     }
 
     /// Adds a span to the last line of the text.
-    pub fn push_span(&mut self, span: Span<'a>) {
+    ///
+    /// `span` can be any type that is convertible into a `Span`. For example, you can pass a
+    /// `&str`, a `String`, or a `Span`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::prelude::*;
+    /// let mut text = Text::from("Hello, world!");
+    /// text.push_span(Span::from("How are you?"));
+    /// text.push_span("How are you?");
+    /// ```
+    pub fn push_span<T: Into<Span<'a>>>(&mut self, span: T) {
+        let span = span.into();
         if let Some(last) = self.lines.last_mut() {
             last.push_span(span);
         } else {
@@ -888,11 +916,18 @@ mod tests {
 
     #[test]
     fn push_line() {
-        let mut text = Text::from("Hello, world!");
-        text.push_line(Line::from("How are you?"));
+        let mut text = Text::from("A");
+        text.push_line(Line::from("B"));
+        text.push_line(Span::from("C"));
+        text.push_line("D");
         assert_eq!(
             text.lines,
-            vec![Line::from("Hello, world!"), Line::from("How are you?")]
+            vec![
+                Line::raw("A"),
+                Line::raw("B"),
+                Line::raw("C"),
+                Line::raw("D")
+            ]
         );
     }
 
@@ -905,13 +940,15 @@ mod tests {
 
     #[test]
     fn push_span() {
-        let mut text = Text::from("Hello, world!");
-        text.push_span(Span::raw("How are you?"));
+        let mut text = Text::from("A");
+        text.push_span(Span::raw("B"));
+        text.push_span("C");
         assert_eq!(
             text.lines,
             vec![Line::from(vec![
-                Span::raw("Hello, world!"),
-                Span::raw("How are you?")
+                Span::raw("A"),
+                Span::raw("B"),
+                Span::raw("C")
             ])],
         );
     }


### PR DESCRIPTION
Adds the following methods to the `Text` and `Line` structs:
- Text::push_line
- Text::push_span
- Line::push_span

This allows for adding lines and spans to a text object without having
to call methods on the fields directly, which is usefult for incremental
construction of text objects.
