### PR TITLE
chore(docs): fix typos in crate documentation

### DIFF
--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -355,7 +355,7 @@ impl<W: WidgetRef> WidgetRef for Option<W> {
 /// to a stateful widget and render it later. It also allows you to render boxed stateful widgets.
 ///
 /// This trait was introduced in Ratatui 0.26.0 and is implemented for all the internal stateful
-/// widgets. Implemetors should prefer to implement this over the `StatefulWidget` trait and add an
+/// widgets. Implementors should prefer to implement this over the `StatefulWidget` trait and add an
 /// implementation of `StatefulWidget` that calls `StatefulWidgetRef::render_ref` where backwards
 /// compatibility is required.
 ///

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -2,8 +2,8 @@
 //!
 //!
 //!
-//! The [`Monthly`] widget will display a calendar for the monh provided in `display_date`. Days are
-//! styled using the default style unless:
+//! The [`Monthly`] widget will display a calendar for the month provided in `display_date`. Days
+//! are styled using the default style unless:
 //! * `show_surrounding` is set, then days not in the `display_date` month will use that style.
 //! * a style is returned by the [`DateStyler`] for the day
 //!

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -330,7 +330,7 @@ impl<'a> Dataset<'a> {
 
     /// Sets the data points of this dataset
     ///
-    /// Points will then either be rendered as scrattered points or with lines between them
+    /// Points will then either be rendered as scattered points or with lines between them
     /// depending on [`Dataset::graph_type`].
     ///
     /// Data consist in an array of `f64` tuples (`(f64, f64)`), the first element being X and the
@@ -493,7 +493,7 @@ pub struct Chart<'a> {
     style: Style,
     /// Constraints used to determine whether the legend should be shown or not
     hidden_legend_constraints: (Constraint, Constraint),
-    /// The position detnermine where the legenth is shown or hide regaurdless of
+    /// The position determine where the length is shown or hide regardless of
     /// `hidden_legend_constraints`
     legend_position: Option<LegendPosition>,
 }
@@ -636,7 +636,7 @@ impl<'a> Chart<'a> {
     /// let chart = Chart::new(vec![]).hidden_legend_constraints(constraints);
     /// ```
     ///
-    /// Always hide the legend. Note this can be accomplished more exclicitely by passing `None` to
+    /// Always hide the legend. Note this can be accomplished more explicitly by passing `None` to
     /// [`Chart::legend_position`].
     ///
     /// ```

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -643,7 +643,7 @@ impl<'a> List<'a> {
     /// - [`HighlightSpacing::Always`] will always allocate the spacing, regardless of whether an
     ///   item is selected or not. This means that the table will never change size, regardless of
     ///   if an item is selected or not.
-    /// - [`HighlightSpacing::WhenSelected`] will only allocate the spacing if an itemis selected.
+    /// - [`HighlightSpacing::WhenSelected`] will only allocate the spacing if an item is selected.
     ///   This means that the table will shift when an item is selected. This is the default setting
     ///   for backwards compatibility, but it is recommended to use `HighlightSpacing::Always` for a
     ///   better user experience.
@@ -2127,9 +2127,9 @@ mod tests {
         terminal.backend().assert_buffer(&expected);
     }
 
-    /// If there isnt enough room for the selected item and the requested padding the list can jump
-    /// up and down every frame if something isnt done about it. This code tests to make sure that
-    /// isnt currently happening
+    /// If there isn't enough room for the selected item and the requested padding the list can jump
+    /// up and down every frame if something isn't done about it. This code tests to make sure that
+    /// isn't currently happening
     #[test]
     fn test_padding_flicker() {
         let backend = backend::TestBackend::new(10, 5);


### PR DESCRIPTION
This PR fixes the typos found with [`cargo-spellcheck`](https://github.com/drahnr/cargo-spellcheck)

I originally wanted to integrate this tool into our CI but there are _a lot_ of false positives so I went ahead and fixed the appropriate ones with hand.