### PR TITLE
refactor(buffer): deprecate assert_buffer_eq! in favor of assert_eq!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,15 @@ cassowary = "0.3"
 compact_str = "0.7.1"
 crossterm = { version = "0.27", optional = true }
 document-features = { version = "0.2.7", optional = true }
-indoc = "2.0"
 itertools = "0.12"
 lru = "0.12.0"
 paste = "1.0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
 stability = "0.2.0"
 strum = { version = "0.26", features = ["derive"] }
-time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 termion = { version = "3.0", optional = true }
 termwiz = { version = "0.22.0", optional = true }
+time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-truncate = "1"
 unicode-width = "0.1"
@@ -56,6 +55,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 derive_builder = "0.20.0"
 fakeit = "1.1"
 font8x8 = "0.3.1"
+indoc = "2"
 palette = "0.7.3"
 pretty_assertions = "1.4.0"
 rand = "0.8.5"

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -286,10 +286,10 @@ fn draw_legend(f: &mut Frame, area: Rect) {
             "- Company B",
             Style::default().fg(Color::Yellow),
         )),
-        Line::from(vec![Span::styled(
+        Line::from(Span::styled(
             "- Company C",
             Style::default().fg(Color::White),
-        )]),
+        )),
     ];
 
     let block = Block::bordered().style(Style::default().fg(Color::White));

--- a/examples/demo2/big_text.rs
+++ b/examples/demo2/big_text.rs
@@ -276,8 +276,6 @@ fn render_glyph(glyph: [u8; 8], area: Rect, buf: &mut Buffer, pixel_size: PixelS
 
 #[cfg(test)]
 mod tests {
-    use ratatui::assert_buffer_eq;
-
     use super::*;
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -308,7 +306,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 80, 8));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             " ████     ██                     ███            ████      ██                    ",
             "██  ██                            ██             ██                             ",
             "███      ███    █████    ███ ██   ██     ████    ██      ███    █████    ████   ",
@@ -318,7 +316,7 @@ mod tests {
             " ████    ████   ██  ██      ██   ████    ████   ███████  ████   ██  ██   ████   ",
             "                        █████                                                   ",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -329,7 +327,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 70, 6));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "██████                                             █               ███",
             "█ ██ █                                            ██                ██",
             "  ██    ██ ███  ██  ██  █████    ████    ████    █████   ████       ██",
@@ -337,7 +335,7 @@ mod tests {
             "  ██     ██  ██ ██  ██  ██  ██  ██       █████    ██    ██████  ██  ██",
             "  ██     ██     ██  ██  ██  ██  ██  ██  ██  ██    ██ █  ██      ██  ██",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -348,7 +346,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 16));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "██   ██          ███       █      ██    ",
             "███ ███           ██      ██            ",
             "███████ ██  ██    ██     █████   ███    ",
@@ -366,7 +364,7 @@ mod tests {
             "███████  ████   ██  ██   ████   █████   ",
             "                                        ",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -378,18 +376,17 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 48, 8));
         big_text.render(buf.area, &mut buf);
-        let mut expected = Buffer::with_lines(vec![
-            " ████      █             ███               ███  ",
-            "██  ██    ██              ██                ██  ",
-            "███      █████  ██  ██    ██     ████       ██  ",
-            " ███      ██    ██  ██    ██    ██  ██   █████  ",
-            "   ███    ██    ██  ██    ██    ██████  ██  ██  ",
-            "██  ██    ██ █   █████    ██    ██      ██  ██  ",
-            " ████      ██       ██   ████    ████    ███ ██ ",
-            "                █████                           ",
+        let expected = Buffer::with_lines([
+            " ████      █             ███               ███  ".bold(),
+            "██  ██    ██              ██                ██  ".bold(),
+            "███      █████  ██  ██    ██     ████       ██  ".bold(),
+            " ███      ██    ██  ██    ██    ██  ██   █████  ".bold(),
+            "   ███    ██    ██  ██    ██    ██████  ██  ██  ".bold(),
+            "██  ██    ██ █   █████    ██    ██      ██  ██  ".bold(),
+            " ████      ██       ██   ████    ████    ███ ██ ".bold(),
+            "                █████                           ".bold(),
         ]);
-        expected.set_style(Rect::new(0, 0, 48, 8), Style::new().bold());
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -404,7 +401,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 24));
         big_text.render(buf.area, &mut buf);
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "██████             ███                  ",
             " ██  ██             ██                  ",
             " ██  ██  ████       ██                  ",
@@ -433,7 +430,7 @@ mod tests {
         expected.set_style(Rect::new(0, 0, 24, 8), Style::new().red());
         expected.set_style(Rect::new(0, 8, 40, 8), Style::new().green());
         expected.set_style(Rect::new(0, 16, 32, 8), Style::new().blue());
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -445,13 +442,13 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 80, 4));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "▄█▀▀█▄    ▀▀                     ▀██            ▀██▀      ▀▀                    ",
             "▀██▄     ▀██    ██▀▀█▄  ▄█▀▀▄█▀   ██    ▄█▀▀█▄   ██      ▀██    ██▀▀█▄  ▄█▀▀█▄  ",
             "▄▄ ▀██    ██    ██  ██  ▀█▄▄██    ██    ██▀▀▀▀   ██  ▄█   ██    ██  ██  ██▀▀▀▀  ",
             " ▀▀▀▀    ▀▀▀▀   ▀▀  ▀▀  ▄▄▄▄█▀   ▀▀▀▀    ▀▀▀▀   ▀▀▀▀▀▀▀  ▀▀▀▀   ▀▀  ▀▀   ▀▀▀▀   ",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -463,12 +460,12 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 70, 3));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "█▀██▀█                                            ▄█               ▀██",
             "  ██    ▀█▄█▀█▄ ██  ██  ██▀▀█▄  ▄█▀▀█▄   ▀▀▀█▄   ▀██▀▀  ▄█▀▀█▄   ▄▄▄██",
             "  ██     ██  ▀▀ ██  ██  ██  ██  ██  ▄▄  ▄█▀▀██    ██ ▄  ██▀▀▀▀  ██  ██",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -480,7 +477,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 8));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "██▄ ▄██          ▀██      ▄█      ▀▀    ",
             "███████ ██  ██    ██     ▀██▀▀   ▀██    ",
             "██ ▀ ██ ██  ██    ██      ██ ▄    ██    ",
@@ -490,7 +487,7 @@ mod tests {
             " ██  ▄█   ██    ██  ██  ██▀▀▀▀   ▀▀▀█▄  ",
             "▀▀▀▀▀▀▀  ▀▀▀▀   ▀▀  ▀▀   ▀▀▀▀   ▀▀▀▀▀   ",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -503,14 +500,13 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 48, 4));
         big_text.render(buf.area, &mut buf);
-        let mut expected = Buffer::with_lines(vec![
-            "▄█▀▀█▄    ▄█             ▀██               ▀██  ",
-            "▀██▄     ▀██▀▀  ██  ██    ██    ▄█▀▀█▄   ▄▄▄██  ",
-            "▄▄ ▀██    ██ ▄  ▀█▄▄██    ██    ██▀▀▀▀  ██  ██  ",
-            " ▀▀▀▀      ▀▀   ▄▄▄▄█▀   ▀▀▀▀    ▀▀▀▀    ▀▀▀ ▀▀ ",
+        let expected = Buffer::with_lines([
+            "▄█▀▀█▄    ▄█             ▀██               ▀██  ".bold(),
+            "▀██▄     ▀██▀▀  ██  ██    ██    ▄█▀▀█▄   ▄▄▄██  ".bold(),
+            "▄▄ ▀██    ██ ▄  ▀█▄▄██    ██    ██▀▀▀▀  ██  ██  ".bold(),
+            " ▀▀▀▀      ▀▀   ▄▄▄▄█▀   ▀▀▀▀    ▀▀▀▀    ▀▀▀ ▀▀ ".bold(),
         ]);
-        expected.set_style(Rect::new(0, 0, 48, 4), Style::new().bold());
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -526,7 +522,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 12));
         big_text.render(buf.area, &mut buf);
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "▀██▀▀█▄            ▀██                  ",
             " ██▄▄█▀ ▄█▀▀█▄   ▄▄▄██                  ",
             " ██ ▀█▄ ██▀▀▀▀  ██  ██                  ",
@@ -543,7 +539,7 @@ mod tests {
         expected.set_style(Rect::new(0, 0, 24, 4), Style::new().red());
         expected.set_style(Rect::new(0, 4, 40, 4), Style::new().green());
         expected.set_style(Rect::new(0, 8, 32, 4), Style::new().blue());
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -555,7 +551,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 8));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "▐█▌  █          ▐█      ██   █          ",
             "█ █              █      ▐▌              ",
             "█▌  ▐█  ██▌ ▐█▐▌ █  ▐█▌ ▐▌  ▐█  ██▌ ▐█▌ ",
@@ -565,7 +561,7 @@ mod tests {
             "▐█▌ ▐█▌ █ █   █ ▐█▌ ▐█▌ ███▌▐█▌ █ █ ▐█▌ ",
             "            ██▌                         ",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -577,7 +573,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 35, 6));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "███                      ▐       ▐█",
             "▌█▐                      █        █",
             " █  █▐█ █ █ ██▌ ▐█▌ ▐█▌ ▐██ ▐█▌   █",
@@ -585,7 +581,7 @@ mod tests {
             " █  ▐▌▐▌█ █ █ █ █   ▐██  █  ███ █ █",
             " █  ▐▌  █ █ █ █ █ █ █ █  █▐ █   █ █",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -597,7 +593,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 20, 16));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "█ ▐▌    ▐█   ▐   █  ",
             "█▌█▌     █   █      ",
             "███▌█ █  █  ▐██ ▐█  ",
@@ -615,7 +611,7 @@ mod tests {
             "███▌▐█▌ █ █ ▐█▌ ██▌ ",
             "                    ",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -628,18 +624,17 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 24, 8));
         big_text.render(buf.area, &mut buf);
-        let mut expected = Buffer::with_lines(vec![
-            "▐█▌  ▐      ▐█       ▐█ ",
-            "█ █  █       █        █ ",
-            "█▌  ▐██ █ █  █  ▐█▌   █ ",
-            "▐█   █  █ █  █  █ █ ▐██ ",
-            " ▐█  █  █ █  █  ███ █ █ ",
-            "█ █  █▐ ▐██  █  █   █ █ ",
-            "▐█▌  ▐▌   █ ▐█▌ ▐█▌ ▐█▐▌",
-            "        ██▌             ",
+        let expected = Buffer::with_lines([
+            "▐█▌  ▐      ▐█       ▐█ ".bold(),
+            "█ █  █       █        █ ".bold(),
+            "█▌  ▐██ █ █  █  ▐█▌   █ ".bold(),
+            "▐█   █  █ █  █  █ █ ▐██ ".bold(),
+            " ▐█  █  █ █  █  ███ █ █ ".bold(),
+            "█ █  █▐ ▐██  █  █   █ █ ".bold(),
+            "▐█▌  ▐▌   █ ▐█▌ ▐█▌ ▐█▐▌".bold(),
+            "        ██▌             ".bold(),
         ]);
-        expected.set_style(Rect::new(0, 0, 24, 8), Style::new().bold());
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -655,7 +650,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 20, 24));
         big_text.render(buf.area, &mut buf);
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "███      ▐█         ",
             "▐▌▐▌      █         ",
             "▐▌▐▌▐█▌   █         ",
@@ -684,7 +679,7 @@ mod tests {
         expected.set_style(Rect::new(0, 0, 12, 8), Style::new().red());
         expected.set_style(Rect::new(0, 8, 20, 8), Style::new().green());
         expected.set_style(Rect::new(0, 16, 16, 8), Style::new().blue());
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -717,13 +712,13 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 40, 4));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "▟▀▙  ▀          ▝█      ▜▛   ▀          ",
             "▜▙  ▝█  █▀▙ ▟▀▟▘ █  ▟▀▙ ▐▌  ▝█  █▀▙ ▟▀▙ ",
             "▄▝█  █  █ █ ▜▄█  █  █▀▀ ▐▌▗▌ █  █ █ █▀▀ ",
             "▝▀▘ ▝▀▘ ▀ ▀ ▄▄▛ ▝▀▘ ▝▀▘ ▀▀▀▘▝▀▘ ▀ ▀ ▝▀▘ ",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -735,12 +730,12 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 35, 3));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "▛█▜                      ▟       ▝█",
             " █  ▜▟▜▖█ █ █▀▙ ▟▀▙ ▝▀▙ ▝█▀ ▟▀▙ ▗▄█",
             " █  ▐▌▝▘█ █ █ █ █ ▄ ▟▀█  █▗ █▀▀ █ █",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -752,7 +747,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 20, 8));
         big_text.render(buf.area, &mut buf);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "█▖▟▌    ▝█   ▟   ▀  ",
             "███▌█ █  █  ▝█▀ ▝█  ",
             "█▝▐▌█ █  █   █▗  █  ",
@@ -762,7 +757,7 @@ mod tests {
             "▐▌▗▌ █  █ █ █▀▀ ▝▀▙ ",
             "▀▀▀▘▝▀▘ ▀ ▀ ▝▀▘ ▀▀▘ ",
         ]);
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -775,14 +770,13 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 24, 4));
         big_text.render(buf.area, &mut buf);
-        let mut expected = Buffer::with_lines(vec![
-            "▟▀▙  ▟      ▝█       ▝█ ",
-            "▜▙  ▝█▀ █ █  █  ▟▀▙ ▗▄█ ",
-            "▄▝█  █▗ ▜▄█  █  █▀▀ █ █ ",
-            "▝▀▘  ▝▘ ▄▄▛ ▝▀▘ ▝▀▘ ▝▀▝▘",
+        let expected = Buffer::with_lines([
+            "▟▀▙  ▟      ▝█       ▝█ ".bold(),
+            "▜▙  ▝█▀ █ █  █  ▟▀▙ ▗▄█ ".bold(),
+            "▄▝█  █▗ ▜▄█  █  █▀▀ █ █ ".bold(),
+            "▝▀▘  ▝▘ ▄▄▛ ▝▀▘ ▝▀▘ ▝▀▝▘".bold(),
         ]);
-        expected.set_style(Rect::new(0, 0, 24, 4), Style::new().bold());
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 
@@ -798,7 +792,7 @@ mod tests {
             .build()?;
         let mut buf = Buffer::empty(Rect::new(0, 0, 20, 12));
         big_text.render(buf.area, &mut buf);
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "▜▛▜▖     ▝█         ",
             "▐▙▟▘▟▀▙ ▗▄█         ",
             "▐▌▜▖█▀▀ █ █         ",
@@ -815,7 +809,7 @@ mod tests {
         expected.set_style(Rect::new(0, 0, 12, 4), Style::new().red());
         expected.set_style(Rect::new(0, 4, 20, 4), Style::new().green());
         expected.set_style(Rect::new(0, 8, 16, 4), Style::new().blue());
-        assert_buffer_eq!(buf, expected);
+        assert_eq!(buf, expected);
         Ok(())
     }
 }

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -9,7 +9,6 @@ use std::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
-    assert_buffer_eq,
     backend::{Backend, ClearType, WindowSize},
     buffer::{Buffer, Cell},
     layout::{Rect, Size},
@@ -30,7 +29,7 @@ use crate::{
 ///
 /// let mut backend = TestBackend::new(10, 2);
 /// backend.clear()?;
-/// backend.assert_buffer(&Buffer::with_lines(vec!["          "; 2]));
+/// backend.assert_buffer_lines(["          "; 2]);
 /// # std::io::Result::Ok(())
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -97,11 +96,33 @@ impl TestBackend {
     }
 
     /// Asserts that the `TestBackend`'s buffer is equal to the expected buffer.
-    /// If the buffers are not equal, a panic occurs with a detailed error message
-    /// showing the differences between the expected and actual buffers.
+    ///
+    /// This is a shortcut for `assert_eq!(self.buffer(), &expected)`.
+    ///
+    /// # Panics
+    /// When they are not equal, a panic occurs with a detailed error message showing the
+    /// differences between the expected and actual buffers.
+    #[allow(deprecated)]
     #[track_caller]
     pub fn assert_buffer(&self, expected: &Buffer) {
-        assert_buffer_eq!(&self.buffer, expected);
+        // TODO: use assert_eq!()
+        crate::assert_buffer_eq!(&self.buffer, expected);
+    }
+
+    /// Asserts that the `TestBackend`'s buffer is equal to the expected lines.
+    ///
+    /// This is a shortcut for `assert_eq!(self.buffer(), &Buffer::with_lines(expected))`.
+    ///
+    /// # Panics
+    /// When they are not equal, a panic occurs with a detailed error message showing the
+    /// differences between the expected and actual buffers.
+    #[track_caller]
+    pub fn assert_buffer_lines<'line, Lines>(&self, expected: Lines)
+    where
+        Lines: IntoIterator,
+        Lines::Item: Into<crate::text::Line<'line>>,
+    {
+        self.assert_buffer(&Buffer::with_lines(expected));
     }
 }
 
@@ -246,7 +267,7 @@ mod tests {
             TestBackend {
                 width: 10,
                 height: 2,
-                buffer: Buffer::with_lines(vec!["          "; 2]),
+                buffer: Buffer::with_lines(["          "; 2]),
                 cursor: false,
                 pos: (0, 0),
             }
@@ -254,14 +275,14 @@ mod tests {
     }
     #[test]
     fn test_buffer_view() {
-        let buffer = Buffer::with_lines(vec!["aaaa"; 2]);
+        let buffer = Buffer::with_lines(["aaaa"; 2]);
         assert_eq!(buffer_view(&buffer), "\"aaaa\"\n\"aaaa\"\n");
     }
 
     #[test]
     fn buffer_view_with_overwrites() {
         let multi_byte_char = "👨‍👩‍👧‍👦"; // renders 8 wide
-        let buffer = Buffer::with_lines(vec![multi_byte_char]);
+        let buffer = Buffer::with_lines([multi_byte_char]);
         assert_eq!(
             buffer_view(&buffer),
             format!(
@@ -274,29 +295,27 @@ mod tests {
     #[test]
     fn buffer() {
         let backend = TestBackend::new(10, 2);
-        assert_eq!(backend.buffer(), &Buffer::with_lines(vec!["          "; 2]));
+        backend.assert_buffer_lines(["          "; 2]);
     }
 
     #[test]
     fn resize() {
         let mut backend = TestBackend::new(10, 2);
         backend.resize(5, 5);
-        assert_eq!(backend.buffer(), &Buffer::with_lines(vec!["     "; 5]));
+        backend.assert_buffer_lines(["     "; 5]);
     }
 
     #[test]
     fn assert_buffer() {
         let backend = TestBackend::new(10, 2);
-        let buffer = Buffer::with_lines(vec!["          "; 2]);
-        backend.assert_buffer(&buffer);
+        backend.assert_buffer_lines(["          "; 2]);
     }
 
     #[test]
     #[should_panic = "buffer contents not equal"]
     fn assert_buffer_panics() {
         let backend = TestBackend::new(10, 2);
-        let buffer = Buffer::with_lines(vec!["aaaaaaaaaa"; 2]);
-        backend.assert_buffer(&buffer);
+        backend.assert_buffer_lines(["aaaaaaaaaa"; 2]);
     }
 
     #[test]
@@ -312,7 +331,7 @@ mod tests {
         cell.set_symbol("a");
         backend.draw([(0, 0, &cell)].into_iter()).unwrap();
         backend.draw([(0, 1, &cell)].into_iter()).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec!["a         "; 2]));
+        backend.assert_buffer_lines(["a         "; 2]);
     }
 
     #[test]
@@ -344,24 +363,19 @@ mod tests {
 
     #[test]
     fn clear() {
-        let mut backend = TestBackend::new(10, 4);
+        let mut backend = TestBackend::new(4, 2);
         let mut cell = Cell::default();
         cell.set_symbol("a");
         backend.draw([(0, 0, &cell)].into_iter()).unwrap();
         backend.draw([(0, 1, &cell)].into_iter()).unwrap();
         backend.clear().unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec![
-            "          ",
-            "          ",
-            "          ",
-            "          ",
-        ]));
+        backend.assert_buffer_lines(["    ", "    "]);
     }
 
     #[test]
     fn clear_region_all() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
@@ -370,19 +384,19 @@ mod tests {
         ]);
 
         backend.clear_region(ClearType::All).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "          ",
             "          ",
             "          ",
             "          ",
             "          ",
-        ]));
+        ]);
     }
 
     #[test]
     fn clear_region_after_cursor() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
@@ -392,19 +406,19 @@ mod tests {
 
         backend.set_cursor(3, 2).unwrap();
         backend.clear_region(ClearType::AfterCursor).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaa      ",
             "          ",
             "          ",
-        ]));
+        ]);
     }
 
     #[test]
     fn clear_region_before_cursor() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
@@ -414,19 +428,19 @@ mod tests {
 
         backend.set_cursor(5, 3).unwrap();
         backend.clear_region(ClearType::BeforeCursor).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "          ",
             "          ",
             "          ",
             "     aaaaa",
             "aaaaaaaaaa",
-        ]));
+        ]);
     }
 
     #[test]
     fn clear_region_current_line() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
@@ -436,19 +450,19 @@ mod tests {
 
         backend.set_cursor(3, 1).unwrap();
         backend.clear_region(ClearType::CurrentLine).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "aaaaaaaaaa",
             "          ",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
-        ]));
+        ]);
     }
 
     #[test]
     fn clear_region_until_new_line() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
@@ -458,19 +472,19 @@ mod tests {
 
         backend.set_cursor(3, 0).unwrap();
         backend.clear_region(ClearType::UntilNewLine).unwrap();
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "aaa       ",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
             "aaaaaaaaaa",
-        ]));
+        ]);
     }
 
     #[test]
     fn append_lines_not_at_last_line() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
@@ -496,19 +510,19 @@ mod tests {
         assert_eq!(backend.get_cursor().unwrap(), (4, 4));
 
         // As such the buffer should remain unchanged
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
             "dddddddddd",
             "eeeeeeeeee",
-        ]));
+        ]);
     }
 
     #[test]
     fn append_lines_at_last_line() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
@@ -522,7 +536,7 @@ mod tests {
 
         backend.append_lines(1).unwrap();
 
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "bbbbbbbbbb",
             "cccccccccc",
             "dddddddddd",
@@ -538,7 +552,7 @@ mod tests {
     #[test]
     fn append_multiple_lines_not_at_last_line() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
@@ -555,19 +569,19 @@ mod tests {
         assert_eq!(backend.get_cursor().unwrap(), (1, 4));
 
         // As such the buffer should remain unchanged
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
             "dddddddddd",
             "eeeeeeeeee",
-        ]));
+        ]);
     }
 
     #[test]
     fn append_multiple_lines_past_last_line() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
@@ -580,19 +594,19 @@ mod tests {
         backend.append_lines(3).unwrap();
         assert_eq!(backend.get_cursor().unwrap(), (1, 4));
 
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "cccccccccc",
             "dddddddddd",
             "eeeeeeeeee",
             "          ",
             "          ",
-        ]));
+        ]);
     }
 
     #[test]
     fn append_multiple_lines_where_cursor_at_end_appends_height_lines() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
@@ -605,19 +619,19 @@ mod tests {
         backend.append_lines(5).unwrap();
         assert_eq!(backend.get_cursor().unwrap(), (1, 4));
 
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "          ",
             "          ",
             "          ",
             "          ",
             "          ",
-        ]));
+        ]);
     }
 
     #[test]
     fn append_multiple_lines_where_cursor_appends_height_lines() {
         let mut backend = TestBackend::new(10, 5);
-        backend.buffer = Buffer::with_lines(vec![
+        backend.buffer = Buffer::with_lines([
             "aaaaaaaaaa",
             "bbbbbbbbbb",
             "cccccccccc",
@@ -630,13 +644,13 @@ mod tests {
         backend.append_lines(5).unwrap();
         assert_eq!(backend.get_cursor().unwrap(), (1, 4));
 
-        backend.assert_buffer(&Buffer::with_lines(vec![
+        backend.assert_buffer_lines([
             "bbbbbbbbbb",
             "cccccccccc",
             "dddddddddd",
             "eeeeeeeeee",
             "          ",
-        ]));
+        ]);
     }
 
     #[test]

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -452,7 +452,6 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use super::*;
-    use crate::assert_buffer_eq;
 
     fn cell(s: &str) -> Cell {
         let mut cell = Cell::default();
@@ -580,27 +579,27 @@ mod tests {
 
         // Zero-width
         buffer.set_stringn(0, 0, "aaa", 0, Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["     "]));
+        assert_eq!(buffer, Buffer::with_lines(["     "]));
 
         buffer.set_string(0, 0, "aaa", Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["aaa  "]));
+        assert_eq!(buffer, Buffer::with_lines(["aaa  "]));
 
         // Width limit:
         buffer.set_stringn(0, 0, "bbbbbbbbbbbbbb", 4, Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["bbbb "]));
+        assert_eq!(buffer, Buffer::with_lines(["bbbb "]));
 
         buffer.set_string(0, 0, "12345", Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["12345"]));
+        assert_eq!(buffer, Buffer::with_lines(["12345"]));
 
         // Width truncation:
         buffer.set_string(0, 0, "123456", Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["12345"]));
+        assert_eq!(buffer, Buffer::with_lines(["12345"]));
 
         // multi-line
         buffer = Buffer::empty(Rect::new(0, 0, 5, 2));
         buffer.set_string(0, 0, "12345", Style::default());
         buffer.set_string(0, 1, "67890", Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["12345", "67890"]));
+        assert_eq!(buffer, Buffer::with_lines(["12345", "67890"]));
     }
 
     #[test]
@@ -611,7 +610,7 @@ mod tests {
         // multi-width overwrite
         buffer.set_string(0, 0, "aaaaa", Style::default());
         buffer.set_string(0, 0, "称号", Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["称号a"]));
+        assert_eq!(buffer, Buffer::with_lines(["称号a"]));
     }
 
     #[test]
@@ -622,12 +621,12 @@ mod tests {
         // Leading grapheme with zero width
         let s = "\u{1}a";
         buffer.set_stringn(0, 0, s, 1, Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["a"]));
+        assert_eq!(buffer, Buffer::with_lines(["a"]));
 
         // Trailing grapheme with zero with
         let s = "a\u{1}";
         buffer.set_stringn(0, 0, s, 1, Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["a"]));
+        assert_eq!(buffer, Buffer::with_lines(["a"]));
     }
 
     #[test]
@@ -635,11 +634,11 @@ mod tests {
         let area = Rect::new(0, 0, 5, 1);
         let mut buffer = Buffer::empty(area);
         buffer.set_string(0, 0, "コン", Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["コン "]));
+        assert_eq!(buffer, Buffer::with_lines(["コン "]));
 
         // Only 1 space left.
         buffer.set_string(0, 0, "コンピ", Style::default());
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["コン "]));
+        assert_eq!(buffer, Buffer::with_lines(["コン "]));
     }
 
     #[fixture]
@@ -664,7 +663,7 @@ mod tests {
         // set_line
         let mut expected_buffer = Buffer::empty(small_one_line_buffer.area);
         expected_buffer.set_string(0, 0, expected, Style::default());
-        assert_buffer_eq!(small_one_line_buffer, expected_buffer);
+        assert_eq!(small_one_line_buffer, expected_buffer);
     }
 
     #[rstest]
@@ -705,28 +704,39 @@ mod tests {
 
     #[test]
     fn set_style() {
-        let mut buffer = Buffer::with_lines(vec!["aaaaa", "bbbbb", "ccccc"]);
+        let mut buffer = Buffer::with_lines(["aaaaa", "bbbbb", "ccccc"]);
         buffer.set_style(Rect::new(0, 1, 5, 1), Style::new().red());
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec!["aaaaa".into(), "bbbbb".red(), "ccccc".into(),])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "aaaaa".into(),
+            "bbbbb".red(),
+            "ccccc".into(),
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn set_style_does_not_panic_when_out_of_area() {
-        let mut buffer = Buffer::with_lines(vec!["aaaaa", "bbbbb", "ccccc"]);
+        let mut buffer = Buffer::with_lines(["aaaaa", "bbbbb", "ccccc"]);
         buffer.set_style(Rect::new(0, 1, 10, 3), Style::new().red());
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec!["aaaaa".into(), "bbbbb".red(), "ccccc".red(),])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "aaaaa".into(),
+            "bbbbb".red(),
+            "ccccc".red(),
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn with_lines() {
-        let buffer =
-            Buffer::with_lines(vec!["┌────────┐", "│コンピュ│", "│ーa 上で│", "└────────┘"]);
+        #[rustfmt::skip]
+        let buffer = Buffer::with_lines([
+            "┌────────┐",
+            "│コンピュ│",
+            "│ーa 上で│",
+            "└────────┘",
+        ]);
         assert_eq!(buffer.area.x, 0);
         assert_eq!(buffer.area.y, 0);
         assert_eq!(buffer.area.width, 10);
@@ -762,14 +772,14 @@ mod tests {
 
     #[test]
     fn diff_single_width() {
-        let prev = Buffer::with_lines(vec![
+        let prev = Buffer::with_lines([
             "          ",
             "┌Title─┐  ",
             "│      │  ",
             "│      │  ",
             "└──────┘  ",
         ]);
-        let next = Buffer::with_lines(vec![
+        let next = Buffer::with_lines([
             "          ",
             "┌TITLE─┐  ",
             "│      │  ",
@@ -791,11 +801,11 @@ mod tests {
     #[test]
     #[rustfmt::skip]
     fn diff_multi_width() {
-        let prev = Buffer::with_lines(vec![
+        let prev = Buffer::with_lines([
             "┌Title─┐  ",
             "└──────┘  ",
         ]);
-        let next = Buffer::with_lines(vec![
+        let next = Buffer::with_lines([
             "┌称号──┐  ",
             "└──────┘  ",
         ]);
@@ -814,8 +824,8 @@ mod tests {
 
     #[test]
     fn diff_multi_width_offset() {
-        let prev = Buffer::with_lines(vec!["┌称号──┐"]);
-        let next = Buffer::with_lines(vec!["┌─称号─┐"]);
+        let prev = Buffer::with_lines(["┌称号──┐"]);
+        let next = Buffer::with_lines(["┌─称号─┐"]);
 
         let diff = prev.diff(&next);
         assert_eq!(
@@ -826,8 +836,8 @@ mod tests {
 
     #[test]
     fn diff_skip() {
-        let prev = Buffer::with_lines(vec!["123"]);
-        let mut next = Buffer::with_lines(vec!["456"]);
+        let prev = Buffer::with_lines(["123"]);
+        let mut next = Buffer::with_lines(["456"]);
         for i in 1..3 {
             next.content[i].set_skip(true);
         }
@@ -857,7 +867,7 @@ mod tests {
             Cell::default().set_symbol("2"),
         );
         one.merge(&two);
-        assert_buffer_eq!(one, Buffer::with_lines(vec!["11", "11", "22", "22"]));
+        assert_eq!(one, Buffer::with_lines(["11", "11", "22", "22"]));
     }
 
     #[test]
@@ -881,10 +891,7 @@ mod tests {
             Cell::default().set_symbol("2"),
         );
         one.merge(&two);
-        assert_buffer_eq!(
-            one,
-            Buffer::with_lines(vec!["22  ", "22  ", "  11", "  11"])
-        );
+        assert_eq!(one, Buffer::with_lines(["22  ", "22  ", "  11", "  11"]));
     }
 
     #[test]
@@ -908,14 +915,14 @@ mod tests {
             Cell::default().set_symbol("2"),
         );
         one.merge(&two);
-        let mut merged = Buffer::with_lines(vec!["222 ", "222 ", "2221", "2221"]);
+        let mut merged = Buffer::with_lines(["222 ", "222 ", "2221", "2221"]);
         merged.area = Rect {
             x: 1,
             y: 1,
             width: 4,
             height: 4,
         };
-        assert_buffer_eq!(one, merged);
+        assert_eq!(one, merged);
     }
 
     #[test]
@@ -974,6 +981,6 @@ mod tests {
         let mut buf = Buffer::empty(Rect::new(0, 0, 3, 2));
         buf.set_string(0, 0, "foo", Style::new().red());
         buf.set_string(0, 1, "bar", Style::new().blue());
-        assert_eq!(buf, Buffer::with_lines(vec!["foo".red(), "bar".blue()]));
+        assert_eq!(buf, Buffer::with_lines(["foo".red(), "bar".blue()]));
     }
 }

--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -1334,7 +1334,6 @@ mod tests {
         use rstest::rstest;
 
         use crate::{
-            assert_buffer_eq,
             layout::flex::Flex,
             prelude::{Constraint::*, *},
             widgets::Paragraph,
@@ -1361,8 +1360,7 @@ mod tests {
                 let s = c.to_string().repeat(area.width as usize);
                 Paragraph::new(s).render(layout[i], &mut buffer);
             }
-            let expected = Buffer::with_lines(vec![expected]);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, Buffer::with_lines([expected]));
         }
 
         #[rstest]

--- a/src/style.rs
+++ b/src/style.rs
@@ -550,6 +550,8 @@ impl From<(Color, Color, Modifier, Modifier)> for Style {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -606,26 +608,21 @@ mod tests {
         }
     }
 
-    #[test]
-    fn modifier_debug() {
-        assert_eq!(format!("{:?}", Modifier::empty()), "NONE");
-        assert_eq!(format!("{:?}", Modifier::BOLD), "BOLD");
-        assert_eq!(format!("{:?}", Modifier::DIM), "DIM");
-        assert_eq!(format!("{:?}", Modifier::ITALIC), "ITALIC");
-        assert_eq!(format!("{:?}", Modifier::UNDERLINED), "UNDERLINED");
-        assert_eq!(format!("{:?}", Modifier::SLOW_BLINK), "SLOW_BLINK");
-        assert_eq!(format!("{:?}", Modifier::RAPID_BLINK), "RAPID_BLINK");
-        assert_eq!(format!("{:?}", Modifier::REVERSED), "REVERSED");
-        assert_eq!(format!("{:?}", Modifier::HIDDEN), "HIDDEN");
-        assert_eq!(format!("{:?}", Modifier::CROSSED_OUT), "CROSSED_OUT");
-        assert_eq!(
-            format!("{:?}", Modifier::BOLD | Modifier::DIM),
-            "BOLD | DIM"
-        );
-        assert_eq!(
-            format!("{:?}", Modifier::all()),
-            "BOLD | DIM | ITALIC | UNDERLINED | SLOW_BLINK | RAPID_BLINK | REVERSED | HIDDEN | CROSSED_OUT"
-        );
+    #[rstest]
+    #[case(Modifier::empty(), "NONE")]
+    #[case(Modifier::BOLD, "BOLD")]
+    #[case(Modifier::DIM, "DIM")]
+    #[case(Modifier::ITALIC, "ITALIC")]
+    #[case(Modifier::UNDERLINED, "UNDERLINED")]
+    #[case(Modifier::SLOW_BLINK, "SLOW_BLINK")]
+    #[case(Modifier::RAPID_BLINK, "RAPID_BLINK")]
+    #[case(Modifier::REVERSED, "REVERSED")]
+    #[case(Modifier::HIDDEN, "HIDDEN")]
+    #[case(Modifier::CROSSED_OUT, "CROSSED_OUT")]
+    #[case(Modifier::BOLD | Modifier::DIM, "BOLD | DIM")]
+    #[case(Modifier::all(), "BOLD | DIM | ITALIC | UNDERLINED | SLOW_BLINK | RAPID_BLINK | REVERSED | HIDDEN | CROSSED_OUT")]
+    fn modifier_debug(#[case] modifier: Modifier, #[case] expected: &str) {
+        assert_eq!(format!("{modifier:?}"), expected);
     }
 
     #[test]

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -953,7 +953,7 @@ mod tests {
         use unicode_width::UnicodeWidthStr;
 
         use super::*;
-        use crate::{assert_buffer_eq, buffer::Cell};
+        use crate::buffer::Cell;
 
         const BLUE: Style = Style::new().fg(Color::Blue);
         const GREEN: Style = Style::new().fg(Color::Green);
@@ -972,37 +972,36 @@ mod tests {
         fn render() {
             let mut buf = Buffer::empty(Rect::new(0, 0, 15, 1));
             hello_world().render(Rect::new(0, 0, 15, 1), &mut buf);
-            let mut expected = Buffer::with_lines(vec!["Hello world!   "]);
+            let mut expected = Buffer::with_lines(["Hello world!   "]);
             expected.set_style(Rect::new(0, 0, 15, 1), ITALIC);
             expected.set_style(Rect::new(0, 0, 6, 1), BLUE);
             expected.set_style(Rect::new(6, 0, 6, 1), GREEN);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[rstest]
         fn render_out_of_bounds(hello_world: Line<'static>, mut small_buf: Buffer) {
             let out_of_bounds = Rect::new(20, 20, 10, 1);
             hello_world.render(out_of_bounds, &mut small_buf);
-            assert_buffer_eq!(small_buf, Buffer::empty(small_buf.area));
+            assert_eq!(small_buf, Buffer::empty(small_buf.area));
         }
 
         #[test]
         fn render_only_styles_line_area() {
             let mut buf = Buffer::empty(Rect::new(0, 0, 20, 1));
             hello_world().render(Rect::new(0, 0, 15, 1), &mut buf);
-            let mut expected = Buffer::with_lines(vec!["Hello world!        "]);
+            let mut expected = Buffer::with_lines(["Hello world!        "]);
             expected.set_style(Rect::new(0, 0, 15, 1), ITALIC);
             expected.set_style(Rect::new(0, 0, 6, 1), BLUE);
             expected.set_style(Rect::new(6, 0, 6, 1), GREEN);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
         fn render_truncates() {
             let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
             Line::from("Hello world!").render(Rect::new(0, 0, 5, 1), &mut buf);
-            let expected = Buffer::with_lines(vec!["Hello     "]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, Buffer::with_lines(["Hello     "]));
         }
 
         #[test]
@@ -1010,11 +1009,11 @@ mod tests {
             let line = hello_world().alignment(Alignment::Center);
             let mut buf = Buffer::empty(Rect::new(0, 0, 15, 1));
             line.render(Rect::new(0, 0, 15, 1), &mut buf);
-            let mut expected = Buffer::with_lines(vec![" Hello world!  "]);
+            let mut expected = Buffer::with_lines([" Hello world!  "]);
             expected.set_style(Rect::new(0, 0, 15, 1), ITALIC);
             expected.set_style(Rect::new(1, 0, 6, 1), BLUE);
             expected.set_style(Rect::new(7, 0, 6, 1), GREEN);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1022,11 +1021,11 @@ mod tests {
             let line = hello_world().alignment(Alignment::Right);
             let mut buf = Buffer::empty(Rect::new(0, 0, 15, 1));
             line.render(Rect::new(0, 0, 15, 1), &mut buf);
-            let mut expected = Buffer::with_lines(vec!["   Hello world!"]);
+            let mut expected = Buffer::with_lines(["   Hello world!"]);
             expected.set_style(Rect::new(0, 0, 15, 1), ITALIC);
             expected.set_style(Rect::new(3, 0, 6, 1), BLUE);
             expected.set_style(Rect::new(9, 0, 6, 1), GREEN);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1035,7 +1034,7 @@ mod tests {
             Line::from("Hello world")
                 .left_aligned()
                 .render(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines(vec!["Hello"]));
+            assert_eq!(buf, Buffer::with_lines(["Hello"]));
         }
 
         #[test]
@@ -1044,7 +1043,7 @@ mod tests {
             Line::from("Hello world")
                 .right_aligned()
                 .render(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines(vec!["world"]));
+            assert_eq!(buf, Buffer::with_lines(["world"]));
         }
 
         #[test]
@@ -1053,7 +1052,7 @@ mod tests {
             Line::from("Hello world")
                 .centered()
                 .render(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines(["lo wo"]));
+            assert_eq!(buf, Buffer::with_lines(["lo wo"]));
         }
 
         /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
@@ -1065,7 +1064,7 @@ mod tests {
             );
             let mut buf = Buffer::empty(Rect::new(0, 0, 83, 1));
             line.render_ref(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines([
+            assert_eq!(buf, Buffer::with_lines([
                 "🦀 RFC8628 OAuth 2.0 Device Authorization GrantでCLIからGithubのaccess tokenを取得 "
             ]));
         }
@@ -1102,7 +1101,7 @@ mod tests {
             let line = Line::from("1234🦀7890").alignment(alignment);
             let mut buf = Buffer::empty(Rect::new(0, 0, buf_width, 1));
             line.render_ref(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines([expected]));
+            assert_eq!(buf, Buffer::with_lines([expected]));
         }
 
         /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
@@ -1155,7 +1154,7 @@ mod tests {
             let line = Line::from(value).centered();
             let mut buf = Buffer::empty(Rect::new(0, 0, buf_width, 1));
             line.render_ref(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines([expected]));
+            assert_eq!(buf, Buffer::with_lines([expected]));
         }
 
         /// Ensures the rendering also works away from the 0x0 position.
@@ -1173,7 +1172,7 @@ mod tests {
             let mut buf = Buffer::filled(Rect::new(0, 0, 10, 1), Cell::default().set_symbol("X"));
             let area = Rect::new(2, 0, 6, 1);
             line.render_ref(area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines([expected]));
+            assert_eq!(buf, Buffer::with_lines([expected]));
         }
 
         /// When two spans are rendered after each other the first needs to be padded in accordance
@@ -1191,7 +1190,7 @@ mod tests {
             // Fill buffer with stuff to ensure the output is indeed padded
             let mut buf = Buffer::filled(area, Cell::default().set_symbol("X"));
             line.render_ref(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines([expected]));
+            assert_eq!(buf, Buffer::with_lines([expected]));
         }
 
         /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
@@ -1222,7 +1221,7 @@ mod tests {
             let line = Line::from("🇺🇸1234");
             let mut buf = Buffer::empty(Rect::new(0, 0, buf_width, 1));
             line.render_ref(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines([expected]));
+            assert_eq!(buf, Buffer::with_lines([expected]));
         }
 
         // Buffer width is `u16`. A line can be longer.
@@ -1246,7 +1245,7 @@ mod tests {
 
             let mut buf = Buffer::empty(Rect::new(0, 0, 32, 1));
             line.render_ref(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines([expected]));
+            assert_eq!(buf, Buffer::with_lines([expected]));
         }
 
         // Buffer width is `u16`. A single span inside a line can be longer.
@@ -1270,7 +1269,7 @@ mod tests {
 
             let mut buf = Buffer::empty(Rect::new(0, 0, 32, 1));
             line.render_ref(buf.area, &mut buf);
-            assert_buffer_eq!(buf, Buffer::with_lines([expected]));
+            assert_eq!(buf, Buffer::with_lines([expected]));
         }
     }
 

--- a/src/text/masked.rs
+++ b/src/text/masked.rs
@@ -16,7 +16,7 @@ use super::Text;
 /// let password = Masked::new("12345", 'x');
 ///
 /// Paragraph::new(password).render(buffer.area, &mut buffer);
-/// assert_eq!(buffer, Buffer::with_lines(vec!["xxxxx"]));
+/// assert_eq!(buffer, Buffer::with_lines(["xxxxx"]));
 /// ```
 #[derive(Default, Clone, Eq, PartialEq, Hash)]
 pub struct Masked<'a> {

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -565,7 +565,6 @@ mod tests {
         use rstest::rstest;
 
         use super::*;
-        use crate::assert_buffer_eq;
 
         #[test]
         fn render() {
@@ -573,12 +572,11 @@ mod tests {
             let span = Span::styled("test content", style);
             let mut buf = Buffer::empty(Rect::new(0, 0, 15, 1));
             span.render(buf.area, &mut buf);
-
-            let expected = Buffer::with_lines(vec![Line::from(vec![
+            let expected = Buffer::with_lines([Line::from(vec![
                 "test content".green().on_yellow(),
                 "   ".into(),
             ])]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[rstest]
@@ -598,10 +596,11 @@ mod tests {
             let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
             span.render(Rect::new(0, 0, 5, 1), &mut buf);
 
-            let mut expected = Buffer::with_lines(vec![Line::from("test      ")]);
-            expected.set_style(Rect::new(0, 0, 5, 1), (Color::Green, Color::Yellow));
-
-            assert_buffer_eq!(buf, expected);
+            let expected = Buffer::with_lines([Line::from(vec![
+                "test ".green().on_yellow(),
+                "     ".into(),
+            ])]);
+            assert_eq!(buf, expected);
         }
 
         /// When there is already a style set on the buffer, the style of the span should be
@@ -613,12 +612,11 @@ mod tests {
             let mut buf = Buffer::empty(Rect::new(0, 0, 15, 1));
             buf.set_style(buf.area, Style::new().italic());
             span.render(buf.area, &mut buf);
-
-            let expected = Buffer::with_lines(vec![Line::from(vec![
+            let expected = Buffer::with_lines([Line::from(vec![
                 "test content".green().on_yellow().italic(),
                 "   ".italic(),
             ])]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         /// When the span contains a multi-width grapheme, the grapheme will ensure that the cells
@@ -629,12 +627,11 @@ mod tests {
             let span = Span::styled("test 😃 content", style);
             let mut buf = Buffer::empty(Rect::new(0, 0, 15, 1));
             span.render(buf.area, &mut buf);
-
             // The existing code in buffer.set_line() handles multi-width graphemes by clearing the
             // cells of the hidden characters. This test ensures that the existing behavior is
             // preserved.
-            let expected = Buffer::with_lines(vec!["test 😃 content".green().on_yellow()]);
-            assert_buffer_eq!(buf, expected);
+            let expected = Buffer::with_lines(["test 😃 content".green().on_yellow()]);
+            assert_eq!(buf, expected);
         }
 
         /// When the span contains a multi-width grapheme that does not fit in the area passed to
@@ -647,11 +644,9 @@ mod tests {
             let mut buf = Buffer::empty(Rect::new(0, 0, 6, 1));
             span.render(buf.area, &mut buf);
 
-            let expected = Buffer::with_lines(vec![Line::from(vec![
-                "test ".green().on_yellow(),
-                " ".into(),
-            ])]);
-            assert_buffer_eq!(buf, expected);
+            let expected =
+                Buffer::with_lines([Line::from(vec!["test ".green().on_yellow(), " ".into()])]);
+            assert_eq!(buf, expected);
         }
 
         /// When the area passed to render overflows the buffer, the content should be truncated
@@ -663,11 +658,11 @@ mod tests {
             let mut buf = Buffer::empty(Rect::new(0, 0, 15, 1));
             span.render(Rect::new(10, 0, 20, 1), &mut buf);
 
-            let expected = Buffer::with_lines(vec![Line::from(vec![
+            let expected = Buffer::with_lines([Line::from(vec![
                 "          ".into(),
                 "test ".green().on_yellow(),
             ])]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
     }
 }

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -962,19 +962,14 @@ mod tests {
 
     mod widget {
         use super::*;
-        use crate::assert_buffer_eq;
 
         #[test]
         fn render() {
             let text = Text::from("foo");
-
             let area = Rect::new(0, 0, 5, 1);
             let mut buf = Buffer::empty(area);
             text.render(area, &mut buf);
-
-            let expected_buf = Buffer::with_lines(vec!["foo  "]);
-
-            assert_buffer_eq!(buf, expected_buf);
+            assert_eq!(buf, Buffer::with_lines(["foo  "]));
         }
 
         #[rstest]
@@ -987,40 +982,28 @@ mod tests {
         #[test]
         fn render_right_aligned() {
             let text = Text::from("foo").alignment(Alignment::Right);
-
             let area = Rect::new(0, 0, 5, 1);
             let mut buf = Buffer::empty(area);
             text.render(area, &mut buf);
-
-            let expected_buf = Buffer::with_lines(vec!["  foo"]);
-
-            assert_buffer_eq!(buf, expected_buf);
+            assert_eq!(buf, Buffer::with_lines(["  foo"]));
         }
 
         #[test]
         fn render_centered_odd() {
             let text = Text::from("foo").alignment(Alignment::Center);
-
             let area = Rect::new(0, 0, 5, 1);
             let mut buf = Buffer::empty(area);
             text.render(area, &mut buf);
-
-            let expected_buf = Buffer::with_lines(vec![" foo "]);
-
-            assert_buffer_eq!(buf, expected_buf);
+            assert_eq!(buf, Buffer::with_lines([" foo "]));
         }
 
         #[test]
         fn render_centered_even() {
             let text = Text::from("foo").alignment(Alignment::Center);
-
             let area = Rect::new(0, 0, 6, 1);
             let mut buf = Buffer::empty(area);
             text.render(area, &mut buf);
-
-            let expected_buf = Buffer::with_lines(vec![" foo  "]);
-
-            assert_buffer_eq!(buf, expected_buf);
+            assert_eq!(buf, Buffer::with_lines([" foo  "]));
         }
 
         #[test]
@@ -1030,14 +1013,10 @@ mod tests {
                 Line::from("bar").alignment(Alignment::Center),
             ])
             .alignment(Alignment::Right);
-
             let area = Rect::new(0, 0, 5, 2);
             let mut buf = Buffer::empty(area);
             text.render(area, &mut buf);
-
-            let expected_buf = Buffer::with_lines(vec!["  foo", " bar "]);
-
-            assert_buffer_eq!(buf, expected_buf);
+            assert_eq!(buf, Buffer::with_lines(["  foo", " bar "]));
         }
 
         #[test]
@@ -1046,10 +1025,9 @@ mod tests {
             let mut buf = Buffer::empty(area);
             Text::from("foo".on_blue()).render(area, &mut buf);
 
-            let mut expected = Buffer::with_lines(vec!["foo  "]);
+            let mut expected = Buffer::with_lines(["foo  "]);
             expected.set_style(Rect::new(0, 0, 3, 1), Style::new().bg(Color::Blue));
-
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1057,10 +1035,9 @@ mod tests {
             let mut buf = Buffer::empty(Rect::new(0, 0, 6, 1));
             Text::from("foobar".on_blue()).render(Rect::new(0, 0, 3, 1), &mut buf);
 
-            let mut expected = Buffer::with_lines(vec!["foo   "]);
+            let mut expected = Buffer::with_lines(["foo   "]);
             expected.set_style(Rect::new(0, 0, 3, 1), Style::new().bg(Color::Blue));
-
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
     }
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -653,6 +653,6 @@ mod tests {
     #[rstest]
     fn string_option_render_ref(mut buf: Buffer) {
         Some(String::from("hello world")).render_ref(buf.area, &mut buf);
-        assert_eq!(buf, Buffer::with_lines(["hello world         "]),);
+        assert_eq!(buf, Buffer::with_lines(["hello world         "]));
     }
 }

--- a/src/widgets/barchart.rs
+++ b/src/widgets/barchart.rs
@@ -615,34 +615,33 @@ mod tests {
     use itertools::iproduct;
 
     use super::*;
-    use crate::{assert_buffer_eq, widgets::BorderType};
+    use crate::widgets::BorderType;
 
     #[test]
     fn default() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default();
         widget.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["          "; 3]));
+        assert_eq!(buffer, Buffer::with_lines(["          "; 3]));
     }
 
     #[test]
     fn data() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default().data(&[("foo", 1), ("bar", 2)]);
         widget.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "  █            ",
-                "1 2            ",
-                "f b            ",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "  █       ",
+            "1 2       ",
+            "f b       ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn block() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 5));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 5));
         let block = Block::bordered()
             .border_type(BorderType::Double)
             .title("Block");
@@ -650,112 +649,106 @@ mod tests {
             .data(&[("foo", 1), ("bar", 2)])
             .block(block);
         widget.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "╔Block════════╗",
-                "║  █          ║",
-                "║1 2          ║",
-                "║f b          ║",
-                "╚═════════════╝",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "╔Block═══╗",
+            "║  █     ║",
+            "║1 2     ║",
+            "║f b     ║",
+            "╚════════╝",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn max() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let without_max = BarChart::default().data(&[("foo", 1), ("bar", 2), ("baz", 100)]);
         without_max.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "    █          ",
-                "    █          ",
-                "f b b          ",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "    █     ",
+            "    █     ",
+            "f b b     ",
+        ]);
+        assert_eq!(buffer, expected);
         let with_max = BarChart::default()
             .data(&[("foo", 1), ("bar", 2), ("baz", 100)])
             .max(2);
         with_max.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "  █ █          ",
-                "1 2 █          ",
-                "f b b          ",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "  █ █     ",
+            "1 2 █     ",
+            "f b b     ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn bar_style() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default()
             .data(&[("foo", 1), ("bar", 2)])
             .bar_style(Style::new().red());
         widget.render(buffer.area, &mut buffer);
-        let mut expected = Buffer::with_lines(vec![
-            "  █            ",
-            "1 2            ",
-            "f b            ",
+        #[rustfmt::skip]
+        let mut expected = Buffer::with_lines([
+            "  █       ",
+            "1 2       ",
+            "f b       ",
         ]);
         for (x, y) in iproduct!([0, 2], [0, 1]) {
             expected.get_mut(x, y).set_fg(Color::Red);
         }
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn bar_width() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default()
             .data(&[("foo", 1), ("bar", 2)])
             .bar_width(3);
         widget.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "    ███        ",
-                "█1█ █2█        ",
-                "foo bar        ",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "    ███   ",
+            "█1█ █2█   ",
+            "foo bar   ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn bar_gap() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default()
             .data(&[("foo", 1), ("bar", 2)])
             .bar_gap(2);
         widget.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "   █           ",
-                "1  2           ",
-                "f  b           ",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "   █      ",
+            "1  2      ",
+            "f  b      ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn bar_set() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default()
             .data(&[("foo", 0), ("bar", 1), ("baz", 3)])
             .bar_set(symbols::bar::THREE_LEVELS);
         widget.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "    █          ",
-                "  ▄ 3          ",
-                "f b b          ",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "    █     ",
+            "  ▄ 3     ",
+            "f b b     ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -775,67 +768,68 @@ mod tests {
             ])
             .bar_set(symbols::bar::NINE_LEVELS);
         widget.render(Rect::new(0, 1, 18, 2), &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "                  ",
-                "  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8 ",
-                "a b c d e f g h i ",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "                  ",
+            "  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8 ",
+            "a b c d e f g h i ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn value_style() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default()
             .data(&[("foo", 1), ("bar", 2)])
             .bar_width(3)
             .value_style(Style::new().red());
         widget.render(buffer.area, &mut buffer);
-        let mut expected = Buffer::with_lines(vec![
-            "    ███        ",
-            "█1█ █2█        ",
-            "foo bar        ",
+        #[rustfmt::skip]
+        let mut expected = Buffer::with_lines([
+            "    ███   ",
+            "█1█ █2█   ",
+            "foo bar   ",
         ]);
         expected.get_mut(1, 1).set_fg(Color::Red);
         expected.get_mut(5, 1).set_fg(Color::Red);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn label_style() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default()
             .data(&[("foo", 1), ("bar", 2)])
             .label_style(Style::new().red());
         widget.render(buffer.area, &mut buffer);
-        let mut expected = Buffer::with_lines(vec![
-            "  █            ",
-            "1 2            ",
-            "f b            ",
+        #[rustfmt::skip]
+        let mut expected = Buffer::with_lines([
+            "  █       ",
+            "1 2       ",
+            "f b       ",
         ]);
         expected.get_mut(0, 2).set_fg(Color::Red);
         expected.get_mut(2, 2).set_fg(Color::Red);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn style() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         let widget = BarChart::default()
             .data(&[("foo", 1), ("bar", 2)])
             .style(Style::new().red());
         widget.render(buffer.area, &mut buffer);
-        let mut expected = Buffer::with_lines(vec![
-            "  █            ",
-            "1 2            ",
-            "f b            ",
+        #[rustfmt::skip]
+        let mut expected = Buffer::with_lines([
+            "  █       ",
+            "1 2       ",
+            "f b       ",
         ]);
-        for (x, y) in iproduct!(0..15, 0..3) {
+        for (x, y) in iproduct!(0..10, 0..3) {
             expected.get_mut(x, y).set_fg(Color::Red);
         }
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -861,8 +855,13 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 3, 3));
         chart.render(buffer.area, &mut buffer);
-        let expected = Buffer::with_lines(vec!["  █", "1 2", "G  "]);
-        assert_buffer_eq!(buffer, expected);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "  █",
+            "1 2",
+            "G  ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     fn build_test_barchart<'a>() -> BarChart<'a> {
@@ -888,7 +887,7 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 5, 8));
         chart.render(buffer.area, &mut buffer);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "2█   ",
             "3██  ",
             "4███ ",
@@ -898,8 +897,7 @@ mod tests {
             "5████",
             "G2   ",
         ]);
-
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -908,7 +906,7 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 5, 7));
         chart.render(buffer.area, &mut buffer);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "2█   ",
             "3██  ",
             "4███ ",
@@ -917,8 +915,7 @@ mod tests {
             "4███ ",
             "5████",
         ]);
-
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -927,9 +924,15 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 5, 5));
         chart.render(buffer.area, &mut buffer);
-        let expected = Buffer::with_lines(vec!["2█   ", "3██  ", "4███ ", "G1   ", "3██  "]);
-
-        assert_buffer_eq!(buffer, expected);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "2█   ",
+            "3██  ",
+            "4███ ",
+            "G1   ",
+            "3██  ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     fn test_horizontal_bars_label_width_greater_than_bar(bar_color: Option<Color>) {
@@ -952,7 +955,7 @@ mod tests {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 5, 2));
         chart.render(buffer.area, &mut buffer);
 
-        let mut expected = Buffer::with_lines(vec!["label", "5████"]);
+        let mut expected = Buffer::with_lines(["label", "5████"]);
 
         // first line has a yellow foreground. first cell contains italic "5"
         expected.get_mut(0, 1).modifier.insert(Modifier::ITALIC);
@@ -977,7 +980,7 @@ mod tests {
         expected.get_mut(3, 0).set_fg(expected_color);
         expected.get_mut(4, 0).set_fg(expected_color);
 
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1000,9 +1003,13 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         chart.render(buffer.area, &mut buffer);
-        let expected = Buffer::with_lines(vec!["Jan 10█   ", "Feb 20████", "Mar 5     "]);
-
-        assert_buffer_eq!(buffer, expected);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "Jan 10█   ",
+            "Feb 20████",
+            "Mar 5     ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1023,13 +1030,13 @@ mod tests {
         // G1 should have the bold red style
         // bold: because of BarChart::label_style
         // red: is included with the label itself
-        let mut expected = Buffer::with_lines(vec!["2████", "G1   "]);
+        let mut expected = Buffer::with_lines(["2████", "G1   "]);
         let cell = expected.get_mut(0, 1).set_fg(Color::Red);
         cell.modifier.insert(Modifier::BOLD);
         let cell = expected.get_mut(1, 1).set_fg(Color::Red);
         cell.modifier.insert(Modifier::BOLD);
 
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1046,17 +1053,14 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 13, 5));
         chart.render(buffer.area, &mut buffer);
-
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "    ▂ █     ▂",
-                "  ▄ █ █   ▄ █",
-                "▆ 2 3 4 ▆ 2 3",
-                "a b c c a b c",
-                "  G1     G2  ",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "    ▂ █     ▂",
+            "  ▄ █ █   ▄ █",
+            "▆ 2 3 4 ▆ 2 3",
+            "a b c c a b c",
+            "  G1     G2  ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1069,9 +1073,13 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 3, 3));
         chart.render(buffer.area, &mut buffer);
-
-        let expected = Buffer::with_lines(vec!["  █", "▆ 5", "  G"]);
-        assert_buffer_eq!(buffer, expected);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "  █",
+            "▆ 5",
+            "  G",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1094,15 +1102,14 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 11, 5));
         chart.render(buffer.area, &mut buffer);
-
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "    ▆▆▆ ███",
             "    ███ ███",
             "▃▃▃ ███ ███",
             "写█ 写█ 写█",
             "B1  B2  B2 ",
         ]);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1114,7 +1121,7 @@ mod tests {
             .bar_gap(0);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 10));
         chart.render(buffer.area, &mut buffer);
-        assert_buffer_eq!(buffer, Buffer::empty(Rect::new(0, 0, 0, 10)));
+        assert_eq!(buffer, Buffer::empty(Rect::new(0, 0, 0, 10)));
     }
 
     #[test]
@@ -1139,8 +1146,7 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 17, 1));
         chart.render(buffer.area, &mut buffer);
-
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8"]));
+        assert_eq!(buffer, Buffer::with_lines(["  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8"]));
     }
 
     #[test]
@@ -1165,15 +1171,12 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 17, 3));
         chart.render(Rect::new(0, 1, buffer.area.width, 2), &mut buffer);
-
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "                 ",
-                "  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8",
-                "a b c d e f g h i",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "                 ",
+            "  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8",
+            "a b c d e f g h i",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1198,15 +1201,12 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 17, 3));
         chart.render(buffer.area, &mut buffer);
-
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8",
-                "a b c d e f g h i",
-                "      Group      ",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8",
+            "a b c d e f g h i",
+            "      Group      ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1231,15 +1231,12 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 26, 3));
         chart.render(buffer.area, &mut buffer);
-
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "   1▁ 2▂ 3▃ 4▄ 5▅ 6▆ 7▇ 8█",
-                "a  b  c  d  e  f  g  h  i ",
-                "          Group           ",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "   1▁ 2▂ 3▃ 4▄ 5▅ 6▆ 7▇ 8█",
+            "a  b  c  d  e  f  g  h  i ",
+            "          Group           ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1264,16 +1261,13 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 17, 4));
         chart.render(buffer.area, &mut buffer);
-
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "          ▂ ▄ ▆ █",
-                "  ▂ ▄ ▆ 4 5 6 7 8",
-                "a b c d e f g h i",
-                "      Group      ",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "          ▂ ▄ ▆ █",
+            "  ▂ ▄ ▆ 4 5 6 7 8",
+            "a b c d e f g h i",
+            "      Group      ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1296,15 +1290,12 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 17, 3));
         chart.render(Rect::new(0, 1, buffer.area.width, 2), &mut buffer);
-
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "                 ",
-                "  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8",
-                "      Group      ",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "                 ",
+            "  ▁ ▂ ▃ ▄ ▅ ▆ ▇ 8",
+            "      Group      ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1315,13 +1306,9 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 59, 1));
         chart.render(buffer.area, &mut buffer);
-
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "        ▁ ▁ ▁ ▁ ▂ ▂ ▂ ▃ ▃ ▃ ▃ ▄ ▄ ▄ ▄ ▅ ▅ ▅ ▆ ▆ ▆ ▆ ▇ ▇ ▇ █",
-            ])
-        );
+        let expected =
+            Buffer::with_lines(["        ▁ ▁ ▁ ▁ ▂ ▂ ▂ ▃ ▃ ▃ ▃ ▄ ▄ ▄ ▄ ▅ ▅ ▅ ▆ ▆ ▆ ▆ ▇ ▇ ▇ █"]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1333,17 +1320,14 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 7, 6));
         chart.render(buffer.area, &mut buffer);
-
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "   ██  ",
-                "   ██  ",
-                "▄▄ ██  ",
-                "██ ██  ",
-                "1█ 2█  ",
-                "a  b   ",
-            ])
-        );
+        let expected = Buffer::with_lines([
+            "   ██  ",
+            "   ██  ",
+            "▄▄ ██  ",
+            "██ ██  ",
+            "1█ 2█  ",
+            "a  b   ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 }

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -864,7 +864,6 @@ mod tests {
     use strum::ParseError;
 
     use super::*;
-    use crate::assert_buffer_eq;
 
     #[test]
     fn create_with_all_borders() {
@@ -1078,7 +1077,7 @@ mod tests {
     fn title() {
         use Alignment::*;
         use Position::*;
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 11, 3));
         Block::bordered()
             .title(Title::from("A").position(Top).alignment(Left))
             .title(Title::from("B").position(Top).alignment(Center))
@@ -1087,19 +1086,18 @@ mod tests {
             .title(Title::from("E").position(Bottom).alignment(Center))
             .title(Title::from("F").position(Bottom).alignment(Right))
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "┌A─────B─────C┐",
-                "│             │",
-                "└D─────E─────F┘",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "┌A───B───C┐",
+            "│         │",
+            "└D───E───F┘",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn title_top_bottom() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 11, 3));
         Block::bordered()
             .title_top(Line::raw("A").left_aligned())
             .title_top(Line::raw("B").centered())
@@ -1108,14 +1106,13 @@ mod tests {
             .title_bottom(Line::raw("E").centered())
             .title_bottom(Line::raw("F").right_aligned())
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "┌A─────B─────C┐",
-                "│             │",
-                "└D─────E─────F┘",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "┌A───B───C┐",
+            "│         │",
+            "└D───E───F┘",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1131,7 +1128,7 @@ mod tests {
                 .title_alignment(alignment)
                 .title("test")
                 .render(buffer.area, &mut buffer);
-            assert_buffer_eq!(buffer, Buffer::with_lines(vec![expected]));
+            assert_eq!(buffer, Buffer::with_lines([expected]));
         }
     }
 
@@ -1148,7 +1145,7 @@ mod tests {
                 .title_alignment(block_title_alignment)
                 .title(Title::from("test").alignment(alignment))
                 .render(buffer.area, &mut buffer);
-            assert_buffer_eq!(buffer, Buffer::with_lines(vec![expected]));
+            assert_eq!(buffer, Buffer::with_lines([expected]));
         }
     }
 
@@ -1160,14 +1157,7 @@ mod tests {
             .title_alignment(Alignment::Right)
             .title("")
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "               ",
-                "               ",
-                "               ",
-            ])
-        );
+        assert_eq!(buffer, Buffer::with_lines(["               "; 3]));
     }
 
     #[test]
@@ -1177,7 +1167,7 @@ mod tests {
             .title_position(Position::Bottom)
             .title("test")
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["    ", "test"]));
+        assert_eq!(buffer, Buffer::with_lines(["    ", "test"]));
     }
 
     #[test]
@@ -1188,11 +1178,7 @@ mod tests {
                 .title_alignment(alignment)
                 .title("test".yellow())
                 .render(buffer.area, &mut buffer);
-
-            let mut expected_buffer = Buffer::with_lines(vec!["test"]);
-            expected_buffer.set_style(Rect::new(0, 0, 4, 1), Style::new().yellow());
-
-            assert_buffer_eq!(buffer, expected_buffer);
+            assert_eq!(buffer, Buffer::with_lines(["test".yellow()]));
         }
     }
 
@@ -1205,11 +1191,7 @@ mod tests {
                 .title_style(Style::new().yellow())
                 .title("test")
                 .render(buffer.area, &mut buffer);
-
-            let mut expected_buffer = Buffer::with_lines(vec!["test"]);
-            expected_buffer.set_style(Rect::new(0, 0, 4, 1), Style::new().yellow());
-
-            assert_buffer_eq!(buffer, expected_buffer);
+            assert_eq!(buffer, Buffer::with_lines(["test".yellow()]));
         }
     }
 
@@ -1222,31 +1204,26 @@ mod tests {
                 .title_style(Style::new().green().on_red())
                 .title("test".yellow())
                 .render(buffer.area, &mut buffer);
-
-            let mut expected_buffer = Buffer::with_lines(vec!["test"]);
-            expected_buffer.set_style(Rect::new(0, 0, 4, 1), Style::new().yellow().on_red());
-
-            assert_buffer_eq!(buffer, expected_buffer);
+            assert_eq!(buffer, Buffer::with_lines(["test".yellow().on_red()]));
         }
     }
 
     #[test]
     fn title_border_style() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         Block::bordered()
             .title("test")
             .border_style(Style::new().yellow())
             .render(buffer.area, &mut buffer);
-
-        let mut expected_buffer = Buffer::with_lines(vec![
-            "┌test─────────┐",
-            "│             │",
-            "└─────────────┘",
+        #[rustfmt::skip]
+        let mut expected = Buffer::with_lines([
+            "┌test────┐",
+            "│        │",
+            "└────────┘",
         ]);
-        expected_buffer.set_style(Rect::new(0, 0, 15, 3), Style::new().yellow());
-        expected_buffer.set_style(Rect::new(1, 1, 13, 1), Style::reset());
-
-        assert_buffer_eq!(buffer, expected_buffer);
+        expected.set_style(Rect::new(0, 0, 10, 3), Style::new().yellow());
+        expected.set_style(Rect::new(1, 1, 8, 1), Style::reset());
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1268,103 +1245,97 @@ mod tests {
 
     #[test]
     fn render_plain_border() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         Block::bordered()
             .border_type(BorderType::Plain)
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "┌─────────────┐",
-                "│             │",
-                "└─────────────┘"
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "┌────────┐",
+            "│        │",
+            "└────────┘",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn render_rounded_border() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         Block::bordered()
             .border_type(BorderType::Rounded)
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "╭─────────────╮",
-                "│             │",
-                "╰─────────────╯"
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "╭────────╮",
+            "│        │",
+            "╰────────╯",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn render_double_border() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         Block::bordered()
             .border_type(BorderType::Double)
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "╔═════════════╗",
-                "║             ║",
-                "╚═════════════╝"
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "╔════════╗",
+            "║        ║",
+            "╚════════╝",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn render_quadrant_inside() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         Block::bordered()
             .border_type(BorderType::QuadrantInside)
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "▗▄▄▄▄▄▄▄▄▄▄▄▄▄▖",
-                "▐             ▌",
-                "▝▀▀▀▀▀▀▀▀▀▀▀▀▀▘",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "▗▄▄▄▄▄▄▄▄▖",
+            "▐        ▌",
+            "▝▀▀▀▀▀▀▀▀▘",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn render_border_quadrant_outside() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         Block::bordered()
             .border_type(BorderType::QuadrantOutside)
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "▛▀▀▀▀▀▀▀▀▀▀▀▀▀▜",
-                "▌             ▐",
-                "▙▄▄▄▄▄▄▄▄▄▄▄▄▄▟",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "▛▀▀▀▀▀▀▀▀▜",
+            "▌        ▐",
+            "▙▄▄▄▄▄▄▄▄▟",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn render_solid_border() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         Block::bordered()
             .border_type(BorderType::Thick)
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "┏━━━━━━━━━━━━━┓",
-                "┃             ┃",
-                "┗━━━━━━━━━━━━━┛"
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "┏━━━━━━━━┓",
+            "┃        ┃",
+            "┗━━━━━━━━┛",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn render_custom_border_set() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
         Block::bordered()
             .border_set(border::Set {
                 top_left: "1",
@@ -1377,13 +1348,12 @@ mod tests {
                 horizontal_bottom: "B",
             })
             .render(buffer.area, &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "1TTTTTTTTTTTTT2",
-                "L             R",
-                "3BBBBBBBBBBBBB4",
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "1TTTTTTTT2",
+            "L        R",
+            "3BBBBBBBB4",
+        ]);
+        assert_eq!(buffer, expected);
     }
 }

--- a/src/widgets/canvas/circle.rs
+++ b/src/widgets/canvas/circle.rs
@@ -58,7 +58,7 @@ mod tests {
             .x_bounds([-10.0, 10.0])
             .y_bounds([-10.0, 10.0]);
         canvas.render(buffer.area, &mut buffer);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "     ⢀⣠⢤⣀ ",
             "    ⢰⠋  ⠈⣇",
             "    ⠘⣆⡀ ⣠⠇",

--- a/src/widgets/canvas/map.rs
+++ b/src/widgets/canvas/map.rs
@@ -65,7 +65,7 @@ mod tests {
     use strum::ParseError;
 
     use super::*;
-    use crate::{assert_buffer_eq, prelude::*, widgets::canvas::Canvas};
+    use crate::{prelude::*, widgets::canvas::Canvas};
 
     #[test]
     fn map_resolution_to_string() {
@@ -101,7 +101,7 @@ mod tests {
                 context.draw(&Map::default());
             });
         canvas.render(buffer.area, &mut buffer);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "                                                                                ",
             "                   ••••••• •• •• •• •                                           ",
             "            ••••••••••••••       •••      ••••  •••  ••    ••••                 ",
@@ -143,7 +143,7 @@ mod tests {
             "       •                                                                        ",
             "                                                                                ",
         ]);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -160,7 +160,7 @@ mod tests {
                 });
             });
         canvas.render(buffer.area, &mut buffer);
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "                                                                                ",
             "                  ⢀⣠⠤⠤⠤⠔⢤⣤⡄⠤⡠⣄⠢⠂⢢⠰⣠⡄⣀⡀                      ⣀                   ",
             "            ⢀⣀⡤⣦⠲⢶⣿⣮⣿⡉⣰⢶⢏⡂        ⢀⣟⠁     ⢺⣻⢿⠏   ⠈⠉⠁ ⢀⣀    ⠈⠓⢳⣢⣂⡀               ",
@@ -202,6 +202,6 @@ mod tests {
             "⠶⠔⠲⠤⠠⠜⢗⠤⠄                 ⠘⠉  ⠁                                            ⠈⠉⠒⠔⠤",
             "                                                                                ",
         ]);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 }

--- a/src/widgets/canvas/rectangle.rs
+++ b/src/widgets/canvas/rectangle.rs
@@ -66,7 +66,7 @@ impl Shape for Rectangle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{assert_buffer_eq, prelude::*, widgets::canvas::Canvas};
+    use crate::{prelude::*, widgets::canvas::Canvas};
 
     #[test]
     fn draw_block_lines() {
@@ -85,7 +85,7 @@ mod tests {
                 });
             });
         canvas.render(buffer.area, &mut buffer);
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "██████████",
             "█        █",
             "█        █",
@@ -99,7 +99,7 @@ mod tests {
         ]);
         expected.set_style(buffer.area, Style::new().red());
         expected.set_style(buffer.area.inner(&Margin::new(1, 1)), Style::reset());
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -119,7 +119,7 @@ mod tests {
                 });
             });
         canvas.render(buffer.area, &mut buffer);
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "█▀▀▀▀▀▀▀▀█",
             "█        █",
             "█        █",
@@ -134,7 +134,7 @@ mod tests {
         expected.set_style(buffer.area, Style::new().red().on_red());
         expected.set_style(buffer.area.inner(&Margin::new(1, 0)), Style::reset().red());
         expected.set_style(buffer.area.inner(&Margin::new(1, 1)), Style::reset());
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -163,7 +163,7 @@ mod tests {
                 });
             });
         canvas.render(buffer.area, &mut buffer);
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "⡏⠉⠉⠉⠉⠉⠉⠉⠉⢹",
             "⡇⢠⠤⠤⠤⠤⠤⠤⡄⢸",
             "⡇⢸      ⡇⢸",
@@ -178,6 +178,6 @@ mod tests {
         expected.set_style(buffer.area, Style::new().red());
         expected.set_style(buffer.area.inner(&Margin::new(1, 1)), Style::new().green());
         expected.set_style(buffer.area.inner(&Margin::new(2, 2)), Style::reset());
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -1111,10 +1111,10 @@ impl<'a> Styled for Chart<'a> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use strum::ParseError;
 
     use super::*;
-    use crate::assert_buffer_eq;
 
     struct LegendTestCase {
         chart_area: Rect,
@@ -1209,7 +1209,6 @@ mod tests {
             .x_axis(Axis::default().title("xxxxxxxxxxxxxxxx"));
         let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 4));
         widget.render(buffer.area, &mut buffer);
-
         assert_eq!(buffer, Buffer::with_lines(vec![" ".repeat(8); 4]));
     }
 
@@ -1244,30 +1243,25 @@ mod tests {
         let widget = Chart::new(vec![long_dataset_name, short_dataset])
             .hidden_legend_constraints((100.into(), 100.into()));
         let mut buffer = Buffer::empty(Rect::new(0, 0, 20, 5));
-
         widget.render(buffer.area, &mut buffer);
-
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "    ┌──────────────┐",
             "    │Very long name│",
             "    │    Short name│",
             "    └──────────────┘",
             "                    ",
         ]);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_chart_have_a_topleft_legend() {
         let chart = Chart::new(vec![Dataset::default().name("Ds1")])
             .legend_position(Some(LegendPosition::TopLeft));
-
         let area = Rect::new(0, 0, 30, 20);
         let mut buffer = Buffer::empty(area);
-
         chart.render(buffer.area, &mut buffer);
-
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "┌───┐                         ",
             "│Ds1│                         ",
             "└───┘                         ",
@@ -1289,7 +1283,6 @@ mod tests {
             "                              ",
             "                              ",
         ]);
-
         assert_eq!(buffer, expected);
     }
 
@@ -1297,13 +1290,10 @@ mod tests {
     fn test_chart_have_a_long_y_axis_title_overlapping_legend() {
         let chart = Chart::new(vec![Dataset::default().name("Ds1")])
             .y_axis(Axis::default().title("The title overlap a legend."));
-
         let area = Rect::new(0, 0, 30, 20);
         let mut buffer = Buffer::empty(area);
-
         chart.render(buffer.area, &mut buffer);
-
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "The title overlap a legend.   ",
             "                         ┌───┐",
             "                         │Ds1│",
@@ -1325,7 +1315,6 @@ mod tests {
             "                              ",
             "                              ",
         ]);
-
         assert_eq!(buffer, expected);
     }
 
@@ -1333,13 +1322,10 @@ mod tests {
     fn test_chart_have_overflowed_y_axis() {
         let chart = Chart::new(vec![Dataset::default().name("Ds1")])
             .y_axis(Axis::default().title("The title overlap a legend."));
-
         let area = Rect::new(0, 0, 10, 10);
         let mut buffer = Buffer::empty(area);
-
         chart.render(buffer.area, &mut buffer);
-
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "          ",
             "          ",
             "          ",
@@ -1351,7 +1337,6 @@ mod tests {
             "          ",
             "          ",
         ]);
-
         assert_eq!(buffer, expected);
     }
 
@@ -1360,12 +1345,8 @@ mod tests {
         let name = "Data";
         let chart = Chart::new(vec![Dataset::default().name(name)])
             .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
-
         let area = Rect::new(0, 0, name.len() as u16 + 2, 3);
         let mut buffer = Buffer::empty(area);
-
-        let expected = Buffer::with_lines(vec!["┌────┐", "│Data│", "└────┘"]);
-
         for position in [
             LegendPosition::TopLeft,
             LegendPosition::Top,
@@ -1379,171 +1360,103 @@ mod tests {
             let chart = chart.clone().legend_position(Some(position));
             buffer.reset();
             chart.render(buffer.area, &mut buffer);
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
+                "┌────┐",
+                "│Data│",
+                "└────┘",
+            ]);
             assert_eq!(buffer, expected);
         }
     }
 
-    #[allow(clippy::too_many_lines)]
-    #[test]
-    fn test_legend_of_chart_have_odd_margin_size() {
+    #[rstest]
+    #[case(Some(LegendPosition::TopLeft), [
+        "┌────┐   ",
+        "│Data│   ",
+        "└────┘   ",
+        "         ",
+        "         ",
+        "         ",
+    ])]
+    #[case(Some(LegendPosition::Top), [
+        " ┌────┐  ",
+        " │Data│  ",
+        " └────┘  ",
+        "         ",
+        "         ",
+        "         ",
+    ])]
+    #[case(Some(LegendPosition::TopRight), [
+        "   ┌────┐",
+        "   │Data│",
+        "   └────┘",
+        "         ",
+        "         ",
+        "         ",
+    ])]
+    #[case(Some(LegendPosition::Left), [
+        "         ",
+        "┌────┐   ",
+        "│Data│   ",
+        "└────┘   ",
+        "         ",
+        "         ",
+    ])]
+    #[case(Some(LegendPosition::Right), [
+        "         ",
+        "   ┌────┐",
+        "   │Data│",
+        "   └────┘",
+        "         ",
+        "         ",
+    ])]
+    #[case(Some(LegendPosition::BottomLeft), [
+        "         ",
+        "         ",
+        "         ",
+        "┌────┐   ",
+        "│Data│   ",
+        "└────┘   ",
+    ])]
+    #[case(Some(LegendPosition::Bottom), [
+        "         ",
+        "         ",
+        "         ",
+        " ┌────┐  ",
+        " │Data│  ",
+        " └────┘  ",
+    ])]
+    #[case(Some(LegendPosition::BottomRight), [
+        "         ",
+        "         ",
+        "         ",
+        "   ┌────┐",
+        "   │Data│",
+        "   └────┘",
+    ])]
+    #[case(None, [
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+    ])]
+    fn test_legend_of_chart_have_odd_margin_size<'line, Lines>(
+        #[case] legend_position: Option<LegendPosition>,
+        #[case] expected: Lines,
+    ) where
+        Lines: IntoIterator,
+        Lines::Item: Into<Line<'line>>,
+    {
         let name = "Data";
-        let base_chart = Chart::new(vec![Dataset::default().name(name)])
-            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
-
         let area = Rect::new(0, 0, name.len() as u16 + 2 + 3, 3 + 3);
         let mut buffer = Buffer::empty(area);
-
-        let chart = base_chart
-            .clone()
-            .legend_position(Some(LegendPosition::TopLeft));
-        buffer.reset();
+        let chart = Chart::new(vec![Dataset::default().name(name)])
+            .legend_position(legend_position)
+            .hidden_legend_constraints((Constraint::Percentage(100), Constraint::Percentage(100)));
         chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "┌────┐   ",
-                "│Data│   ",
-                "└────┘   ",
-                "         ",
-                "         ",
-                "         ",
-            ])
-        );
-        buffer.reset();
-
-        let chart = base_chart
-            .clone()
-            .legend_position(Some(LegendPosition::Top));
-        buffer.reset();
-        chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                " ┌────┐  ",
-                " │Data│  ",
-                " └────┘  ",
-                "         ",
-                "         ",
-                "         ",
-            ])
-        );
-
-        let chart = base_chart
-            .clone()
-            .legend_position(Some(LegendPosition::TopRight));
-        buffer.reset();
-        chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "   ┌────┐",
-                "   │Data│",
-                "   └────┘",
-                "         ",
-                "         ",
-                "         ",
-            ])
-        );
-
-        let chart = base_chart
-            .clone()
-            .legend_position(Some(LegendPosition::Left));
-        buffer.reset();
-        chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "         ",
-                "┌────┐   ",
-                "│Data│   ",
-                "└────┘   ",
-                "         ",
-                "         ",
-            ])
-        );
-        buffer.reset();
-
-        let chart = base_chart
-            .clone()
-            .legend_position(Some(LegendPosition::Right));
-        buffer.reset();
-        chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "         ",
-                "   ┌────┐",
-                "   │Data│",
-                "   └────┘",
-                "         ",
-                "         ",
-            ])
-        );
-
-        let chart = base_chart
-            .clone()
-            .legend_position(Some(LegendPosition::BottomLeft));
-        buffer.reset();
-        chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "         ",
-                "         ",
-                "         ",
-                "┌────┐   ",
-                "│Data│   ",
-                "└────┘   ",
-            ])
-        );
-
-        let chart = base_chart
-            .clone()
-            .legend_position(Some(LegendPosition::Bottom));
-        buffer.reset();
-        chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "         ",
-                "         ",
-                "         ",
-                " ┌────┐  ",
-                " │Data│  ",
-                " └────┘  ",
-            ])
-        );
-
-        let chart = base_chart
-            .clone()
-            .legend_position(Some(LegendPosition::BottomRight));
-        buffer.reset();
-        chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "         ",
-                "         ",
-                "         ",
-                "   ┌────┐",
-                "   │Data│",
-                "   └────┘",
-            ])
-        );
-
-        let chart = base_chart.clone().legend_position(None);
-        buffer.reset();
-        chart.render(buffer.area, &mut buffer);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "         ",
-                "         ",
-                "         ",
-                "         ",
-                "         ",
-                "         ",
-            ])
-        );
+        assert_eq!(buffer, Buffer::with_lines(expected));
     }
 }

--- a/src/widgets/clear.rs
+++ b/src/widgets/clear.rs
@@ -43,24 +43,21 @@ impl WidgetRef for Clear {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_buffer_eq;
 
     #[test]
     fn render() {
-        let mut buf = Buffer::with_lines(vec!["xxxxxxxxxxxxxxx"; 7]);
+        let mut buffer = Buffer::with_lines(["xxxxxxxxxxxxxxx"; 7]);
         let clear = Clear;
-        clear.render(Rect::new(1, 2, 3, 4), &mut buf);
-        assert_buffer_eq!(
-            buf,
-            Buffer::with_lines(vec![
-                "xxxxxxxxxxxxxxx",
-                "xxxxxxxxxxxxxxx",
-                "x   xxxxxxxxxxx",
-                "x   xxxxxxxxxxx",
-                "x   xxxxxxxxxxx",
-                "x   xxxxxxxxxxx",
-                "xxxxxxxxxxxxxxx",
-            ])
-        );
+        clear.render(Rect::new(1, 2, 3, 4), &mut buffer);
+        let expected = Buffer::with_lines([
+            "xxxxxxxxxxxxxxx",
+            "xxxxxxxxxxxxxxx",
+            "x   xxxxxxxxxxx",
+            "x   xxxxxxxxxxx",
+            "x   xxxxxxxxxxx",
+            "x   xxxxxxxxxxx",
+            "xxxxxxxxxxxxxxx",
+        ]);
+        assert_eq!(buffer, expected);
     }
 }

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -31,7 +31,7 @@ use crate::{
 /// # use ratatui::{prelude::*, widgets::*};
 /// # fn ui(frame: &mut Frame) {
 /// # let area = Rect::default();
-/// # let items = vec!["Item 1"];
+/// # let items = ["Item 1"];
 /// let list = List::new(items);
 ///
 /// // This should be stored outside of the function in your application state.
@@ -536,7 +536,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1"];
+    /// # let items = ["Item 1"];
     /// let block = Block::bordered().title("List");
     /// let list = List::new(items).block(block);
     /// ```
@@ -560,7 +560,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1"];
+    /// # let items = ["Item 1"];
     /// let list = List::new(items).style(Style::new().red().italic());
     /// ```
     ///
@@ -571,7 +571,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1"];
+    /// # let items = ["Item 1"];
     /// let list = List::new(items).red().italic();
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -590,7 +590,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1", "Item 2"];
+    /// # let items = ["Item 1", "Item 2"];
     /// let list = List::new(items).highlight_symbol(">>");
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -614,7 +614,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1", "Item 2"];
+    /// # let items = ["Item 1", "Item 2"];
     /// let list = List::new(items).highlight_style(Style::new().red().italic());
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -656,7 +656,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1"];
+    /// # let items = ["Item 1"];
     /// let list = List::new(items).highlight_spacing(HighlightSpacing::Always);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -678,7 +678,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1"];
+    /// # let items = ["Item 1"];
     /// let list = List::new(items).direction(ListDirection::BottomToTop);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -697,7 +697,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1"];
+    /// # let items = ["Item 1"];
     /// let list = List::new(items).scroll_padding(1);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -727,7 +727,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1"];
+    /// # let items = ["Item 1"];
     /// let list = List::new(items).start_corner(Corner::BottomRight);
     /// ```
     ///
@@ -735,7 +735,7 @@ impl<'a> List<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// # let items = vec!["Item 1"];
+    /// # let items = ["Item 1"];
     /// let list = List::new(items).start_corner(Corner::BottomLeft);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -1049,7 +1049,6 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use super::*;
-    use crate::assert_buffer_eq;
 
     #[test]
     fn test_list_state_selected() {
@@ -1189,11 +1188,6 @@ mod tests {
         assert_eq!(item.width(), 9);
     }
 
-    /// helper method to take a vector of strings and return a vector of list items
-    fn list_items(items: Vec<&str>) -> Vec<ListItem> {
-        items.into_iter().map(ListItem::new).collect()
-    }
-
     /// helper method to render a widget to an empty buffer with the default state
     fn render_widget(widget: List<'_>, width: u16, height: u16) -> Buffer {
         let mut buffer = Buffer::empty(Rect::new(0, 0, width, height));
@@ -1221,11 +1215,11 @@ mod tests {
 
         // attempt to render into an area of the buffer with 0 width
         Widget::render(list.clone(), Rect::new(0, 0, 0, 3), &mut buffer);
-        assert_buffer_eq!(buffer, Buffer::empty(buffer.area));
+        assert_eq!(&buffer, &Buffer::empty(buffer.area));
 
         // attempt to render into an area of the buffer with 0 height
         Widget::render(list.clone(), Rect::new(0, 0, 15, 0), &mut buffer);
-        assert_buffer_eq!(buffer, Buffer::empty(buffer.area));
+        assert_eq!(&buffer, &Buffer::empty(buffer.area));
 
         let list = List::new(items)
             .highlight_symbol(">>")
@@ -1233,52 +1227,55 @@ mod tests {
         // attempt to render into an area of the buffer with zero height after
         // setting the block borders
         Widget::render(list, Rect::new(0, 0, 15, 2), &mut buffer);
-        assert_buffer_eq!(
-            buffer,
-            Buffer::with_lines(vec![
-                "┌─────────────┐",
-                "└─────────────┘",
-                "               "
-            ])
-        );
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "┌─────────────┐",
+            "└─────────────┘",
+            "               ",
+        ]);
+        assert_eq!(buffer, expected,);
     }
 
     #[allow(clippy::too_many_lines)]
     #[test]
     fn test_list_combinations() {
-        fn test_case_render(items: &[ListItem], expected_lines: Vec<&str>) {
+        #[track_caller]
+        fn test_case_render<'line, Lines>(items: &[ListItem], expected: Lines)
+        where
+            Lines: IntoIterator,
+            Lines::Item: Into<Line<'line>>,
+        {
             let list = List::new(items.to_owned()).highlight_symbol(">>");
             let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 5));
-
             Widget::render(list, buffer.area, &mut buffer);
-
-            let expected = Buffer::with_lines(expected_lines);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, Buffer::with_lines(expected));
         }
-        fn test_case_render_stateful(
+
+        #[track_caller]
+        fn test_case_render_stateful<'line, Lines>(
             items: &[ListItem],
             selected: Option<usize>,
-            expected_lines: Vec<&str>,
-        ) {
+            expected: Lines,
+        ) where
+            Lines: IntoIterator,
+            Lines::Item: Into<Line<'line>>,
+        {
             let list = List::new(items.to_owned()).highlight_symbol(">>");
             let mut state = ListState::default().with_selected(selected);
             let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 5));
-
             StatefulWidget::render(list, buffer.area, &mut buffer, &mut state);
-
-            let expected = Buffer::with_lines(expected_lines);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, Buffer::with_lines(expected));
         }
 
-        let empty_items: Vec<ListItem> = Vec::new();
-        let single_item = list_items(vec!["Item 0"]);
-        let multiple_items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-        let multi_line_items = list_items(vec!["Item 0\nLine 2", "Item 1", "Item 2"]);
+        let empty_items = Vec::new();
+        let single_item = vec!["Item 0".into()];
+        let multiple_items = vec!["Item 0".into(), "Item 1".into(), "Item 2".into()];
+        let multi_line_items = vec!["Item 0\nLine 2".into(), "Item 1".into(), "Item 2".into()];
 
         // empty list
         test_case_render(
             &empty_items,
-            vec![
+            [
                 "          ",
                 "          ",
                 "          ",
@@ -1289,7 +1286,7 @@ mod tests {
         test_case_render_stateful(
             &empty_items,
             None,
-            vec![
+            [
                 "          ",
                 "          ",
                 "          ",
@@ -1300,7 +1297,7 @@ mod tests {
         test_case_render_stateful(
             &empty_items,
             Some(0),
-            vec![
+            [
                 "          ",
                 "          ",
                 "          ",
@@ -1312,7 +1309,7 @@ mod tests {
         // single item
         test_case_render(
             &single_item,
-            vec![
+            [
                 "Item 0    ",
                 "          ",
                 "          ",
@@ -1323,7 +1320,7 @@ mod tests {
         test_case_render_stateful(
             &single_item,
             None,
-            vec![
+            [
                 "Item 0    ",
                 "          ",
                 "          ",
@@ -1334,7 +1331,7 @@ mod tests {
         test_case_render_stateful(
             &single_item,
             Some(0),
-            vec![
+            [
                 ">>Item 0  ",
                 "          ",
                 "          ",
@@ -1345,7 +1342,7 @@ mod tests {
         test_case_render_stateful(
             &single_item,
             Some(1),
-            vec![
+            [
                 "  Item 0  ",
                 "          ",
                 "          ",
@@ -1357,7 +1354,7 @@ mod tests {
         // multiple items
         test_case_render(
             &multiple_items,
-            vec![
+            [
                 "Item 0    ",
                 "Item 1    ",
                 "Item 2    ",
@@ -1368,7 +1365,7 @@ mod tests {
         test_case_render_stateful(
             &multiple_items,
             None,
-            vec![
+            [
                 "Item 0    ",
                 "Item 1    ",
                 "Item 2    ",
@@ -1379,7 +1376,7 @@ mod tests {
         test_case_render_stateful(
             &multiple_items,
             Some(0),
-            vec![
+            [
                 ">>Item 0  ",
                 "  Item 1  ",
                 "  Item 2  ",
@@ -1390,7 +1387,7 @@ mod tests {
         test_case_render_stateful(
             &multiple_items,
             Some(1),
-            vec![
+            [
                 "  Item 0  ",
                 ">>Item 1  ",
                 "  Item 2  ",
@@ -1401,7 +1398,7 @@ mod tests {
         test_case_render_stateful(
             &multiple_items,
             Some(3),
-            vec![
+            [
                 "  Item 0  ",
                 "  Item 1  ",
                 "  Item 2  ",
@@ -1413,7 +1410,7 @@ mod tests {
         // multi line items
         test_case_render(
             &multi_line_items,
-            vec![
+            [
                 "Item 0    ",
                 "Line 2    ",
                 "Item 1    ",
@@ -1424,7 +1421,7 @@ mod tests {
         test_case_render_stateful(
             &multi_line_items,
             None,
-            vec![
+            [
                 "Item 0    ",
                 "Line 2    ",
                 "Item 1    ",
@@ -1435,7 +1432,7 @@ mod tests {
         test_case_render_stateful(
             &multi_line_items,
             Some(0),
-            vec![
+            [
                 ">>Item 0  ",
                 "  Line 2  ",
                 "  Item 1  ",
@@ -1446,7 +1443,7 @@ mod tests {
         test_case_render_stateful(
             &multi_line_items,
             Some(1),
-            vec![
+            [
                 "  Item 0  ",
                 "  Line 2  ",
                 ">>Item 1  ",
@@ -1459,25 +1456,23 @@ mod tests {
     #[test]
     fn test_list_items_setter() {
         let list = List::default().items(["Item 0", "Item 1", "Item 2"]);
-        assert_buffer_eq!(
-            render_widget(list, 10, 5),
-            Buffer::with_lines(vec![
-                "Item 0    ",
-                "Item 1    ",
-                "Item 2    ",
-                "          ",
-                "          ",
-            ])
-        );
+        let buffer = render_widget(list, 10, 5);
+        let expected = Buffer::with_lines([
+            "Item 0    ",
+            "Item 1    ",
+            "Item 2    ",
+            "          ",
+            "          ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_list_with_empty_strings() {
-        let items = list_items(vec!["Item 0", "", "", "Item 1", "Item 2"]);
-        let list = List::new(items).block(Block::bordered().title("List"));
+        let list = List::new(["Item 0", "", "", "Item 1", "Item 2"])
+            .block(Block::bordered().title("List"));
         let buffer = render_widget(list, 10, 7);
-
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "┌List────┐",
             "│Item 0  │",
             "│        │",
@@ -1486,7 +1481,7 @@ mod tests {
             "│Item 2  │",
             "└────────┘",
         ]);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
@@ -1498,11 +1493,9 @@ mod tests {
 
     #[test]
     fn test_list_block() {
-        let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-        let list = List::new(items).block(Block::bordered().title("List"));
+        let list = List::new(["Item 0", "Item 1", "Item 2"]).block(Block::bordered().title("List"));
         let buffer = render_widget(list, 10, 7);
-
-        let expected = Buffer::with_lines(vec![
+        let expected = Buffer::with_lines([
             "┌List────┐",
             "│Item 0  │",
             "│Item 1  │",
@@ -1511,84 +1504,72 @@ mod tests {
             "│        │",
             "└────────┘",
         ]);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_list_style() {
-        let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-        let list = List::new(items).style(Style::default().fg(Color::Red));
-
-        assert_buffer_eq!(
-            render_widget(list, 10, 5),
-            Buffer::with_lines(vec![
-                "Item 0    ".red(),
-                "Item 1    ".red(),
-                "Item 2    ".red(),
-                "          ".red(),
-                "          ".red(),
-            ])
-        );
+        let list = List::new(["Item 0", "Item 1", "Item 2"]).style(Style::default().fg(Color::Red));
+        let buffer = render_widget(list, 10, 5);
+        let expected = Buffer::with_lines([
+            "Item 0    ".red(),
+            "Item 1    ".red(),
+            "Item 2    ".red(),
+            "          ".red(),
+            "          ".red(),
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_list_highlight_symbol_and_style() {
-        let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-        let list = List::new(items)
+        let list = List::new(["Item 0", "Item 1", "Item 2"])
             .highlight_symbol(">>")
             .highlight_style(Style::default().fg(Color::Yellow));
         let mut state = ListState::default();
         state.select(Some(1));
-
-        assert_buffer_eq!(
-            render_stateful_widget(list, &mut state, 10, 5),
-            Buffer::with_lines(vec![
-                "  Item 0  ".into(),
-                ">>Item 1  ".yellow(),
-                "  Item 2  ".into(),
-                "          ".into(),
-                "          ".into(),
-            ])
-        );
+        let buffer = render_stateful_widget(list, &mut state, 10, 5);
+        let expected = Buffer::with_lines([
+            "  Item 0  ".into(),
+            ">>Item 1  ".yellow(),
+            "  Item 2  ".into(),
+            "          ".into(),
+            "          ".into(),
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_list_highlight_spacing_default_whenselected() {
         // when not selected
         {
-            let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-            let list = List::new(items).highlight_symbol(">>");
+            let list = List::new(["Item 0", "Item 1", "Item 2"]).highlight_symbol(">>");
             let mut state = ListState::default();
-
             let buffer = render_stateful_widget(list, &mut state, 10, 5);
-
-            let expected = Buffer::with_lines(vec![
+            let expected = Buffer::with_lines([
                 "Item 0    ",
                 "Item 1    ",
                 "Item 2    ",
                 "          ",
                 "          ",
             ]);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, expected);
         }
 
         // when selected
         {
-            let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-            let list = List::new(items).highlight_symbol(">>");
+            let list = List::new(["Item 0", "Item 1", "Item 2"]).highlight_symbol(">>");
             let mut state = ListState::default();
             state.select(Some(1));
-
             let buffer = render_stateful_widget(list, &mut state, 10, 5);
-
-            let expected = Buffer::with_lines(vec![
+            let expected = Buffer::with_lines([
                 "  Item 0  ",
                 ">>Item 1  ",
                 "  Item 2  ",
                 "          ",
                 "          ",
             ]);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, expected);
         }
     }
 
@@ -1596,43 +1577,37 @@ mod tests {
     fn test_list_highlight_spacing_default_always() {
         // when not selected
         {
-            let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-            let list = List::new(items)
+            let list = List::new(["Item 0", "Item 1", "Item 2"])
                 .highlight_symbol(">>")
                 .highlight_spacing(HighlightSpacing::Always);
             let mut state = ListState::default();
-
             let buffer = render_stateful_widget(list, &mut state, 10, 5);
-
-            let expected = Buffer::with_lines(vec![
+            let expected = Buffer::with_lines([
                 "  Item 0  ",
                 "  Item 1  ",
                 "  Item 2  ",
                 "          ",
                 "          ",
             ]);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, expected);
         }
 
         // when selected
         {
-            let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-            let list = List::new(items)
+            let list = List::new(["Item 0", "Item 1", "Item 2"])
                 .highlight_symbol(">>")
                 .highlight_spacing(HighlightSpacing::Always);
             let mut state = ListState::default();
             state.select(Some(1));
-
             let buffer = render_stateful_widget(list, &mut state, 10, 5);
-
-            let expected = Buffer::with_lines(vec![
+            let expected = Buffer::with_lines([
                 "  Item 0  ",
                 ">>Item 1  ",
                 "  Item 2  ",
                 "          ",
                 "          ",
             ]);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, expected);
         }
     }
 
@@ -1640,194 +1615,177 @@ mod tests {
     fn test_list_highlight_spacing_default_never() {
         // when not selected
         {
-            let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-            let list = List::new(items)
+            let list = List::new(["Item 0", "Item 1", "Item 2"])
                 .highlight_symbol(">>")
                 .highlight_spacing(HighlightSpacing::Never);
             let mut state = ListState::default();
-
             let buffer = render_stateful_widget(list, &mut state, 10, 5);
-
-            let expected = Buffer::with_lines(vec![
+            let expected = Buffer::with_lines([
                 "Item 0    ",
                 "Item 1    ",
                 "Item 2    ",
                 "          ",
                 "          ",
             ]);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, expected);
         }
 
         // when selected
         {
-            let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-            let list = List::new(items)
+            let list = List::new(["Item 0", "Item 1", "Item 2"])
                 .highlight_symbol(">>")
                 .highlight_spacing(HighlightSpacing::Never);
             let mut state = ListState::default();
             state.select(Some(1));
-
             let buffer = render_stateful_widget(list, &mut state, 10, 5);
-
-            let expected = Buffer::with_lines(vec![
+            let expected = Buffer::with_lines([
                 "Item 0    ",
                 "Item 1    ",
                 "Item 2    ",
                 "          ",
                 "          ",
             ]);
-            assert_buffer_eq!(buffer, expected);
+            assert_eq!(buffer, expected);
         }
     }
 
     #[test]
     fn test_list_repeat_highlight_symbol() {
-        let items = list_items(vec!["Item 0\nLine 2", "Item 1", "Item 2"]);
-        let list = List::new(items)
+        let list = List::new(["Item 0\nLine 2", "Item 1", "Item 2"])
             .highlight_symbol(">>")
             .highlight_style(Style::default().fg(Color::Yellow))
             .repeat_highlight_symbol(true);
         let mut state = ListState::default();
         state.select(Some(0));
-
-        assert_buffer_eq!(
-            render_stateful_widget(list, &mut state, 10, 5),
-            Buffer::with_lines(vec![
-                ">>Item 0  ".yellow(),
-                ">>Line 2  ".yellow(),
-                "  Item 1  ".into(),
-                "  Item 2  ".into(),
-                "          ".into(),
-            ])
-        );
-    }
-
-    #[test]
-    fn test_list_direction_top_to_bottom() {
-        let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-        let list = List::new(items).direction(ListDirection::TopToBottom);
-        let buffer = render_widget(list, 10, 5);
-        let expected = Buffer::with_lines(vec![
-            "Item 0    ",
-            "Item 1    ",
-            "Item 2    ",
-            "          ",
-            "          ",
+        let buffer = render_stateful_widget(list, &mut state, 10, 5);
+        let expected = Buffer::with_lines([
+            ">>Item 0  ".yellow(),
+            ">>Line 2  ".yellow(),
+            "  Item 1  ".into(),
+            "  Item 2  ".into(),
+            "          ".into(),
         ]);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, expected);
     }
 
-    #[test]
-    fn test_list_direction_bottom_to_top() {
-        let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-        let list = List::new(items).direction(ListDirection::BottomToTop);
-        let buffer = render_widget(list, 10, 5);
-        let expected = Buffer::with_lines(vec![
-            "          ",
-            "          ",
-            "Item 2    ",
-            "Item 1    ",
-            "Item 0    ",
-        ]);
-        assert_buffer_eq!(buffer, expected);
+    #[rstest]
+    #[case::top_to_bottom(ListDirection::TopToBottom, [
+        "Item 0    ",
+        "Item 1    ",
+        "Item 2    ",
+        "          ",
+    ])]
+    #[case::top_to_bottom(ListDirection::BottomToTop, [
+        "          ",
+        "Item 2    ",
+        "Item 1    ",
+        "Item 0    ",
+    ])]
+    fn list_direction<'line, Lines>(#[case] direction: ListDirection, #[case] expected: Lines)
+    where
+        Lines: IntoIterator,
+        Lines::Item: Into<Line<'line>>,
+    {
+        let list = List::new(["Item 0", "Item 1", "Item 2"]).direction(direction);
+        let buffer = render_widget(list, 10, 4);
+        assert_eq!(buffer, Buffer::with_lines(expected));
     }
 
-    #[test]
-    fn test_list_start_corner_top_left() {
-        let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
+    #[rstest]
+    #[case::topleft(Corner::TopLeft, [
+        "Item 0    ",
+        "Item 1    ",
+        "Item 2    ",
+        "          ",
+    ])]
+    #[case::bottomleft(Corner::BottomLeft, [
+        "          ",
+        "Item 2    ",
+        "Item 1    ",
+        "Item 0    ",
+    ])]
+    fn start_corner<'line, Lines>(#[case] corner: Corner, #[case] expected: Lines)
+    where
+        Lines: IntoIterator,
+        Lines::Item: Into<Line<'line>>,
+    {
         #[allow(deprecated)] // For start_corner
-        let list = List::new(items).start_corner(Corner::TopLeft);
-        let buffer = render_widget(list, 10, 5);
-        let expected = Buffer::with_lines(vec![
-            "Item 0    ",
-            "Item 1    ",
-            "Item 2    ",
-            "          ",
-            "          ",
-        ]);
-        assert_buffer_eq!(buffer, expected);
-    }
-
-    #[test]
-    fn test_list_start_corner_bottom_left() {
-        let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-        #[allow(deprecated)] // For start_corner
-        let list = List::new(items).start_corner(Corner::BottomLeft);
-        let buffer = render_widget(list, 10, 5);
-        let expected = Buffer::with_lines(vec![
-            "          ",
-            "          ",
-            "Item 2    ",
-            "Item 1    ",
-            "Item 0    ",
-        ]);
-        assert_buffer_eq!(buffer, expected);
+        let list = List::new(["Item 0", "Item 1", "Item 2"]).start_corner(corner);
+        let buffer = render_widget(list, 10, 4);
+        assert_eq!(buffer, Buffer::with_lines(expected));
     }
 
     #[test]
     fn test_list_truncate_items() {
-        let items = list_items(vec!["Item 0", "Item 1", "Item 2", "Item 3", "Item 4"]);
-        let list = List::new(items);
+        let list = List::new(["Item 0", "Item 1", "Item 2", "Item 3", "Item 4"]);
         let buffer = render_widget(list, 10, 3);
-        let expected = Buffer::with_lines(vec!["Item 0    ", "Item 1    ", "Item 2    "]);
-        assert_buffer_eq!(buffer, expected);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "Item 0    ",
+            "Item 1    ",
+            "Item 2    ",
+        ]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_offset_renders_shifted() {
-        let items = list_items(vec![
+        let list = List::new([
             "Item 0", "Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6",
         ]);
-        let list = List::new(items);
         let mut state = ListState::default().with_offset(3);
         let buffer = render_stateful_widget(list, &mut state, 6, 3);
 
-        let expected = Buffer::with_lines(vec!["Item 3", "Item 4", "Item 5"]);
-        assert_buffer_eq!(buffer, expected);
+        let expected = Buffer::with_lines(["Item 3", "Item 4", "Item 5"]);
+        assert_eq!(buffer, expected);
     }
 
-    #[test]
-    fn test_list_long_lines() {
-        fn test_case(list: List, selected: Option<usize>, expected_lines: Vec<&str>) {
-            let mut state = ListState::default();
-            state.select(selected);
-            let buffer = render_stateful_widget(list, &mut state, 15, 3);
-            let expected = Buffer::with_lines(expected_lines);
-            assert_buffer_eq!(buffer, expected);
-        }
-
-        let items = list_items(vec![
+    #[rstest]
+    #[case(None, [
+        "Item 0 with a v",
+        "Item 1         ",
+        "Item 2         ",
+    ])]
+    #[case(Some(0), [
+        ">>Item 0 with a",
+        "  Item 1       ",
+        "  Item 2       ",
+    ])]
+    fn test_list_long_lines<'line, Lines>(#[case] selected: Option<usize>, #[case] expected: Lines)
+    where
+        Lines: IntoIterator,
+        Lines::Item: Into<Line<'line>>,
+    {
+        let items = [
             "Item 0 with a very long line that will be truncated",
             "Item 1",
             "Item 2",
-        ]);
+        ];
         let list = List::new(items).highlight_symbol(">>");
-
-        test_case(
-            list.clone(),
-            None,
-            vec!["Item 0 with a v", "Item 1         ", "Item 2         "],
-        );
-        test_case(
-            list,
-            Some(0),
-            vec![">>Item 0 with a", "  Item 1       ", "  Item 2       "],
-        );
+        let mut state = ListState::default().with_selected(selected);
+        let buffer = render_stateful_widget(list, &mut state, 15, 3);
+        assert_eq!(buffer, Buffer::with_lines(expected));
     }
 
     #[test]
     fn test_list_selected_item_ensures_selected_item_is_visible_when_offset_is_before_visible_range(
     ) {
-        let items = list_items(vec![
+        let items = [
             "Item 0", "Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6",
-        ]);
+        ];
         let list = List::new(items).highlight_symbol(">>");
         // Set the initial visible range to items 3, 4, and 5
         let mut state = ListState::default().with_selected(Some(1)).with_offset(3);
         let buffer = render_stateful_widget(list, &mut state, 10, 3);
 
-        let expected = Buffer::with_lines(vec![">>Item 1  ", "  Item 2  ", "  Item 3  "]);
-        assert_buffer_eq!(buffer, expected);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            ">>Item 1  ",
+            "  Item 2  ",
+            "  Item 3  ",
+        ]);
+
+        assert_eq!(buffer, expected);
         assert_eq!(state.selected, Some(1));
         assert_eq!(
             state.offset, 1,
@@ -1838,16 +1796,22 @@ mod tests {
     #[test]
     fn test_list_selected_item_ensures_selected_item_is_visible_when_offset_is_after_visible_range()
     {
-        let items = list_items(vec![
+        let items = [
             "Item 0", "Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6",
-        ]);
+        ];
         let list = List::new(items).highlight_symbol(">>");
         // Set the initial visible range to items 3, 4, and 5
         let mut state = ListState::default().with_selected(Some(6)).with_offset(3);
         let buffer = render_stateful_widget(list, &mut state, 10, 3);
 
-        let expected = Buffer::with_lines(vec!["  Item 4  ", "  Item 5  ", ">>Item 6  "]);
-        assert_buffer_eq!(buffer, expected);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines([
+            "  Item 4  ",
+            "  Item 5  ",
+            ">>Item 6  ",
+        ]);
+
+        assert_eq!(buffer, expected);
         assert_eq!(state.selected, Some(6));
         assert_eq!(
             state.offset, 4,
@@ -1886,155 +1850,99 @@ mod tests {
 
     #[test]
     fn test_render_list_with_alignment() {
-        let items = [
+        let list = List::new([
             Line::from("Left").alignment(Alignment::Left),
             Line::from("Center").alignment(Alignment::Center),
             Line::from("Right").alignment(Alignment::Right),
-        ]
-        .into_iter()
-        .map(ListItem::new)
-        .collect::<Vec<ListItem>>();
-        let list = List::new(items);
-        let buffer = render_widget(list, 10, 5);
-        let expected = Buffer::with_lines(vec![
-            "Left      ",
-            "  Center  ",
-            "     Right",
-            "          ",
-            "          ",
         ]);
-        assert_buffer_eq!(buffer, expected);
+        let buffer = render_widget(list, 10, 4);
+        let expected = Buffer::with_lines(["Left      ", "  Center  ", "     Right", ""]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_render_list_alignment_odd_line_odd_area() {
-        let items = [
+        let list = List::new([
             Line::from("Odd").alignment(Alignment::Left),
             Line::from("Even").alignment(Alignment::Center),
             Line::from("Width").alignment(Alignment::Right),
-        ]
-        .into_iter()
-        .map(ListItem::new)
-        .collect::<Vec<ListItem>>();
-        let list = List::new(items);
-        let buffer = render_widget(list, 7, 5);
-        let expected =
-            Buffer::with_lines(vec!["Odd    ", " Even  ", "  Width", "       ", "       "]);
-        assert_buffer_eq!(buffer, expected);
+        ]);
+        let buffer = render_widget(list, 7, 4);
+        let expected = Buffer::with_lines(["Odd    ", " Even  ", "  Width", ""]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_render_list_alignment_even_line_even_area() {
-        let items = [
+        let list = List::new([
             Line::from("Odd").alignment(Alignment::Left),
             Line::from("Even").alignment(Alignment::Center),
             Line::from("Width").alignment(Alignment::Right),
-        ]
-        .into_iter()
-        .map(ListItem::new)
-        .collect::<Vec<ListItem>>();
-        let list = List::new(items);
+        ]);
         let buffer = render_widget(list, 6, 4);
-        let expected = Buffer::with_lines(vec!["Odd   ", " Even ", " Width", "      "]);
-        assert_buffer_eq!(buffer, expected);
+        let expected = Buffer::with_lines(["Odd   ", " Even ", " Width", ""]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_render_list_alignment_odd_line_even_area() {
-        let items = [
+        let list = List::new([
             Line::from("Odd").alignment(Alignment::Left),
             Line::from("Even").alignment(Alignment::Center),
             Line::from("Width").alignment(Alignment::Right),
-        ]
-        .into_iter()
-        .map(ListItem::new)
-        .collect::<Vec<ListItem>>();
-        let list = List::new(items);
+        ]);
         let buffer = render_widget(list, 8, 4);
-        let expected = Buffer::with_lines(vec!["Odd     ", "  Even  ", "   Width", "        "]);
-        assert_buffer_eq!(buffer, expected);
+        let expected = Buffer::with_lines(["Odd     ", "  Even  ", "   Width", ""]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_render_list_alignment_even_line_odd_area() {
-        let items = [
+        let list = List::new([
             Line::from("Odd").alignment(Alignment::Left),
             Line::from("Even").alignment(Alignment::Center),
             Line::from("Width").alignment(Alignment::Right),
-        ]
-        .into_iter()
-        .map(ListItem::new)
-        .collect::<Vec<ListItem>>();
-        let list = List::new(items);
-        let buffer = render_widget(list, 6, 5);
-        let expected = Buffer::with_lines(vec!["Odd   ", " Even ", " Width", "     ", "     "]);
-        assert_buffer_eq!(buffer, expected);
+        ]);
+        let buffer = render_widget(list, 6, 4);
+        let expected = Buffer::with_lines(["Odd   ", " Even ", " Width", ""]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_render_list_alignment_zero_line_width() {
-        let items = [Line::from("This line has zero width").alignment(Alignment::Center)]
-            .into_iter()
-            .map(ListItem::new)
-            .collect::<Vec<ListItem>>();
-        let list = List::new(items);
-        let buffer = render_widget(list, 0, 5);
-        let expected = Buffer::with_lines(vec!["", "", "", "", ""]);
-        assert_buffer_eq!(buffer, expected);
+        let list = List::new([Line::from("This line has zero width").alignment(Alignment::Center)]);
+        let buffer = render_widget(list, 0, 2);
+        assert_eq!(buffer, Buffer::with_lines([""; 2]));
     }
 
     #[test]
     fn test_render_list_alignment_zero_area_width() {
-        let items = [Line::from("Text").alignment(Alignment::Left)]
-            .into_iter()
-            .map(ListItem::new)
-            .collect::<Vec<ListItem>>();
-        let list = List::new(items);
-        // assert_buffer_eq! doesn't handle zero height buffers so we call this test manually
-        // rather than using render_widget
+        let list = List::new([Line::from("Text").alignment(Alignment::Left)]);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
         Widget::render(list, Rect::new(0, 0, 4, 0), &mut buffer);
-        let expected = Buffer::with_lines(vec!["    "]);
-        assert_buffer_eq!(buffer, expected);
+        assert_eq!(buffer, Buffer::with_lines(["    "]));
     }
 
     #[test]
     fn test_render_list_alignment_line_less_than_width() {
-        let items = [Line::from("Small").alignment(Alignment::Center)];
-        let list = List::new(items);
-        let buffer = render_widget(list, 10, 5);
-        let expected = Buffer::with_lines(vec![
-            "  Small   ",
-            "          ",
-            "          ",
-            "          ",
-            "          ",
-        ]);
-        assert_buffer_eq!(buffer, expected);
+        let list = List::new([Line::from("Small").alignment(Alignment::Center)]);
+        let buffer = render_widget(list, 10, 2);
+        let expected = Buffer::with_lines(["  Small   ", ""]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]
     fn test_render_list_alignment_line_equal_to_width() {
-        let items = [Line::from("Exact").alignment(Alignment::Left)]
-            .into_iter()
-            .map(ListItem::new)
-            .collect::<Vec<ListItem>>();
-        let list = List::new(items);
-        let buffer = render_widget(list, 5, 3);
-        let expected = Buffer::with_lines(vec!["Exact", "     ", "     "]);
-        assert_buffer_eq!(buffer, expected);
+        let list = List::new([Line::from("Exact").alignment(Alignment::Left)]);
+        let buffer = render_widget(list, 5, 2);
+        assert_eq!(buffer, Buffer::with_lines(["Exact", ""]));
     }
 
     #[test]
     fn test_render_list_alignment_line_greater_than_width() {
-        let items = [Line::from("Large line").alignment(Alignment::Left)]
-            .into_iter()
-            .map(ListItem::new)
-            .collect::<Vec<ListItem>>();
-        let list = List::new(items);
-        let buffer = render_widget(list, 5, 3);
-        let expected = Buffer::with_lines(vec!["Large", "     ", "     "]);
-        assert_buffer_eq!(buffer, expected);
+        let list = List::new([Line::from("Large line").alignment(Alignment::Left)]);
+        let buffer = render_widget(list, 5, 2);
+        assert_eq!(buffer, Buffer::with_lines(["Large", ""]));
     }
 
     #[rstest]
@@ -2043,61 +1951,97 @@ mod tests {
         2, // Offset
         0, // Padding
         Some(2), // Selected
-        Buffer::with_lines(vec![">> Item 2 ", "   Item 3 ", "   Item 4 ", "   Item 5 "])
+        [
+            ">> Item 2 ",
+            "   Item 3 ",
+            "   Item 4 ",
+            "   Item 5 ",
+        ]
     )]
     #[case::one_before(
         4,
         2, // Offset
         1, // Padding
         Some(2), // Selected
-        Buffer::with_lines(vec!["   Item 1 ", ">> Item 2 ", "   Item 3 ", "   Item 4 "])
+        [
+            "   Item 1 ",
+            ">> Item 2 ",
+            "   Item 3 ",
+            "   Item 4 ",
+        ]
     )]
     #[case::one_after(
         4,
         1, // Offset
         1, // Padding
         Some(4), // Selected
-        Buffer::with_lines(vec!["   Item 2 ", "   Item 3 ", ">> Item 4 ", "   Item 5 "])
+        [
+            "   Item 2 ",
+            "   Item 3 ",
+            ">> Item 4 ",
+            "   Item 5 ",
+        ]
     )]
     #[case::check_padding_overflow(
         4,
         1, // Offset
         2, // Padding
         Some(4), // Selected
-        Buffer::with_lines(vec!["   Item 2 ", "   Item 3 ", ">> Item 4 ", "   Item 5 "])
+        [
+            "   Item 2 ",
+            "   Item 3 ",
+            ">> Item 4 ",
+            "   Item 5 ",
+        ]
     )]
     #[case::no_padding_offset_behavior(
         5, // Render Area Height
         2, // Offset
         0, // Padding
         Some(3), // Selected
-        Buffer::with_lines(
-            vec!["   Item 2 ", ">> Item 3 ", "   Item 4 ", "   Item 5 ", "          "]
-            )
+        [
+            "   Item 2 ",
+            ">> Item 3 ",
+            "   Item 4 ",
+            "   Item 5 ",
+            "          ",
+        ]
     )]
     #[case::two_before(
         5, // Render Area Height
         2, // Offset
         2, // Padding
         Some(3), // Selected
-        Buffer::with_lines(
-            vec!["   Item 1 ", "   Item 2 ", ">> Item 3 ", "   Item 4 ", "   Item 5 "]
-            )
+        [
+            "   Item 1 ",
+            "   Item 2 ",
+            ">> Item 3 ",
+            "   Item 4 ",
+            "   Item 5 ",
+        ]
     )]
     #[case::keep_selected_visible(
         4,
         0, // Offset
         4, // Padding
         Some(1), // Selected
-        Buffer::with_lines(vec!["   Item 0 ", ">> Item 1 ", "   Item 2 ", "   Item 3 "])
+        [
+            "   Item 0 ",
+            ">> Item 1 ",
+            "   Item 2 ",
+            "   Item 3 ",
+        ]
     )]
-    fn test_padding(
+    fn test_padding<'line, Lines>(
         #[case] render_height: u16,
         #[case] offset: usize,
         #[case] padding: usize,
         #[case] selected: Option<usize>,
-        #[case] expected: Buffer,
-    ) {
+        #[case] expected: Lines,
+    ) where
+        Lines: IntoIterator,
+        Lines::Item: Into<Line<'line>>,
+    {
         let backend = backend::TestBackend::new(10, render_height);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut state = ListState::default();
@@ -2105,26 +2049,16 @@ mod tests {
         *state.offset_mut() = offset;
         state.select(selected);
 
-        let items = vec![
-            ListItem::new("Item 0"),
-            ListItem::new("Item 1"),
-            ListItem::new("Item 2"),
-            ListItem::new("Item 3"),
-            ListItem::new("Item 4"),
-            ListItem::new("Item 5"),
-        ];
-        let list = List::new(items)
+        let list = List::new(["Item 0", "Item 1", "Item 2", "Item 3", "Item 4", "Item 5"])
             .scroll_padding(padding)
             .highlight_symbol(">> ");
-
         terminal
             .draw(|f| {
                 let size = f.size();
                 f.render_stateful_widget(list, size, &mut state);
             })
             .unwrap();
-
-        terminal.backend().assert_buffer(&expected);
+        terminal.backend().assert_buffer_lines(expected);
     }
 
     /// If there isn't enough room for the selected item and the requested padding the list can jump
@@ -2139,15 +2073,8 @@ mod tests {
         *state.offset_mut() = 2;
         state.select(Some(4));
 
-        let items = vec![
-            ListItem::new("Item 0"),
-            ListItem::new("Item 1"),
-            ListItem::new("Item 2"),
-            ListItem::new("Item 3"),
-            ListItem::new("Item 4"),
-            ListItem::new("Item 5"),
-            ListItem::new("Item 6"),
-            ListItem::new("Item 7"),
+        let items = [
+            "Item 0", "Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7",
         ];
         let list = List::new(items).scroll_padding(3).highlight_symbol(">> ");
 
@@ -2177,7 +2104,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut state = ListState::default().with_offset(0).with_selected(Some(3));
 
-        let items = vec![
+        let items = [
             ListItem::new("Item 0"),
             ListItem::new("Item 1"),
             ListItem::new("Item 2"),
@@ -2194,11 +2121,13 @@ mod tests {
             })
             .unwrap();
 
-        terminal.backend().assert_buffer(&Buffer::with_lines(vec![
+        #[rustfmt::skip]
+        let expected = [
             "   Item 1 ",
             "   Item 2 ",
             ">> Item 3 ",
-        ]));
+        ];
+        terminal.backend().assert_buffer_lines(expected);
     }
 
     // Tests to make sure when it's pushing back the first visible index value that it doesnt
@@ -2212,7 +2141,7 @@ mod tests {
         *state.offset_mut() = 1;
         state.select(Some(2));
 
-        let items = vec![
+        let items = [
             ListItem::new("Item 0\nTest\nTest"),
             ListItem::new("Item 1"),
             ListItem::new("Item 2"),
@@ -2227,12 +2156,12 @@ mod tests {
             })
             .unwrap();
 
-        terminal.backend().assert_buffer(&Buffer::with_lines(vec![
+        terminal.backend().assert_buffer_lines([
             "   Item 1 ",
             ">> Item 2 ",
             "   Item 3 ",
             "          ",
-        ]));
+        ]);
     }
 
     #[fixture]
@@ -2254,10 +2183,10 @@ mod tests {
         #[case] expected: &str,
         mut single_line_buf: Buffer,
     ) {
-        let list = List::new(vec![item]).highlight_symbol(highlight_symbol);
+        let list = List::new([item]).highlight_symbol(highlight_symbol);
         let mut state = ListState::default();
         state.select(Some(0));
         StatefulWidget::render(list, single_line_buf.area, &mut single_line_buf, &mut state);
-        assert_buffer_eq!(single_line_buf, Buffer::with_lines(vec![expected]));
+        assert_eq!(single_line_buf, Buffer::with_lines([expected]));
     }
 }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -414,73 +414,65 @@ mod test {
     /// area and comparing the rendered and expected content.
     /// This can be used for easy testing of varying configured paragraphs with the same expected
     /// buffer or any other test case really.
-    #[allow(clippy::needless_pass_by_value)]
-    fn test_case(paragraph: &Paragraph, expected: Buffer) {
+    #[track_caller]
+    fn test_case(paragraph: &Paragraph, expected: &Buffer) {
         let backend = TestBackend::new(expected.area.width, expected.area.height);
         let mut terminal = Terminal::new(backend).unwrap();
-
         terminal
             .draw(|f| {
                 let size = f.size();
                 f.render_widget(paragraph.clone(), size);
             })
             .unwrap();
-
-        terminal.backend().assert_buffer(&expected);
+        terminal.backend().assert_buffer(expected);
     }
 
     #[test]
     fn zero_width_char_at_end_of_line() {
         let line = "foo\0";
-        let paragraphs = vec![
+        for paragraph in [
             Paragraph::new(line),
             Paragraph::new(line).wrap(Wrap { trim: false }),
             Paragraph::new(line).wrap(Wrap { trim: true }),
-        ];
-
-        for paragraph in paragraphs {
-            test_case(&paragraph, Buffer::with_lines(vec!["foo"]));
-            test_case(&paragraph, Buffer::with_lines(vec!["foo   "]));
-            test_case(&paragraph, Buffer::with_lines(vec!["foo   ", "      "]));
-            test_case(&paragraph, Buffer::with_lines(vec!["foo", "   "]));
+        ] {
+            test_case(&paragraph, &Buffer::with_lines(["foo"]));
+            test_case(&paragraph, &Buffer::with_lines(["foo   "]));
+            test_case(&paragraph, &Buffer::with_lines(["foo   ", "      "]));
+            test_case(&paragraph, &Buffer::with_lines(["foo", "   "]));
         }
     }
 
     #[test]
     fn test_render_empty_paragraph() {
-        let paragraphs = vec![
+        for paragraph in [
             Paragraph::new(""),
             Paragraph::new("").wrap(Wrap { trim: false }),
             Paragraph::new("").wrap(Wrap { trim: true }),
-        ];
-
-        for paragraph in paragraphs {
-            test_case(&paragraph, Buffer::with_lines(vec![" "]));
-            test_case(&paragraph, Buffer::with_lines(vec!["          "]));
-            test_case(&paragraph, Buffer::with_lines(vec!["     "; 10]));
-            test_case(&paragraph, Buffer::with_lines(vec![" ", " "]));
+        ] {
+            test_case(&paragraph, &Buffer::with_lines([" "]));
+            test_case(&paragraph, &Buffer::with_lines(["          "]));
+            test_case(&paragraph, &Buffer::with_lines(["     "; 10]));
+            test_case(&paragraph, &Buffer::with_lines([" ", " "]));
         }
     }
 
     #[test]
     fn test_render_single_line_paragraph() {
         let text = "Hello, world!";
-        let truncated_paragraph = Paragraph::new(text);
-        let wrapped_paragraph = Paragraph::new(text).wrap(Wrap { trim: false });
-        let trimmed_paragraph = Paragraph::new(text).wrap(Wrap { trim: true });
-
-        let paragraphs = vec![&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph];
-
-        for paragraph in paragraphs {
-            test_case(paragraph, Buffer::with_lines(vec!["Hello, world!  "]));
-            test_case(paragraph, Buffer::with_lines(vec!["Hello, world!"]));
+        for paragraph in [
+            Paragraph::new(text),
+            Paragraph::new(text).wrap(Wrap { trim: false }),
+            Paragraph::new(text).wrap(Wrap { trim: true }),
+        ] {
+            test_case(&paragraph, &Buffer::with_lines(["Hello, world!  "]));
+            test_case(&paragraph, &Buffer::with_lines(["Hello, world!"]));
             test_case(
-                paragraph,
-                Buffer::with_lines(vec!["Hello, world!  ", "               "]),
+                &paragraph,
+                &Buffer::with_lines(["Hello, world!  ", "               "]),
             );
             test_case(
-                paragraph,
-                Buffer::with_lines(vec!["Hello, world!", "             "]),
+                &paragraph,
+                &Buffer::with_lines(["Hello, world!", "             "]),
             );
         }
     }
@@ -488,29 +480,22 @@ mod test {
     #[test]
     fn test_render_multi_line_paragraph() {
         let text = "This is a\nmultiline\nparagraph.";
-
-        let paragraphs = vec![
+        for paragraph in [
             Paragraph::new(text),
             Paragraph::new(text).wrap(Wrap { trim: false }),
             Paragraph::new(text).wrap(Wrap { trim: true }),
-        ];
-
-        for paragraph in paragraphs {
+        ] {
             test_case(
                 &paragraph,
-                Buffer::with_lines(vec!["This is a ", "multiline ", "paragraph."]),
+                &Buffer::with_lines(["This is a ", "multiline ", "paragraph."]),
             );
             test_case(
                 &paragraph,
-                Buffer::with_lines(vec![
-                    "This is a      ",
-                    "multiline      ",
-                    "paragraph.     ",
-                ]),
+                &Buffer::with_lines(["This is a      ", "multiline      ", "paragraph.     "]),
             );
             test_case(
                 &paragraph,
-                Buffer::with_lines(vec![
+                &Buffer::with_lines([
                     "This is a      ",
                     "multiline      ",
                     "paragraph.     ",
@@ -530,12 +515,11 @@ mod test {
         let wrapped_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: false });
         let trimmed_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: true });
 
-        let paragraphs = vec![&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph];
-
-        for paragraph in paragraphs {
+        for paragraph in [&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph] {
+            #[rustfmt::skip]
             test_case(
                 paragraph,
-                Buffer::with_lines(vec![
+                &Buffer::with_lines([
                     "┌Title─────────┐",
                     "│Hello, worlds!│",
                     "└──────────────┘",
@@ -543,7 +527,7 @@ mod test {
             );
             test_case(
                 paragraph,
-                Buffer::with_lines(vec![
+                &Buffer::with_lines([
                     "┌Title───────────┐",
                     "│Hello, worlds!  │",
                     "└────────────────┘",
@@ -551,7 +535,7 @@ mod test {
             );
             test_case(
                 paragraph,
-                Buffer::with_lines(vec![
+                &Buffer::with_lines([
                     "┌Title────────────┐",
                     "│Hello, worlds!   │",
                     "│                 │",
@@ -562,7 +546,7 @@ mod test {
 
         test_case(
             &truncated_paragraph,
-            Buffer::with_lines(vec![
+            &Buffer::with_lines([
                 "┌Title───────┐",
                 "│Hello, world│",
                 "│            │",
@@ -571,7 +555,7 @@ mod test {
         );
         test_case(
             &wrapped_paragraph,
-            Buffer::with_lines(vec![
+            &Buffer::with_lines([
                 "┌Title──────┐",
                 "│Hello,     │",
                 "│worlds!    │",
@@ -580,7 +564,7 @@ mod test {
         );
         test_case(
             &trimmed_paragraph,
-            Buffer::with_lines(vec![
+            &Buffer::with_lines([
                 "┌Title──────┐",
                 "│Hello,     │",
                 "│worlds!    │",
@@ -598,29 +582,29 @@ mod test {
         let paragraph = Paragraph::new(vec![l0, l1, l2, l3]);
 
         let mut expected =
-            Buffer::with_lines(vec!["unformatted", "bold text", "cyan text", "dim text"]);
+            Buffer::with_lines(["unformatted", "bold text", "cyan text", "dim text"]);
         expected.set_style(Rect::new(0, 1, 9, 1), Style::new().bold());
         expected.set_style(Rect::new(0, 2, 9, 1), Style::new().cyan());
         expected.set_style(Rect::new(0, 3, 8, 1), Style::new().dim());
 
-        test_case(&paragraph, expected);
+        test_case(&paragraph, &expected);
     }
 
     #[test]
     fn test_render_line_spans_styled() {
-        let l0 = Line::default().spans(vec![
+        let l0 = Line::default().spans([
             Span::styled("bold", Style::new().bold()),
             Span::raw(" and "),
             Span::styled("cyan", Style::new().cyan()),
         ]);
-        let l1 = Line::default().spans(vec![Span::raw("unformatted")]);
+        let l1 = Line::default().spans([Span::raw("unformatted")]);
         let paragraph = Paragraph::new(vec![l0, l1]);
 
-        let mut expected = Buffer::with_lines(vec!["bold and cyan", "unformatted"]);
+        let mut expected = Buffer::with_lines(["bold and cyan", "unformatted"]);
         expected.set_style(Rect::new(0, 0, 4, 1), Style::new().bold());
         expected.set_style(Rect::new(9, 0, 4, 1), Style::new().cyan());
 
-        test_case(&paragraph, expected);
+        test_case(&paragraph, &expected);
     }
 
     #[test]
@@ -630,10 +614,9 @@ mod test {
             .title_position(Position::Bottom)
             .title("Title");
         let paragraph = Paragraph::new("Hello, world!").block(block);
-
         test_case(
             &paragraph,
-            Buffer::with_lines(vec!["Hello, world!  ", "Title──────────"]),
+            &Buffer::with_lines(["Hello, world!  ", "Title──────────"]),
         );
     }
 
@@ -645,7 +628,7 @@ mod test {
 
         test_case(
             &wrapped_paragraph,
-            Buffer::with_lines(vec![
+            &Buffer::with_lines([
                 "This is a long line",
                 "of text that should",
                 "wrap      and      ",
@@ -656,7 +639,7 @@ mod test {
         );
         test_case(
             &wrapped_paragraph,
-            Buffer::with_lines(vec![
+            &Buffer::with_lines([
                 "This is a   ",
                 "long line of",
                 "text that   ",
@@ -671,7 +654,7 @@ mod test {
 
         test_case(
             &trimmed_paragraph,
-            Buffer::with_lines(vec![
+            &Buffer::with_lines([
                 "This is a long line",
                 "of text that should",
                 "wrap      and      ",
@@ -682,7 +665,7 @@ mod test {
         );
         test_case(
             &trimmed_paragraph,
-            Buffer::with_lines(vec![
+            &Buffer::with_lines([
                 "This is a   ",
                 "long line of",
                 "text that   ",
@@ -703,19 +686,19 @@ mod test {
 
         test_case(
             &truncated_paragraph,
-            Buffer::with_lines(vec!["This is a long line of"]),
+            &Buffer::with_lines(["This is a long line of"]),
         );
         test_case(
             &truncated_paragraph,
-            Buffer::with_lines(vec!["This is a long line of te"]),
+            &Buffer::with_lines(["This is a long line of te"]),
         );
         test_case(
             &truncated_paragraph,
-            Buffer::with_lines(vec!["This is a long line of "]),
+            &Buffer::with_lines(["This is a long line of "]),
         );
         test_case(
             &truncated_paragraph.clone().scroll((0, 2)),
-            Buffer::with_lines(vec!["is is a long line of te"]),
+            &Buffer::with_lines(["is is a long line of te"]),
         );
     }
 
@@ -726,21 +709,19 @@ mod test {
         let wrapped_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: false });
         let trimmed_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: true });
 
-        let paragraphs = vec![&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph];
-
-        for paragraph in paragraphs {
-            test_case(paragraph, Buffer::with_lines(vec!["Hello, world!  "]));
-            test_case(paragraph, Buffer::with_lines(vec!["Hello, world!"]));
+        for paragraph in [&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph] {
+            test_case(paragraph, &Buffer::with_lines(["Hello, world!  "]));
+            test_case(paragraph, &Buffer::with_lines(["Hello, world!"]));
         }
 
-        test_case(&truncated_paragraph, Buffer::with_lines(vec!["Hello, wor"]));
+        test_case(&truncated_paragraph, &Buffer::with_lines(["Hello, wor"]));
         test_case(
             &wrapped_paragraph,
-            Buffer::with_lines(vec!["Hello,    ", "world!    "]),
+            &Buffer::with_lines(["Hello,    ", "world!    "]),
         );
         test_case(
             &trimmed_paragraph,
-            Buffer::with_lines(vec!["Hello,    ", "world!    "]),
+            &Buffer::with_lines(["Hello,    ", "world!    "]),
         );
     }
 
@@ -751,23 +732,21 @@ mod test {
         let wrapped_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: false });
         let trimmed_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: true });
 
-        let paragraphs = vec![&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph];
-
-        for paragraph in paragraphs {
-            test_case(paragraph, Buffer::with_lines(vec![" Hello, world! "]));
-            test_case(paragraph, Buffer::with_lines(vec!["  Hello, world! "]));
-            test_case(paragraph, Buffer::with_lines(vec!["  Hello, world!  "]));
-            test_case(paragraph, Buffer::with_lines(vec!["Hello, world!"]));
+        for paragraph in [&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph] {
+            test_case(paragraph, &Buffer::with_lines([" Hello, world! "]));
+            test_case(paragraph, &Buffer::with_lines(["  Hello, world! "]));
+            test_case(paragraph, &Buffer::with_lines(["  Hello, world!  "]));
+            test_case(paragraph, &Buffer::with_lines(["Hello, world!"]));
         }
 
-        test_case(&truncated_paragraph, Buffer::with_lines(vec!["Hello, wor"]));
+        test_case(&truncated_paragraph, &Buffer::with_lines(["Hello, wor"]));
         test_case(
             &wrapped_paragraph,
-            Buffer::with_lines(vec!["  Hello,  ", "  world!  "]),
+            &Buffer::with_lines(["  Hello,  ", "  world!  "]),
         );
         test_case(
             &trimmed_paragraph,
-            Buffer::with_lines(vec!["  Hello,  ", "  world!  "]),
+            &Buffer::with_lines(["  Hello,  ", "  world!  "]),
         );
     }
 
@@ -778,21 +757,19 @@ mod test {
         let wrapped_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: false });
         let trimmed_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: true });
 
-        let paragraphs = vec![&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph];
-
-        for paragraph in paragraphs {
-            test_case(paragraph, Buffer::with_lines(vec!["  Hello, world!"]));
-            test_case(paragraph, Buffer::with_lines(vec!["Hello, world!"]));
+        for paragraph in [&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph] {
+            test_case(paragraph, &Buffer::with_lines(["  Hello, world!"]));
+            test_case(paragraph, &Buffer::with_lines(["Hello, world!"]));
         }
 
-        test_case(&truncated_paragraph, Buffer::with_lines(vec!["Hello, wor"]));
+        test_case(&truncated_paragraph, &Buffer::with_lines(["Hello, wor"]));
         test_case(
             &wrapped_paragraph,
-            Buffer::with_lines(vec!["    Hello,", "    world!"]),
+            &Buffer::with_lines(["    Hello,", "    world!"]),
         );
         test_case(
             &trimmed_paragraph,
-            Buffer::with_lines(vec!["    Hello,", "    world!"]),
+            &Buffer::with_lines(["    Hello,", "    world!"]),
         );
     }
 
@@ -803,57 +780,51 @@ mod test {
         let wrapped_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: false });
         let trimmed_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: true });
 
-        let paragraphs = vec![&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph];
-
-        for paragraph in paragraphs {
+        for paragraph in [&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph] {
             test_case(
                 paragraph,
-                Buffer::with_lines(vec!["multiline   ", "paragraph.  ", "            "]),
+                &Buffer::with_lines(["multiline   ", "paragraph.  ", "            "]),
             );
-            test_case(paragraph, Buffer::with_lines(vec!["multiline   "]));
+            test_case(paragraph, &Buffer::with_lines(["multiline   "]));
         }
 
         test_case(
             &truncated_paragraph.clone().scroll((2, 4)),
-            Buffer::with_lines(vec!["iline   ", "graph.  "]),
+            &Buffer::with_lines(["iline   ", "graph.  "]),
         );
         test_case(
             &wrapped_paragraph,
-            Buffer::with_lines(vec!["cool   ", "multili", "ne     "]),
+            &Buffer::with_lines(["cool   ", "multili", "ne     "]),
         );
     }
 
     #[test]
     fn test_render_paragraph_with_zero_width_area() {
         let text = "Hello, world!";
+        let area = Rect::new(0, 0, 0, 3);
 
-        let paragraphs = vec![
+        for paragraph in [
             Paragraph::new(text),
             Paragraph::new(text).wrap(Wrap { trim: false }),
             Paragraph::new(text).wrap(Wrap { trim: true }),
-        ];
-
-        let area = Rect::new(0, 0, 0, 3);
-        for paragraph in paragraphs {
-            test_case(&paragraph, Buffer::empty(area));
-            test_case(&paragraph.clone().scroll((2, 4)), Buffer::empty(area));
+        ] {
+            test_case(&paragraph, &Buffer::empty(area));
+            test_case(&paragraph.clone().scroll((2, 4)), &Buffer::empty(area));
         }
     }
 
     #[test]
     fn test_render_paragraph_with_zero_height_area() {
         let text = "Hello, world!";
+        let area = Rect::new(0, 0, 10, 0);
 
-        let paragraphs = vec![
+        for paragraph in [
             Paragraph::new(text),
             Paragraph::new(text).wrap(Wrap { trim: false }),
             Paragraph::new(text).wrap(Wrap { trim: true }),
-        ];
-
-        let area = Rect::new(0, 0, 10, 0);
-        for paragraph in paragraphs {
-            test_case(&paragraph, Buffer::empty(area));
-            test_case(&paragraph.clone().scroll((2, 4)), Buffer::empty(area));
+        ] {
+            test_case(&paragraph, &Buffer::empty(area));
+            test_case(&paragraph.clone().scroll((2, 4)), &Buffer::empty(area));
         }
     }
 
@@ -864,13 +835,7 @@ mod test {
             Span::styled("world!", Style::default().fg(Color::Blue)),
         ]);
 
-        let paragraphs = vec![
-            Paragraph::new(text.clone()),
-            Paragraph::new(text.clone()).wrap(Wrap { trim: false }),
-            Paragraph::new(text.clone()).wrap(Wrap { trim: true }),
-        ];
-
-        let mut expected_buffer = Buffer::with_lines(vec!["Hello, world!"]);
+        let mut expected_buffer = Buffer::with_lines(["Hello, world!"]);
         expected_buffer.set_style(
             Rect::new(0, 0, 7, 1),
             Style::default().fg(Color::Red).bg(Color::Green),
@@ -879,10 +844,15 @@ mod test {
             Rect::new(7, 0, 6, 1),
             Style::default().fg(Color::Blue).bg(Color::Green),
         );
-        for paragraph in paragraphs {
+
+        for paragraph in [
+            Paragraph::new(text.clone()),
+            Paragraph::new(text.clone()).wrap(Wrap { trim: false }),
+            Paragraph::new(text.clone()).wrap(Wrap { trim: true }),
+        ] {
             test_case(
                 &paragraph.style(Style::default().bg(Color::Green)),
-                expected_buffer.clone(),
+                &expected_buffer,
             );
         }
     }
@@ -890,22 +860,20 @@ mod test {
     #[test]
     fn test_render_paragraph_with_special_characters() {
         let text = "Hello, <world>!";
-        let paragraphs = vec![
+        for paragraph in [
             Paragraph::new(text),
             Paragraph::new(text).wrap(Wrap { trim: false }),
             Paragraph::new(text).wrap(Wrap { trim: true }),
-        ];
-
-        for paragraph in paragraphs {
-            test_case(&paragraph, Buffer::with_lines(vec!["Hello, <world>!"]));
-            test_case(&paragraph, Buffer::with_lines(vec!["Hello, <world>!     "]));
+        ] {
+            test_case(&paragraph, &Buffer::with_lines(["Hello, <world>!"]));
+            test_case(&paragraph, &Buffer::with_lines(["Hello, <world>!     "]));
             test_case(
                 &paragraph,
-                Buffer::with_lines(vec!["Hello, <world>!     ", "                    "]),
+                &Buffer::with_lines(["Hello, <world>!     ", "                    "]),
             );
             test_case(
                 &paragraph,
-                Buffer::with_lines(vec!["Hello, <world>!", "               "]),
+                &Buffer::with_lines(["Hello, <world>!", "               "]),
             );
         }
     }
@@ -917,27 +885,25 @@ mod test {
         let wrapped_paragraph = Paragraph::new(text).wrap(Wrap { trim: false });
         let trimmed_paragraph = Paragraph::new(text).wrap(Wrap { trim: true });
 
-        let paragraphs = vec![&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph];
-
-        for paragraph in paragraphs {
-            test_case(paragraph, Buffer::with_lines(vec!["こんにちは, 世界! 😃"]));
+        for paragraph in [&truncated_paragraph, &wrapped_paragraph, &trimmed_paragraph] {
+            test_case(paragraph, &Buffer::with_lines(["こんにちは, 世界! 😃"]));
             test_case(
                 paragraph,
-                Buffer::with_lines(vec!["こんにちは, 世界! 😃     "]),
+                &Buffer::with_lines(["こんにちは, 世界! 😃     "]),
             );
         }
 
         test_case(
             &truncated_paragraph,
-            Buffer::with_lines(vec!["こんにちは, 世 "]),
+            &Buffer::with_lines(["こんにちは, 世 "]),
         );
         test_case(
             &wrapped_paragraph,
-            Buffer::with_lines(vec!["こんにちは,    ", "世界! 😃      "]),
+            &Buffer::with_lines(["こんにちは,    ", "世界! 😃      "]),
         );
         test_case(
             &trimmed_paragraph,
-            Buffer::with_lines(vec!["こんにちは,    ", "世界! 😃      "]),
+            &Buffer::with_lines(["こんにちは,    ", "世界! 😃      "]),
         );
     }
 
@@ -1025,13 +991,12 @@ mod test {
         let mut buf = Buffer::empty(Rect::new(0, 0, 20, 3));
         paragraph.render(Rect::new(0, 0, 20, 3), &mut buf);
 
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "┌──────────────────┐",
             "│Styled text       │",
             "└──────────────────┘",
         ]);
         expected.set_style(Rect::new(1, 1, 11, 1), Style::default().fg(Color::Green));
-
         assert_eq!(buf, expected);
     }
 }

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -674,113 +674,107 @@ mod tests {
     }
 
     #[rstest]
-    #[case("#-", 0, 2, "area 2, position_0")]
-    #[case("-#", 1, 2, "area 2, position_1")]
+    #[case::area_2_position_0("#-", 0, 2)]
+    #[case::area_2_position_1("-#", 1, 2)]
     fn render_scrollbar_simplest(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
         scrollbar_no_arrows: Scrollbar,
     ) {
         let mut buffer = Buffer::empty(Rect::new(0, 0, expected.width() as u16, 1));
         let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("#####-----", 0, 10, "position_0")]
-    #[case("-#####----", 1, 10, "position_1")]
-    #[case("-#####----", 2, 10, "position_2")]
-    #[case("--#####---", 3, 10, "position_3")]
-    #[case("--#####---", 4, 10, "position_4")]
-    #[case("---#####--", 5, 10, "position_5")]
-    #[case("---#####--", 6, 10, "position_6")]
-    #[case("----#####-", 7, 10, "position_7")]
-    #[case("----#####-", 8, 10, "position_8")]
-    #[case("-----#####", 9, 10, "position_9")]
+    #[case::position_0("#####-----", 0, 10)]
+    #[case::position_1("-#####----", 1, 10)]
+    #[case::position_2("-#####----", 2, 10)]
+    #[case::position_3("--#####---", 3, 10)]
+    #[case::position_4("--#####---", 4, 10)]
+    #[case::position_5("---#####--", 5, 10)]
+    #[case::position_6("---#####--", 6, 10)]
+    #[case::position_7("----#####-", 7, 10)]
+    #[case::position_8("----#####-", 8, 10)]
+    #[case::position_9("-----#####", 9, 10)]
     fn render_scrollbar_simple(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
         scrollbar_no_arrows: Scrollbar,
     ) {
         let mut buffer = Buffer::empty(Rect::new(0, 0, expected.width() as u16, 1));
         let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("          ", 0, 0, "position_0")]
+    #[case::position_0("          ", 0, 0)]
     fn render_scrollbar_nobar(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
         scrollbar_no_arrows: Scrollbar,
     ) {
         let size = expected.width();
         let mut buffer = Buffer::empty(Rect::new(0, 0, size as u16, 1));
         let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("##########", 0, 1, "fullbar position 0")]
-    #[case("#########-", 0, 2, "almost fullbar position 0")]
-    #[case("-#########", 1, 2, "almost fullbar position 1")]
+    #[case::fullbar_position_0("##########", 0, 1)]
+    #[case::almost_fullbar_position_0("#########-", 0, 2)]
+    #[case::almost_fullbar_position_1("-#########", 1, 2)]
     fn render_scrollbar_fullbar(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
         scrollbar_no_arrows: Scrollbar,
     ) {
         let size = expected.width();
         let mut buffer = Buffer::empty(Rect::new(0, 0, size as u16, 1));
         let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("#########-", 0, 2, "position_0")]
-    #[case("-#########", 1, 2, "position_1")]
+    #[case::position_0("#########-", 0, 2)]
+    #[case::position_1("-#########", 1, 2)]
     fn render_scrollbar_almost_fullbar(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
         scrollbar_no_arrows: Scrollbar,
     ) {
         let size = expected.width();
         let mut buffer = Buffer::empty(Rect::new(0, 0, size as u16, 1));
         let mut state = ScrollbarState::new(content_length).position(position);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}",);
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("█████═════", 0, 10, "position_0")]
-    #[case("═█████════", 1, 10, "position_1")]
-    #[case("═█████════", 2, 10, "position_2")]
-    #[case("══█████═══", 3, 10, "position_3")]
-    #[case("══█████═══", 4, 10, "position_4")]
-    #[case("═══█████══", 5, 10, "position_5")]
-    #[case("═══█████══", 6, 10, "position_6")]
-    #[case("════█████═", 7, 10, "position_7")]
-    #[case("════█████═", 8, 10, "position_8")]
-    #[case("═════█████", 9, 10, "position_9")]
-    #[case("═════█████", 100, 10, "position_out_of_bounds")]
+    #[case::position_0("█████═════", 0, 10)]
+    #[case::position_1("═█████════", 1, 10)]
+    #[case::position_2("═█████════", 2, 10)]
+    #[case::position_3("══█████═══", 3, 10)]
+    #[case::position_4("══█████═══", 4, 10)]
+    #[case::position_5("═══█████══", 5, 10)]
+    #[case::position_6("═══█████══", 6, 10)]
+    #[case::position_7("════█████═", 7, 10)]
+    #[case::position_8("════█████═", 8, 10)]
+    #[case::position_9("═════█████", 9, 10)]
+    #[case::position_out_of_bounds("═════█████", 100, 10)]
     fn render_scrollbar_without_symbols(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] assertion_message: &str,
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
@@ -789,30 +783,25 @@ mod tests {
             .begin_symbol(None)
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![expected]),
-            "{assertion_message}",
-        );
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("█████     ", 0, 10, "position_0")]
-    #[case(" █████    ", 1, 10, "position_1")]
-    #[case(" █████    ", 2, 10, "position_2")]
-    #[case("  █████   ", 3, 10, "position_3")]
-    #[case("  █████   ", 4, 10, "position_4")]
-    #[case("   █████  ", 5, 10, "position_5")]
-    #[case("   █████  ", 6, 10, "position_6")]
-    #[case("    █████ ", 7, 10, "position_7")]
-    #[case("    █████ ", 8, 10, "position_8")]
-    #[case("     █████", 9, 10, "position_9")]
-    #[case("     █████", 100, 10, "position_out_of_bounds")]
+    #[case::position_0("█████     ", 0, 10)]
+    #[case::position_1(" █████    ", 1, 10)]
+    #[case::position_2(" █████    ", 2, 10)]
+    #[case::position_3("  █████   ", 3, 10)]
+    #[case::position_4("  █████   ", 4, 10)]
+    #[case::position_5("   █████  ", 5, 10)]
+    #[case::position_6("   █████  ", 6, 10)]
+    #[case::position_7("    █████ ", 7, 10)]
+    #[case::position_8("    █████ ", 8, 10)]
+    #[case::position_9("     █████", 9, 10)]
+    #[case::position_out_of_bounds("     █████", 100, 10)]
     fn render_scrollbar_without_track_symbols(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] assertion_message: &str,
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
@@ -822,30 +811,25 @@ mod tests {
             .begin_symbol(None)
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![expected]),
-            "{assertion_message}",
-        );
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("█████-----", 0, 10, "position_0")]
-    #[case("-█████----", 1, 10, "position_1")]
-    #[case("-█████----", 2, 10, "position_2")]
-    #[case("--█████---", 3, 10, "position_3")]
-    #[case("--█████---", 4, 10, "position_4")]
-    #[case("---█████--", 5, 10, "position_5")]
-    #[case("---█████--", 6, 10, "position_6")]
-    #[case("----█████-", 7, 10, "position_7")]
-    #[case("----█████-", 8, 10, "position_8")]
-    #[case("-----█████", 9, 10, "position_9")]
-    #[case("-----█████", 100, 10, "position_out_of_bounds")]
+    #[case::position_0("█████-----", 0, 10)]
+    #[case::position_1("-█████----", 1, 10)]
+    #[case::position_2("-█████----", 2, 10)]
+    #[case::position_3("--█████---", 3, 10)]
+    #[case::position_4("--█████---", 4, 10)]
+    #[case::position_5("---█████--", 5, 10)]
+    #[case::position_6("---█████--", 6, 10)]
+    #[case::position_7("----█████-", 7, 10)]
+    #[case::position_8("----█████-", 8, 10)]
+    #[case::position_9("-----█████", 9, 10)]
+    #[case::position_out_of_bounds("-----█████", 100, 10)]
     fn render_scrollbar_without_track_symbols_over_content(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] assertion_message: &str,
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
@@ -858,32 +842,27 @@ mod tests {
             .begin_symbol(None)
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![expected]),
-            "{assertion_message}",
-        );
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("<####---->", 0, 10, "position_0")]
-    #[case("<#####--->", 1, 10, "position_1")]
-    #[case("<-####--->", 2, 10, "position_2")]
-    #[case("<-####--->", 3, 10, "position_3")]
-    #[case("<--####-->", 4, 10, "position_4")]
-    #[case("<--####-->", 5, 10, "position_5")]
-    #[case("<---####->", 6, 10, "position_6")]
-    #[case("<---####->", 7, 10, "position_7")]
-    #[case("<---#####>", 8, 10, "position_8")]
-    #[case("<----####>", 9, 10, "position_9")]
-    #[case("<----####>", 10, 10, "position_one_out_of_bounds")]
-    #[case("<----####>", 15, 10, "position_few_out_of_bounds")]
-    #[case("<----####>", 500, 10, "position_very_many_out_of_bounds")]
+    #[case::position_0("<####---->", 0, 10)]
+    #[case::position_1("<#####--->", 1, 10)]
+    #[case::position_2("<-####--->", 2, 10)]
+    #[case::position_3("<-####--->", 3, 10)]
+    #[case::position_4("<--####-->", 4, 10)]
+    #[case::position_5("<--####-->", 5, 10)]
+    #[case::position_6("<---####->", 6, 10)]
+    #[case::position_7("<---####->", 7, 10)]
+    #[case::position_8("<---#####>", 8, 10)]
+    #[case::position_9("<----####>", 9, 10)]
+    #[case::position_one_out_of_bounds("<----####>", 10, 10)]
+    #[case::position_few_out_of_bounds("<----####>", 15, 10)]
+    #[case::position_very_many_out_of_bounds("<----####>", 500, 10)]
     fn render_scrollbar_with_symbols(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] assertion_message: &str,
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 1));
@@ -894,30 +873,25 @@ mod tests {
             .track_symbol(Some("-"))
             .thumb_symbol("#")
             .render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![expected]),
-            "{assertion_message}",
-        );
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     #[rstest]
-    #[case("█████═════", 0, 10, "position_0")]
-    #[case("═█████════", 1, 10, "position_1")]
-    #[case("═█████════", 2, 10, "position_2")]
-    #[case("══█████═══", 3, 10, "position_3")]
-    #[case("══█████═══", 4, 10, "position_4")]
-    #[case("═══█████══", 5, 10, "position_5")]
-    #[case("═══█████══", 6, 10, "position_6")]
-    #[case("════█████═", 7, 10, "position_7")]
-    #[case("════█████═", 8, 10, "position_8")]
-    #[case("═════█████", 9, 10, "position_9")]
-    #[case("═════█████", 100, 10, "position_out_of_bounds")]
+    #[case::position_0("█████═════", 0, 10)]
+    #[case::position_1("═█████════", 1, 10)]
+    #[case::position_2("═█████════", 2, 10)]
+    #[case::position_3("══█████═══", 3, 10)]
+    #[case::position_4("══█████═══", 4, 10)]
+    #[case::position_5("═══█████══", 5, 10)]
+    #[case::position_6("═══█████══", 6, 10)]
+    #[case::position_7("════█████═", 7, 10)]
+    #[case::position_8("════█████═", 8, 10)]
+    #[case::position_9("═════█████", 9, 10)]
+    #[case::position_out_of_bounds("═════█████", 100, 10)]
     fn render_scrollbar_horizontal_bottom(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 2));
@@ -927,30 +901,25 @@ mod tests {
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
         let empty_string = " ".repeat(size as usize);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![&empty_string, expected]),
-            "{description}",
-        );
+        assert_eq!(buffer, Buffer::with_lines([&empty_string, expected]));
     }
 
     #[rstest]
-    #[case("█████═════", 0, 10, "position_0")]
-    #[case("═█████════", 1, 10, "position_1")]
-    #[case("═█████════", 2, 10, "position_2")]
-    #[case("══█████═══", 3, 10, "position_3")]
-    #[case("══█████═══", 4, 10, "position_4")]
-    #[case("═══█████══", 5, 10, "position_5")]
-    #[case("═══█████══", 6, 10, "position_6")]
-    #[case("════█████═", 7, 10, "position_7")]
-    #[case("════█████═", 8, 10, "position_8")]
-    #[case("═════█████", 9, 10, "position_9")]
-    #[case("═════█████", 100, 10, "position_out_of_bounds")]
+    #[case::position_0("█████═════", 0, 10)]
+    #[case::position_1("═█████════", 1, 10)]
+    #[case::position_2("═█████════", 2, 10)]
+    #[case::position_3("══█████═══", 3, 10)]
+    #[case::position_4("══█████═══", 4, 10)]
+    #[case::position_5("═══█████══", 5, 10)]
+    #[case::position_6("═══█████══", 6, 10)]
+    #[case::position_7("════█████═", 7, 10)]
+    #[case::position_8("════█████═", 8, 10)]
+    #[case::position_9("═════█████", 9, 10)]
+    #[case::position_out_of_bounds("═════█████", 100, 10)]
     fn render_scrollbar_horizontal_top(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, size, 2));
@@ -960,30 +929,25 @@ mod tests {
             .end_symbol(None)
             .render(buffer.area, &mut buffer, &mut state);
         let empty_string = " ".repeat(size as usize);
-        assert_eq!(
-            buffer,
-            Buffer::with_lines(vec![expected, &empty_string]),
-            "{description}",
-        );
+        assert_eq!(buffer, Buffer::with_lines([expected, &empty_string]));
     }
 
     #[rstest]
-    #[case("<####---->", 0, 10, "position_0")]
-    #[case("<#####--->", 1, 10, "position_1")]
-    #[case("<-####--->", 2, 10, "position_2")]
-    #[case("<-####--->", 3, 10, "position_3")]
-    #[case("<--####-->", 4, 10, "position_4")]
-    #[case("<--####-->", 5, 10, "position_5")]
-    #[case("<---####->", 6, 10, "position_6")]
-    #[case("<---####->", 7, 10, "position_7")]
-    #[case("<---#####>", 8, 10, "position_8")]
-    #[case("<----####>", 9, 10, "position_9")]
-    #[case("<----####>", 10, 10, "position_one_out_of_bounds")]
+    #[case::position_0("<####---->", 0, 10)]
+    #[case::position_1("<#####--->", 1, 10)]
+    #[case::position_2("<-####--->", 2, 10)]
+    #[case::position_3("<-####--->", 3, 10)]
+    #[case::position_4("<--####-->", 4, 10)]
+    #[case::position_5("<--####-->", 5, 10)]
+    #[case::position_6("<---####->", 6, 10)]
+    #[case::position_7("<---####->", 7, 10)]
+    #[case::position_8("<---#####>", 8, 10)]
+    #[case::position_9("<----####>", 9, 10)]
+    #[case::position_one_out_of_bounds("<----####>", 10, 10)]
     fn render_scrollbar_vertical_left(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, 5, size));
@@ -995,26 +959,25 @@ mod tests {
             .thumb_symbol("#")
             .render(buffer.area, &mut buffer, &mut state);
         let bar = expected.chars().map(|c| format!("{c}    "));
-        assert_eq!(buffer, Buffer::with_lines(bar), "{description}");
+        assert_eq!(buffer, Buffer::with_lines(bar));
     }
 
     #[rstest]
-    #[case("<####---->", 0, 10, "position_0")]
-    #[case("<#####--->", 1, 10, "position_1")]
-    #[case("<-####--->", 2, 10, "position_2")]
-    #[case("<-####--->", 3, 10, "position_3")]
-    #[case("<--####-->", 4, 10, "position_4")]
-    #[case("<--####-->", 5, 10, "position_5")]
-    #[case("<---####->", 6, 10, "position_6")]
-    #[case("<---####->", 7, 10, "position_7")]
-    #[case("<---#####>", 8, 10, "position_8")]
-    #[case("<----####>", 9, 10, "position_9")]
-    #[case("<----####>", 10, 10, "position_one_out_of_bounds")]
+    #[case::position_0("<####---->", 0, 10)]
+    #[case::position_1("<#####--->", 1, 10)]
+    #[case::position_2("<-####--->", 2, 10)]
+    #[case::position_3("<-####--->", 3, 10)]
+    #[case::position_4("<--####-->", 4, 10)]
+    #[case::position_5("<--####-->", 5, 10)]
+    #[case::position_6("<---####->", 6, 10)]
+    #[case::position_7("<---####->", 7, 10)]
+    #[case::position_8("<---#####>", 8, 10)]
+    #[case::position_9("<----####>", 9, 10)]
+    #[case::position_one_out_of_bounds("<----####>", 10, 10)]
     fn render_scrollbar_vertical_rightl(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
     ) {
         let size = expected.width() as u16;
         let mut buffer = Buffer::empty(Rect::new(0, 0, 5, size));
@@ -1026,26 +989,25 @@ mod tests {
             .thumb_symbol("#")
             .render(buffer.area, &mut buffer, &mut state);
         let bar = expected.chars().map(|c| format!("    {c}"));
-        assert_eq!(buffer, Buffer::with_lines(bar), "{description}");
+        assert_eq!(buffer, Buffer::with_lines(bar));
     }
 
     #[rstest]
-    #[case("##--------", 0, 10, "position_0")]
-    #[case("-##-------", 1, 10, "position_1")]
-    #[case("--##------", 2, 10, "position_2")]
-    #[case("---##-----", 3, 10, "position_3")]
-    #[case("----#-----", 4, 10, "position_4")]
-    #[case("-----#----", 5, 10, "position_5")]
-    #[case("-----##---", 6, 10, "position_6")]
-    #[case("------##--", 7, 10, "position_7")]
-    #[case("-------##-", 8, 10, "position_8")]
-    #[case("--------##", 9, 10, "position_9")]
-    #[case("--------##", 10, 10, "position_one_out_of_bounds")]
+    #[case::position_0("##--------", 0, 10)]
+    #[case::position_1("-##-------", 1, 10)]
+    #[case::position_2("--##------", 2, 10)]
+    #[case::position_3("---##-----", 3, 10)]
+    #[case::position_4("----#-----", 4, 10)]
+    #[case::position_5("-----#----", 5, 10)]
+    #[case::position_6("-----##---", 6, 10)]
+    #[case::position_7("------##--", 7, 10)]
+    #[case::position_8("-------##-", 8, 10)]
+    #[case::position_9("--------##", 9, 10)]
+    #[case::position_one_out_of_bounds("--------##", 10, 10)]
     fn custom_viewport_length(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
         scrollbar_no_arrows: Scrollbar,
     ) {
         let size = expected.width() as u16;
@@ -1054,28 +1016,27 @@ mod tests {
             .position(position)
             .viewport_content_length(2);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}");
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
     /// Fixes <https://github.com/ratatui-org/ratatui/pull/959> which was a bug that would not
     /// render a thumb when the viewport was very small in comparison to the content length.
     #[rstest]
-    #[case("#----", 0, 100, "position_0")]
-    #[case("#----", 10, 100, "position_10")]
-    #[case("-#---", 20, 100, "position_20")]
-    #[case("-#---", 30, 100, "position_30")]
-    #[case("--#--", 40, 100, "position_40")]
-    #[case("--#--", 50, 100, "position_50")]
-    #[case("---#-", 60, 100, "position_60")]
-    #[case("---#-", 70, 100, "position_70")]
-    #[case("----#", 80, 100, "position_80")]
-    #[case("----#", 90, 100, "position_90")]
-    #[case("----#", 100, 100, "position_one_out_of_bounds")]
+    #[case::position_0("#----", 0, 100)]
+    #[case::position_10("#----", 10, 100)]
+    #[case::position_20("-#---", 20, 100)]
+    #[case::position_30("-#---", 30, 100)]
+    #[case::position_40("--#--", 40, 100)]
+    #[case::position_50("--#--", 50, 100)]
+    #[case::position_60("---#-", 60, 100)]
+    #[case::position_70("---#-", 70, 100)]
+    #[case::position_80("----#", 80, 100)]
+    #[case::position_90("----#", 90, 100)]
+    #[case::position_one_out_of_bounds("----#", 100, 100)]
     fn thumb_visible_on_very_small_track(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
-        #[case] description: &str,
         scrollbar_no_arrows: Scrollbar,
     ) {
         let size = expected.width() as u16;
@@ -1084,6 +1045,6 @@ mod tests {
             .position(position)
             .viewport_content_length(2);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
-        assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}");
+        assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 }

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -225,7 +225,7 @@ mod tests {
     use strum::ParseError;
 
     use super::*;
-    use crate::{assert_buffer_eq, buffer::Cell};
+    use crate::buffer::Cell;
 
     #[test]
     fn render_direction_to_string() {
@@ -264,21 +264,21 @@ mod tests {
     fn it_does_not_panic_if_max_is_zero() {
         let widget = Sparkline::default().data(&[0, 0, 0]);
         let buffer = render(widget, 6);
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["   xxx"]));
+        assert_eq!(buffer, Buffer::with_lines(["   xxx"]));
     }
 
     #[test]
     fn it_does_not_panic_if_max_is_set_to_zero() {
         let widget = Sparkline::default().data(&[0, 1, 2]).max(0);
         let buffer = render(widget, 6);
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["   xxx"]));
+        assert_eq!(buffer, Buffer::with_lines(["   xxx"]));
     }
 
     #[test]
     fn it_draws() {
         let widget = Sparkline::default().data(&[0, 1, 2, 3, 4, 5, 6, 7, 8]);
         let buffer = render(widget, 12);
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec![" ▁▂▃▄▅▆▇█xxx"]));
+        assert_eq!(buffer, Buffer::with_lines([" ▁▂▃▄▅▆▇█xxx"]));
     }
 
     #[test]
@@ -287,7 +287,7 @@ mod tests {
             .data(&[0, 1, 2, 3, 4, 5, 6, 7, 8])
             .direction(RenderDirection::LeftToRight);
         let buffer = render(widget, 12);
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec![" ▁▂▃▄▅▆▇█xxx"]));
+        assert_eq!(buffer, Buffer::with_lines([" ▁▂▃▄▅▆▇█xxx"]));
     }
 
     #[test]
@@ -296,7 +296,7 @@ mod tests {
             .data(&[0, 1, 2, 3, 4, 5, 6, 7, 8])
             .direction(RenderDirection::RightToLeft);
         let buffer = render(widget, 12);
-        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["xxx█▇▆▅▄▃▂▁ "]));
+        assert_eq!(buffer, Buffer::with_lines(["xxx█▇▆▅▄▃▂▁ "]));
     }
 
     #[test]

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -1001,7 +1001,6 @@ mod tests {
     #[cfg(test)]
     mod render {
         use super::*;
-        use crate::assert_buffer_eq;
 
         #[test]
         fn render_empty_area() {
@@ -1009,7 +1008,7 @@ mod tests {
             let rows = vec![Row::new(vec!["Cell1", "Cell2"])];
             let table = Table::new(rows, vec![Constraint::Length(5); 2]);
             Widget::render(table, Rect::new(0, 0, 0, 0), &mut buf);
-            assert_buffer_eq!(buf, Buffer::empty(Rect::new(0, 0, 15, 3)));
+            assert_eq!(buf, Buffer::empty(Rect::new(0, 0, 15, 3)));
         }
 
         #[test]
@@ -1017,7 +1016,7 @@ mod tests {
             let mut buf = Buffer::empty(Rect::new(0, 0, 15, 3));
             let table = Table::default();
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            assert_buffer_eq!(buf, Buffer::empty(Rect::new(0, 0, 15, 3)));
+            assert_eq!(buf, Buffer::empty(Rect::new(0, 0, 15, 3)));
         }
 
         #[test]
@@ -1030,12 +1029,13 @@ mod tests {
             let block = Block::bordered().title("Block");
             let table = Table::new(rows, vec![Constraint::Length(5); 2]).block(block);
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            let expected = Buffer::with_lines(vec![
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
                 "┌Block────────┐",
                 "│Cell1 Cell2  │",
                 "└─────────────┘",
             ]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1048,12 +1048,13 @@ mod tests {
             ];
             let table = Table::new(rows, [Constraint::Length(5); 2]).header(header);
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            let expected = Buffer::with_lines(vec![
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
                 "Head1 Head2    ",
                 "Cell1 Cell2    ",
                 "Cell3 Cell4    ",
             ]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1066,12 +1067,13 @@ mod tests {
             ];
             let table = Table::new(rows, [Constraint::Length(5); 2]).footer(footer);
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            let expected = Buffer::with_lines(vec![
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
                 "Cell1 Cell2    ",
                 "Cell3 Cell4    ",
                 "Foot1 Foot2    ",
             ]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1084,12 +1086,13 @@ mod tests {
                 .header(header)
                 .footer(footer);
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            let expected = Buffer::with_lines(vec![
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
                 "Head1 Head2    ",
                 "Cell1 Cell2    ",
                 "Foot1 Foot2    ",
             ]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1102,12 +1105,13 @@ mod tests {
             ];
             let table = Table::new(rows, [Constraint::Length(5); 2]).header(header);
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            let expected = Buffer::with_lines(vec![
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
                 "Head1 Head2    ",
                 "               ",
                 "Cell1 Cell2    ",
             ]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1117,12 +1121,13 @@ mod tests {
             let rows = vec![Row::new(vec!["Cell1", "Cell2"])];
             let table = Table::new(rows, [Constraint::Length(5); 2]).footer(footer);
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            let expected = Buffer::with_lines(vec![
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
                 "Cell1 Cell2    ",
                 "               ",
                 "Foot1 Foot2    ",
             ]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1134,30 +1139,27 @@ mod tests {
             ];
             let table = Table::new(rows, [Constraint::Length(5); 2]);
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            let expected = Buffer::with_lines(vec![
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
                 "Cell1 Cell2    ",
                 "               ",
                 "Cell3 Cell4    ",
             ]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
 
         #[test]
         fn render_with_alignment() {
-            let mut buf = Buffer::empty(Rect::new(0, 0, 15, 3));
+            let mut buf = Buffer::empty(Rect::new(0, 0, 10, 3));
             let rows = vec![
                 Row::new(vec![Line::from("Left").alignment(Alignment::Left)]),
                 Row::new(vec![Line::from("Center").alignment(Alignment::Center)]),
                 Row::new(vec![Line::from("Right").alignment(Alignment::Right)]),
             ];
             let table = Table::new(rows, [Percentage(100)]);
-            Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
-            let expected = Buffer::with_lines(vec![
-                "Left           ",
-                "    Center     ",
-                "          Right",
-            ]);
-            assert_buffer_eq!(buf, expected);
+            Widget::render(table, Rect::new(0, 0, 10, 3), &mut buf);
+            let expected = Buffer::with_lines(["Left      ", "  Center  ", "     Right"]);
+            assert_eq!(buf, expected);
         }
 
         #[test]
@@ -1181,19 +1183,18 @@ mod tests {
                 .highlight_symbol(">>");
             let mut state = TableState::new().with_selected(0);
             StatefulWidget::render(table, Rect::new(0, 0, 15, 3), &mut buf, &mut state);
-            let expected = Buffer::with_lines(vec![
+            let expected = Buffer::with_lines([
                 ">>Cell1 Cell2  ".red(),
                 "  Cell3 Cell4  ".into(),
                 "               ".into(),
             ]);
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
     }
 
     // test how constraints interact with table column width allocation
     mod column_widths {
         use super::*;
-        use crate::assert_buffer_eq;
 
         #[test]
         fn length_constraint() {
@@ -1387,12 +1388,17 @@ mod tests {
             assert_eq!(table.get_columns_widths(10, 0), [(0, 5), (5, 5)]);
         }
 
-        fn test_table_with_selection(
+        #[track_caller]
+        fn test_table_with_selection<'line, Lines>(
             highlight_spacing: HighlightSpacing,
             columns: u16,
             spacing: u16,
             selection: Option<usize>,
-        ) -> Buffer {
+            expected: Lines,
+        ) where
+            Lines: IntoIterator,
+            Lines::Item: Into<Line<'line>>,
+        {
             let table = Table::default()
                 .rows(vec![Row::new(vec!["ABCDE", "12345"])])
                 .highlight_spacing(highlight_spacing)
@@ -1402,26 +1408,24 @@ mod tests {
             let mut buf = Buffer::empty(area);
             let mut state = TableState::default().with_selected(selection);
             StatefulWidget::render(table, area, &mut buf, &mut state);
-            buf
+            assert_eq!(buf, Buffer::with_lines(expected));
         }
 
         #[test]
         fn excess_area_highlight_symbol_and_column_spacing_allocation() {
             // no highlight_symbol rendered ever
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Never,
-                    15,   // width
-                    0,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Never,
+                15,   // width
+                0,    // spacing
+                None, // selection
+                [
                     "ABCDE  12345   ", /* default layout is Flex::Start but columns length
                                         * constraints are calculated as `max_area / n_columns`,
                                         * i.e. they are distributed amongst available space */
                     "               ", // row 2
                     "               ", // row 3
-                ])
+                ],
             );
 
             let table = Table::default()
@@ -1431,88 +1435,76 @@ mod tests {
             let area = Rect::new(0, 0, 15, 3);
             let mut buf = Buffer::empty(area);
             Widget::render(table, area, &mut buf);
-            assert_buffer_eq!(
-                buf,
-                Buffer::with_lines(vec![
-                    "ABCDE12345     ", /* As reference, this is what happens when you manually
-                                        * specify widths */
-                    "               ", // row 2
-                    "               ", // row 3
-                ])
-            );
+            let expected = Buffer::with_lines([
+                "ABCDE12345     ", /* As reference, this is what happens when you manually
+                                    * specify widths */
+                "               ", // row 2
+                "               ", // row 3
+            ]);
+            assert_eq!(buf, expected);
 
             // no highlight_symbol rendered ever
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Never,
-                    15,      // width
-                    0,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Never,
+                15,      // width
+                0,       // spacing
+                Some(0), // selection
+                [
                     "ABCDE  12345   ", // row 1
                     "               ", // row 2
                     "               ", // row 3
-                ])
+                ],
             );
 
             // no highlight_symbol rendered because no selection is made
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::WhenSelected,
-                    15,   // width
-                    0,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::WhenSelected,
+                15,   // width
+                0,    // spacing
+                None, // selection
+                [
                     "ABCDE  12345   ", // row 1
                     "               ", // row 2
                     "               ", // row 3
-                ])
+                ],
             );
             // highlight_symbol rendered because selection is made
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::WhenSelected,
-                    15,      // width
-                    0,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::WhenSelected,
+                15,      // width
+                0,       // spacing
+                Some(0), // selection
+                [
                     ">>>ABCDE 12345 ", // row 1
                     "               ", // row 2
                     "               ", // row 3
-                ])
+                ],
             );
 
             // highlight_symbol always rendered even no selection is made
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    15,   // width
-                    0,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                15,   // width
+                0,    // spacing
+                None, // selection
+                [
                     "   ABCDE 12345 ", // row 1
                     "               ", // row 2
                     "               ", // row 3
-                ])
+                ],
             );
 
             // no highlight_symbol rendered because no selection is made
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    15,      // width
-                    0,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                15,      // width
+                0,       // spacing
+                Some(0), // selection
+                [
                     ">>>ABCDE 12345 ", // row 1
                     "               ", // row 2
                     "               ", // row 3
-                ])
+                ],
             );
         }
 
@@ -1520,31 +1512,27 @@ mod tests {
         #[test]
         fn insufficient_area_highlight_symbol_and_column_spacing_allocation() {
             // column spacing is prioritized over every other constraint
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Never,
-                    10,   // width
-                    1,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Never,
+                10,   // width
+                1,    // spacing
+                None, // selection
+                [
                     "ABCDE 1234", // spacing is prioritized and column is cut
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::WhenSelected,
-                    10,   // width
-                    1,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::WhenSelected,
+                10,   // width
+                1,    // spacing
+                None, // selection
+                [
                     "ABCDE 1234", // spacing is prioritized and column is cut
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
 
             // this test checks that space for highlight_symbol space is always allocated.
@@ -1555,59 +1543,51 @@ mod tests {
             // Then in a separate step, column widths are calculated.
             // column spacing is prioritized when column widths are calculated and last column here
             // ends up with just 1 wide
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    10,   // width
-                    1,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                10,   // width
+                1,    // spacing
+                None, // selection
+                [
                     "   ABC 123", // highlight_symbol and spacing are prioritized
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
 
             // the following are specification tests
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    9,    // width
-                    1,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                9,    // width
+                1,    // spacing
+                None, // selection
+                [
                     "   ABC 12", // highlight_symbol and spacing are prioritized
                     "         ", // row 2
                     "         ", // row 3
-                ])
+                ],
             );
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    8,    // width
-                    1,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                8,    // width
+                1,    // spacing
+                None, // selection
+                [
                     "   AB 12", // highlight_symbol and spacing are prioritized
                     "        ", // row 2
                     "        ", // row 3
-                ])
+                ],
             );
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    7,    // width
-                    1,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                7,    // width
+                1,    // spacing
+                None, // selection
+                [
                     "   AB 1", // highlight_symbol and spacing are prioritized
                     "       ", // row 2
                     "       ", // row 3
-                ])
+                ],
             );
 
             let table = Table::default()
@@ -1620,10 +1600,13 @@ mod tests {
             let mut buf = Buffer::empty(area);
             Widget::render(table, area, &mut buf);
             // highlight_symbol and spacing are prioritized but columns are evenly distributed
-            assert_buffer_eq!(
-                buf,
-                Buffer::with_lines(vec!["   ABCDE 1", "          ", "          ",])
-            );
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
+                "   ABCDE 1",
+                "          ",
+                "          ",
+            ]);
+            assert_eq!(buf, expected);
 
             let table = Table::default()
                 .rows(vec![Row::new(vec!["ABCDE", "12345"])])
@@ -1635,137 +1618,122 @@ mod tests {
             let mut buf = Buffer::empty(area);
             Widget::render(table, area, &mut buf);
             // highlight_symbol and spacing are prioritized but columns are evenly distributed
-            assert_buffer_eq!(
-                buf,
-                Buffer::with_lines(vec!["   ABC 123", "          ", "          ",])
-            );
+            #[rustfmt::skip]
+            let expected = Buffer::with_lines([
+                "   ABC 123",
+                "          ",
+                "          ",
+            ]);
+            assert_eq!(buf, expected);
 
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Never,
-                    10,      // width
-                    1,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Never,
+                10,      // width
+                1,       // spacing
+                Some(0), // selection
+                [
                     "ABCDE 1234", // spacing is prioritized
                     "          ",
                     "          ",
-                ])
+                ],
             );
 
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::WhenSelected,
-                    10,      // width
-                    1,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::WhenSelected,
+                10,      // width
+                1,       // spacing
+                Some(0), // selection
+                [
                     ">>>ABC 123", // row 1
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
 
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    10,      // width
-                    1,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                10,      // width
+                1,       // spacing
+                Some(0), // selection
+                [
                     ">>>ABC 123", // highlight column and spacing are prioritized
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
         }
 
         #[test]
         fn insufficient_area_highlight_symbol_allocation_with_no_column_spacing() {
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Never,
-                    10,   // width
-                    0,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Never,
+                10,   // width
+                0,    // spacing
+                None, // selection
+                [
                     "ABCDE12345", // row 1
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::WhenSelected,
-                    10,   // width
-                    0,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::WhenSelected,
+                10,   // width
+                0,    // spacing
+                None, // selection
+                [
                     "ABCDE12345", // row 1
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
             // highlight symbol spacing is prioritized over all constraints
             // even if the constraints are fixed length
             // this is because highlight_symbol column is separated _before_ any of the constraint
             // widths are calculated
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    10,   // width
-                    0,    // spacing
-                    None, // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                10,   // width
+                0,    // spacing
+                None, // selection
+                [
                     "   ABCD123", // highlight column and spacing are prioritized
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Never,
-                    10,      // width
-                    0,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Never,
+                10,      // width
+                0,       // spacing
+                Some(0), // selection
+                [
                     "ABCDE12345", // row 1
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::WhenSelected,
-                    10,      // width
-                    0,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::WhenSelected,
+                10,      // width
+                0,       // spacing
+                Some(0), // selection
+                [
                     ">>>ABCD123", // highlight column and spacing are prioritized
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
-            assert_buffer_eq!(
-                test_table_with_selection(
-                    HighlightSpacing::Always,
-                    10,      // width
-                    0,       // spacing
-                    Some(0), // selection
-                ),
-                Buffer::with_lines(vec![
+            test_table_with_selection(
+                HighlightSpacing::Always,
+                10,      // width
+                0,       // spacing
+                Some(0), // selection
+                [
                     ">>>ABCD123", // highlight column and spacing are prioritized
                     "          ", // row 2
                     "          ", // row 3
-                ])
+                ],
             );
         }
     }

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -333,7 +333,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_buffer_eq;
 
     #[test]
     fn new() {
@@ -379,60 +378,61 @@ mod tests {
         );
     }
 
-    fn render(tabs: Tabs, area: Rect) -> Buffer {
+    #[track_caller]
+    fn test_case(tabs: Tabs, area: Rect, expected: &Buffer) {
         let mut buffer = Buffer::empty(area);
         tabs.render(area, &mut buffer);
-        buffer
+        assert_eq!(&buffer, expected);
     }
 
     #[test]
     fn render_default() {
         let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"]);
-        let mut expected = Buffer::with_lines(vec![" Tab1 │ Tab2 │ Tab3 │ Tab4    "]);
+        let mut expected = Buffer::with_lines([" Tab1 │ Tab2 │ Tab3 │ Tab4    "]);
         // first tab selected
         expected.set_style(Rect::new(1, 0, 4, 1), DEFAULT_HIGHLIGHT_STYLE);
-        assert_buffer_eq!(render(tabs, Rect::new(0, 0, 30, 1)), expected);
+        test_case(tabs, Rect::new(0, 0, 30, 1), &expected);
     }
 
     #[test]
     fn render_no_padding() {
         let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"]).padding("", "");
-        let mut expected = Buffer::with_lines(vec!["Tab1│Tab2│Tab3│Tab4           "]);
+        let mut expected = Buffer::with_lines(["Tab1│Tab2│Tab3│Tab4           "]);
         // first tab selected
         expected.set_style(Rect::new(0, 0, 4, 1), DEFAULT_HIGHLIGHT_STYLE);
-        assert_buffer_eq!(render(tabs, Rect::new(0, 0, 30, 1)), expected);
+        test_case(tabs, Rect::new(0, 0, 30, 1), &expected);
     }
 
     #[test]
     fn render_more_padding() {
         let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"]).padding("---", "++");
-        let mut expected = Buffer::with_lines(vec!["---Tab1++│---Tab2++│---Tab3++│"]);
+        let mut expected = Buffer::with_lines(["---Tab1++│---Tab2++│---Tab3++│"]);
         // first tab selected
         expected.set_style(Rect::new(3, 0, 4, 1), DEFAULT_HIGHLIGHT_STYLE);
-        assert_buffer_eq!(render(tabs, Rect::new(0, 0, 30, 1)), expected);
+        test_case(tabs, Rect::new(0, 0, 30, 1), &expected);
     }
 
     #[test]
     fn render_with_block() {
         let tabs =
             Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"]).block(Block::bordered().title("Tabs"));
-        let mut expected = Buffer::with_lines(vec![
+        let mut expected = Buffer::with_lines([
             "┌Tabs────────────────────────┐",
             "│ Tab1 │ Tab2 │ Tab3 │ Tab4  │",
             "└────────────────────────────┘",
         ]);
         // first tab selected
         expected.set_style(Rect::new(2, 1, 4, 1), DEFAULT_HIGHLIGHT_STYLE);
-        assert_buffer_eq!(render(tabs, Rect::new(0, 0, 30, 3)), expected);
+        test_case(tabs, Rect::new(0, 0, 30, 3), &expected);
     }
 
     #[test]
     fn render_style() {
         let tabs =
             Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"]).style(Style::default().fg(Color::Red));
-        let mut expected = Buffer::with_lines(vec![" Tab1 │ Tab2 │ Tab3 │ Tab4    ".red()]);
+        let mut expected = Buffer::with_lines([" Tab1 │ Tab2 │ Tab3 │ Tab4    ".red()]);
         expected.set_style(Rect::new(1, 0, 4, 1), DEFAULT_HIGHLIGHT_STYLE.red());
-        assert_buffer_eq!(render(tabs, Rect::new(0, 0, 30, 1)), expected);
+        test_case(tabs, Rect::new(0, 0, 30, 1), &expected);
     }
 
     #[test]
@@ -440,40 +440,32 @@ mod tests {
         let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"]);
 
         // first tab selected
-        assert_buffer_eq!(
-            render(tabs.clone().select(0), Rect::new(0, 0, 30, 1)),
-            Buffer::with_lines(vec![Line::from(vec![
-                " ".into(),
-                "Tab1".reversed(),
-                " │ Tab2 │ Tab3 │ Tab4    ".into(),
-            ])])
-        );
+        let expected = Buffer::with_lines([Line::from(vec![
+            " ".into(),
+            "Tab1".reversed(),
+            " │ Tab2 │ Tab3 │ Tab4    ".into(),
+        ])]);
+        test_case(tabs.clone().select(0), Rect::new(0, 0, 30, 1), &expected);
 
         // second tab selected
-        assert_buffer_eq!(
-            render(tabs.clone().select(1), Rect::new(0, 0, 30, 1)),
-            Buffer::with_lines(vec![Line::from(vec![
-                " Tab1 │ ".into(),
-                "Tab2".reversed(),
-                " │ Tab3 │ Tab4    ".into(),
-            ])])
-        );
+        let expected = Buffer::with_lines([Line::from(vec![
+            " Tab1 │ ".into(),
+            "Tab2".reversed(),
+            " │ Tab3 │ Tab4    ".into(),
+        ])]);
+        test_case(tabs.clone().select(1), Rect::new(0, 0, 30, 1), &expected);
 
         // last tab selected
-        assert_buffer_eq!(
-            render(tabs.clone().select(3), Rect::new(0, 0, 30, 1)),
-            Buffer::with_lines(vec![Line::from(vec![
-                " Tab1 │ Tab2 │ Tab3 │ ".into(),
-                "Tab4".reversed(),
-                "    ".into(),
-            ])])
-        );
+        let expected = Buffer::with_lines([Line::from(vec![
+            " Tab1 │ Tab2 │ Tab3 │ ".into(),
+            "Tab4".reversed(),
+            "    ".into(),
+        ])]);
+        test_case(tabs.clone().select(3), Rect::new(0, 0, 30, 1), &expected);
 
         // out of bounds selects no tab
-        assert_buffer_eq!(
-            render(tabs.clone().select(4), Rect::new(0, 0, 30, 1)),
-            Buffer::with_lines(vec![" Tab1 │ Tab2 │ Tab3 │ Tab4    "])
-        );
+        let expected = Buffer::with_lines([" Tab1 │ Tab2 │ Tab3 │ Tab4    "]);
+        test_case(tabs.clone().select(4), Rect::new(0, 0, 30, 1), &expected);
     }
 
     #[test]
@@ -482,23 +474,21 @@ mod tests {
             .style(Style::new().red())
             .highlight_style(Style::new().underlined())
             .select(0);
-        assert_buffer_eq!(
-            render(tabs, Rect::new(0, 0, 30, 1)),
-            Buffer::with_lines(vec![Line::from(vec![
-                " ".red(),
-                "Tab1".red().underlined(),
-                " │ Tab2 │ Tab3 │ Tab4    ".red(),
-            ])])
-        );
+        let expected = Buffer::with_lines([Line::from(vec![
+            " ".red(),
+            "Tab1".red().underlined(),
+            " │ Tab2 │ Tab3 │ Tab4    ".red(),
+        ])]);
+        test_case(tabs, Rect::new(0, 0, 30, 1), &expected);
     }
 
     #[test]
     fn render_divider() {
         let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"]).divider("--");
-        let mut expected = Buffer::with_lines(vec![" Tab1 -- Tab2 -- Tab3 -- Tab4 "]);
+        let mut expected = Buffer::with_lines([" Tab1 -- Tab2 -- Tab3 -- Tab4 "]);
         // first tab selected
         expected.set_style(Rect::new(1, 0, 4, 1), DEFAULT_HIGHLIGHT_STYLE);
-        assert_buffer_eq!(render(tabs, Rect::new(0, 0, 30, 1)), expected);
+        test_case(tabs, Rect::new(0, 0, 30, 1), &expected);
     }
 
     #[test]

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -42,7 +42,11 @@ impl AppState {
 
 /// Renders the list to a `TestBackend` and asserts that the result matches the expected buffer.
 #[track_caller]
-fn assert_buffer(state: &mut AppState, expected: &Buffer) {
+fn assert_buffer<'line, Lines>(state: &mut AppState, expected: Lines)
+where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
     let backend = TestBackend::new(21, 5);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
@@ -76,7 +80,7 @@ fn assert_buffer(state: &mut AppState, expected: &Buffer) {
             f.render_stateful_widget(scrollbar, layout[2], &mut state.scrollbar);
         })
         .unwrap();
-    terminal.backend().assert_buffer(expected);
+    terminal.backend().assert_buffer_lines(expected);
 }
 
 const DEFAULT_STATE_BUFFER: [&str; 5] = [
@@ -106,19 +110,15 @@ const DEFAULT_STATE_REPR: &str = r#"{
 #[test]
 fn default_state_serialize() {
     let mut state = AppState::default();
-
-    let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER);
-    assert_buffer(&mut state, &expected);
-
+    assert_buffer(&mut state, DEFAULT_STATE_BUFFER);
     let state = serde_json::to_string_pretty(&state).unwrap();
     assert_eq!(state, DEFAULT_STATE_REPR);
 }
 
 #[test]
 fn default_state_deserialize() {
-    let expected = Buffer::with_lines(DEFAULT_STATE_BUFFER);
     let mut state: AppState = serde_json::from_str(DEFAULT_STATE_REPR).unwrap();
-    assert_buffer(&mut state, &expected);
+    assert_buffer(&mut state, DEFAULT_STATE_BUFFER);
 }
 
 const SELECTED_STATE_BUFFER: [&str; 5] = [
@@ -148,19 +148,15 @@ const SELECTED_STATE_REPR: &str = r#"{
 fn selected_state_serialize() {
     let mut state = AppState::default();
     state.select(1);
-
-    let expected = Buffer::with_lines(SELECTED_STATE_BUFFER);
-    assert_buffer(&mut state, &expected);
-
+    assert_buffer(&mut state, SELECTED_STATE_BUFFER);
     let state = serde_json::to_string_pretty(&state).unwrap();
     assert_eq!(state, SELECTED_STATE_REPR);
 }
 
 #[test]
 fn selected_state_deserialize() {
-    let expected = Buffer::with_lines(SELECTED_STATE_BUFFER);
     let mut state: AppState = serde_json::from_str(SELECTED_STATE_REPR).unwrap();
-    assert_buffer(&mut state, &expected);
+    assert_buffer(&mut state, SELECTED_STATE_BUFFER);
 }
 
 const SCROLLED_STATE_BUFFER: [&str; 5] = [
@@ -191,17 +187,13 @@ const SCROLLED_STATE_REPR: &str = r#"{
 fn scrolled_state_serialize() {
     let mut state = AppState::default();
     state.select(8);
-
-    let expected = Buffer::with_lines(SCROLLED_STATE_BUFFER);
-    assert_buffer(&mut state, &expected);
-
+    assert_buffer(&mut state, SCROLLED_STATE_BUFFER);
     let state = serde_json::to_string_pretty(&state).unwrap();
     assert_eq!(state, SCROLLED_STATE_REPR);
 }
 
 #[test]
 fn scrolled_state_deserialize() {
-    let expected = Buffer::with_lines(SCROLLED_STATE_BUFFER);
     let mut state: AppState = serde_json::from_str(SCROLLED_STATE_REPR).unwrap();
-    assert_buffer(&mut state, &expected);
+    assert_buffer(&mut state, SCROLLED_STATE_BUFFER);
 }

--- a/tests/stylize.rs
+++ b/tests/stylize.rs
@@ -28,7 +28,7 @@ fn barchart_can_be_stylized() {
         })
         .unwrap();
 
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "      ██ ",
         "   ▅▅ ██ ",
         "▂▂ ██ ██ ",
@@ -55,7 +55,6 @@ fn barchart_can_be_stylized() {
         expected.get_mut(x * 3, 4).set_fg(Color::Blue);
         expected.get_mut(x * 3 + 1, 4).set_fg(Color::Reset);
     }
-
     terminal.backend().assert_buffer(&expected);
 }
 
@@ -72,7 +71,8 @@ fn block_can_be_stylized() -> io::Result<()> {
         f.render_widget(block, area);
     })?;
 
-    let mut expected = Buffer::with_lines(vec![
+    #[rustfmt::skip]
+    let mut expected = Buffer::with_lines([
         "┌Title─┐   ",
         "│      │   ",
         "└──────┘   ",
@@ -89,7 +89,6 @@ fn block_can_be_stylized() -> io::Result<()> {
     for x in 1..=5 {
         expected.get_mut(x, 0).set_fg(Color::LightBlue);
     }
-
     terminal.backend().assert_buffer(&expected);
     Ok(())
 }
@@ -104,7 +103,7 @@ fn paragraph_can_be_stylized() -> io::Result<()> {
         f.render_widget(paragraph, area);
     })?;
 
-    let mut expected = Buffer::with_lines(vec!["Text      "]);
+    let mut expected = Buffer::with_lines(["Text      "]);
     for x in 0..4 {
         expected.get_mut(x, 0).set_fg(Color::Cyan);
     }

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -1,10 +1,8 @@
 use std::error::Error;
 
 use ratatui::{
-    assert_buffer_eq,
     backend::{Backend, TestBackend},
     layout::Rect,
-    prelude::Buffer,
     widgets::{Paragraph, Widget},
     Terminal, TerminalOptions, Viewport,
 };
@@ -105,16 +103,13 @@ fn terminal_insert_before_moves_viewport() -> Result<(), Box<dyn Error>> {
         f.render_widget(paragraph, f.size());
     })?;
 
-    assert_buffer_eq!(
-        terminal.backend().buffer().clone(),
-        Buffer::with_lines(vec![
-            "------ Line 1 ------",
-            "------ Line 2 ------",
-            "[---- Viewport ----]",
-            "                    ",
-            "                    ",
-        ])
-    );
+    terminal.backend().assert_buffer_lines([
+        "------ Line 1 ------",
+        "------ Line 2 ------",
+        "[---- Viewport ----]",
+        "                    ",
+        "                    ",
+    ]);
 
     Ok(())
 }
@@ -150,16 +145,13 @@ fn terminal_insert_before_scrolls_on_large_input() -> Result<(), Box<dyn Error>>
         f.render_widget(paragraph, f.size());
     })?;
 
-    assert_buffer_eq!(
-        terminal.backend().buffer().clone(),
-        Buffer::with_lines(vec![
-            "------ Line 2 ------",
-            "------ Line 3 ------",
-            "------ Line 4 ------",
-            "------ Line 5 ------",
-            "[---- Viewport ----]",
-        ])
-    );
+    terminal.backend().assert_buffer_lines([
+        "------ Line 2 ------",
+        "------ Line 3 ------",
+        "------ Line 4 ------",
+        "------ Line 5 ------",
+        "[---- Viewport ----]",
+    ]);
 
     Ok(())
 }
@@ -205,16 +197,13 @@ fn terminal_insert_before_scrolls_on_many_inserts() -> Result<(), Box<dyn Error>
         f.render_widget(paragraph, f.size());
     })?;
 
-    assert_buffer_eq!(
-        terminal.backend().buffer().clone(),
-        Buffer::with_lines(vec![
-            "------ Line 2 ------",
-            "------ Line 3 ------",
-            "------ Line 4 ------",
-            "------ Line 5 ------",
-            "[---- Viewport ----]",
-        ])
-    );
+    terminal.backend().assert_buffer_lines([
+        "------ Line 2 ------",
+        "------ Line 3 ------",
+        "------ Line 4 ------",
+        "------ Line 5 ------",
+        "[---- Viewport ----]",
+    ]);
 
     Ok(())
 }

--- a/tests/widgets_barchart.rs
+++ b/tests/widgets_barchart.rs
@@ -6,29 +6,24 @@ use ratatui::{
     Terminal,
 };
 
+// check that bars fill up correctly up to max value
 #[test]
 fn widgets_barchart_not_full_below_max_value() {
-    let test_case = |expected| {
-        let backend = TestBackend::new(30, 10);
-        let mut terminal = Terminal::new(backend).unwrap();
-
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let barchart = BarChart::default()
-                    .block(Block::bordered())
-                    .data(&[("empty", 0), ("half", 50), ("almost", 99), ("full", 100)])
-                    .max(100)
-                    .bar_width(7)
-                    .bar_gap(0);
-                f.render_widget(barchart, size);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    };
-
-    // check that bars fill up correctly up to max value
-    test_case(Buffer::with_lines(vec![
+    let backend = TestBackend::new(30, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let barchart = BarChart::default()
+                .block(Block::bordered())
+                .data(&[("empty", 0), ("half", 50), ("almost", 99), ("full", 100)])
+                .max(100)
+                .bar_width(7)
+                .bar_gap(0);
+            f.render_widget(barchart, size);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines([
         "┌────────────────────────────┐",
         "│              ▇▇▇▇▇▇▇███████│",
         "│              ██████████████│",
@@ -39,47 +34,43 @@ fn widgets_barchart_not_full_below_max_value() {
         "│       ██50█████99█████100██│",
         "│ empty  half  almost  full  │",
         "└────────────────────────────┘",
-    ]));
+    ]);
 }
 
 #[test]
 fn widgets_barchart_group() {
     const TERMINAL_HEIGHT: u16 = 11;
-    let test_case = |expected| {
-        let backend = TestBackend::new(35, TERMINAL_HEIGHT);
-        let mut terminal = Terminal::new(backend).unwrap();
+    let backend = TestBackend::new(35, TERMINAL_HEIGHT);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let barchart = BarChart::default()
+                .block(Block::bordered())
+                .data(
+                    BarGroup::default().label("Mar".into()).bars(&[
+                        Bar::default()
+                            .value(10)
+                            .label("C1".into())
+                            .style(Style::default().fg(Color::Red))
+                            .value_style(Style::default().fg(Color::Blue)),
+                        Bar::default()
+                            .value(20)
+                            .style(Style::default().fg(Color::Green))
+                            .text_value("20M".to_string()),
+                    ]),
+                )
+                .data(&vec![("C1", 50), ("C2", 40)])
+                .data(&[("C1", 60), ("C2", 90)])
+                .data(&[("xx", 10), ("xx", 10)])
+                .group_gap(2)
+                .bar_width(4)
+                .bar_gap(1);
+            f.render_widget(barchart, size);
+        })
+        .unwrap();
 
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let barchart = BarChart::default()
-                    .block(Block::bordered())
-                    .data(
-                        BarGroup::default().label("Mar".into()).bars(&[
-                            Bar::default()
-                                .value(10)
-                                .label("C1".into())
-                                .style(Style::default().fg(Color::Red))
-                                .value_style(Style::default().fg(Color::Blue)),
-                            Bar::default()
-                                .value(20)
-                                .style(Style::default().fg(Color::Green))
-                                .text_value("20M".to_string()),
-                        ]),
-                    )
-                    .data(&vec![("C1", 50), ("C2", 40)])
-                    .data(&[("C1", 60), ("C2", 90)])
-                    .data(&[("xx", 10), ("xx", 10)])
-                    .group_gap(2)
-                    .bar_width(4)
-                    .bar_gap(1);
-                f.render_widget(barchart, size);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    };
-
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "┌─────────────────────────────────┐",
         "│                             ████│",
         "│                             ████│",
@@ -92,16 +83,13 @@ fn widgets_barchart_group() {
         "│Mar                              │",
         "└─────────────────────────────────┘",
     ]);
-
     for y in 1..(TERMINAL_HEIGHT - 3) {
         for x in 1..5 {
             expected.get_mut(x, y).set_fg(Color::Red);
             expected.get_mut(x + 5, y).set_fg(Color::Green);
         }
     }
-
     expected.get_mut(2, 7).set_fg(Color::Blue);
     expected.get_mut(3, 7).set_fg(Color::Blue);
-
-    test_case(expected);
+    terminal.backend().assert_buffer(&expected);
 }

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -10,6 +10,7 @@ use ratatui::{
     },
     Terminal,
 };
+use rstest::rstest;
 
 #[test]
 fn widgets_block_renders() {
@@ -20,7 +21,7 @@ fn widgets_block_renders() {
     terminal
         .draw(|frame| frame.render_widget(block, Rect::new(0, 0, 8, 8)))
         .unwrap();
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "┌Title─┐  ",
         "│      │  ",
         "│      │  ",
@@ -40,15 +41,18 @@ fn widgets_block_renders() {
 
 #[test]
 fn widgets_block_titles_overlap() {
-    #[allow(clippy::needless_pass_by_value)]
     #[track_caller]
-    fn test_case(block: Block, area: Rect, expected: Buffer) {
+    fn test_case<'line, Lines>(block: Block, area: Rect, expected: Lines)
+    where
+        Lines: IntoIterator,
+        Lines::Item: Into<ratatui::text::Line<'line>>,
+    {
         let backend = TestBackend::new(area.width, area.height);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| frame.render_widget(block, area))
             .unwrap();
-        terminal.backend().assert_buffer(&expected);
+        terminal.backend().assert_buffer_lines(expected);
     }
 
     // Left overrides the center
@@ -58,7 +62,7 @@ fn widgets_block_titles_overlap() {
             .title(Title::from("bbb").alignment(Alignment::Center))
             .title(Title::from("ccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 10, 1),
-        Buffer::with_lines(vec!["aaaaab ccc"]),
+        ["aaaaab ccc"],
     );
 
     // Left alignment overrides the center alignment which overrides the right alignment
@@ -68,7 +72,7 @@ fn widgets_block_titles_overlap() {
             .title(Title::from("bbbbb").alignment(Alignment::Center))
             .title(Title::from("ccccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 11, 1),
-        Buffer::with_lines(vec!["aaaaabbbccc"]),
+        ["aaaaabbbccc"],
     );
 
     // Multiple left alignment overrides the center alignment and the right alignment
@@ -79,7 +83,7 @@ fn widgets_block_titles_overlap() {
             .title(Title::from("bbbbb").alignment(Alignment::Center))
             .title(Title::from("ccccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 11, 1),
-        Buffer::with_lines(vec!["aaaaabaaaaa"]),
+        ["aaaaabaaaaa"],
     );
 
     // The right alignment doesn't override the center alignment, but pierces through it
@@ -88,21 +92,20 @@ fn widgets_block_titles_overlap() {
             .title(Title::from("bbbbb").alignment(Alignment::Center))
             .title(Title::from("ccccccccccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 11, 1),
-        Buffer::with_lines(vec!["cccbbbbbccc"]),
+        ["cccbbbbbccc"],
     );
 }
 
 #[test]
 fn widgets_block_renders_on_small_areas() {
-    #[allow(clippy::needless_pass_by_value)]
     #[track_caller]
-    fn test_case(block: Block, area: Rect, expected: Buffer) {
+    fn test_case(block: Block, area: Rect, expected: &Buffer) {
         let backend = TestBackend::new(area.width, area.height);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| frame.render_widget(block, area))
             .unwrap();
-        terminal.backend().assert_buffer(&expected);
+        terminal.backend().assert_buffer(expected);
     }
 
     let one_cell_test_cases = [
@@ -117,651 +120,372 @@ fn widgets_block_renders_on_small_areas() {
         test_case(
             Block::new().borders(borders).title("Test"),
             Rect::new(0, 0, 0, 0),
-            Buffer::empty(Rect::new(0, 0, 0, 0)),
+            &Buffer::empty(Rect::new(0, 0, 0, 0)),
         );
         test_case(
             Block::new().borders(borders).title("Test"),
             Rect::new(0, 0, 1, 0),
-            Buffer::empty(Rect::new(0, 0, 1, 0)),
+            &Buffer::empty(Rect::new(0, 0, 1, 0)),
         );
         test_case(
             Block::new().borders(borders).title("Test"),
             Rect::new(0, 0, 0, 1),
-            Buffer::empty(Rect::new(0, 0, 0, 1)),
+            &Buffer::empty(Rect::new(0, 0, 0, 1)),
         );
         test_case(
             Block::new().borders(borders).title("Test"),
             Rect::new(0, 0, 1, 1),
-            Buffer::with_lines(vec![symbol]),
+            &Buffer::with_lines([symbol]),
         );
     }
     test_case(
         Block::new().borders(Borders::LEFT).title("Test"),
         Rect::new(0, 0, 4, 1),
-        Buffer::with_lines(vec!["│Tes"]),
+        &Buffer::with_lines(["│Tes"]),
     );
     test_case(
         Block::new().borders(Borders::RIGHT).title("Test"),
         Rect::new(0, 0, 4, 1),
-        Buffer::with_lines(vec!["Tes│"]),
+        &Buffer::with_lines(["Tes│"]),
     );
     test_case(
         Block::new().borders(Borders::RIGHT).title("Test"),
         Rect::new(0, 0, 4, 1),
-        Buffer::with_lines(vec!["Tes│"]),
+        &Buffer::with_lines(["Tes│"]),
     );
     test_case(
         Block::new()
             .borders(Borders::LEFT | Borders::RIGHT)
             .title("Test"),
         Rect::new(0, 0, 4, 1),
-        Buffer::with_lines(vec!["│Te│"]),
+        &Buffer::with_lines(["│Te│"]),
     );
     test_case(
         Block::new().borders(Borders::TOP).title("Test"),
         Rect::new(0, 0, 4, 1),
-        Buffer::with_lines(vec!["Test"]),
+        &Buffer::with_lines(["Test"]),
     );
     test_case(
         Block::new().borders(Borders::TOP).title("Test"),
         Rect::new(0, 0, 5, 1),
-        Buffer::with_lines(vec!["Test─"]),
+        &Buffer::with_lines(["Test─"]),
     );
     test_case(
         Block::new()
             .borders(Borders::LEFT | Borders::TOP)
             .title("Test"),
         Rect::new(0, 0, 5, 1),
-        Buffer::with_lines(vec!["┌Test"]),
+        &Buffer::with_lines(["┌Test"]),
     );
     test_case(
         Block::new()
             .borders(Borders::LEFT | Borders::TOP)
             .title("Test"),
         Rect::new(0, 0, 6, 1),
-        Buffer::with_lines(vec!["┌Test─"]),
+        &Buffer::with_lines(["┌Test─"]),
     );
 }
 
-#[allow(clippy::too_many_lines)]
-#[test]
-fn widgets_block_title_alignment() {
-    #[allow(clippy::needless_pass_by_value)]
-    #[track_caller]
-    fn test_case(alignment: Alignment, borders: Borders, expected: Buffer) {
-        let backend = TestBackend::new(15, 3);
-        let mut terminal = Terminal::new(backend).unwrap();
+#[rstest]
+#[case::left_with_all_borders(Alignment::Left, Borders::ALL, [
+    " ┌Title──────┐ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::left_without_top_border(Alignment::Left, Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+    " │Title      │ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::left_without_left_border(Alignment::Left, Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " Title───────┐ ",
+    "             │ ",
+    " ────────────┘ ",
+])]
+#[case::left_without_right_border(Alignment::Left, Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌Title─────── ",
+    " │             ",
+    " └──────────── ",
+])]
+#[case::left_without_borders(Alignment::Left, Borders::NONE, [
+    " Title         ",
+    "               ",
+    "               ",
+])]
+#[case::center_with_all_borders(Alignment::Center, Borders::ALL, [
+    " ┌───Title───┐ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::center_without_top_border(Alignment::Center, Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+    " │   Title   │ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::center_without_left_border(Alignment::Center, Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " ───Title────┐ ",
+    "             │ ",
+    " ────────────┘ ",
+])]
+#[case::center_without_right_border(Alignment::Center, Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌───Title──── ",
+    " │             ",
+    " └──────────── ",
+])]
+#[case::center_without_borders(Alignment::Center, Borders::NONE, [
+    "     Title     ",
+    "               ",
+    "               ",
+])]
+#[case::right_with_all_borders(Alignment::Right, Borders::ALL, [
+    " ┌──────Title┐ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::right_without_top_border(Alignment::Right, Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+    " │      Title│ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::right_without_left_border(Alignment::Right, Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " ───────Title┐ ",
+    "             │ ",
+    " ────────────┘ ",
+])]
+#[case::right_without_right_border(Alignment::Right, Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌───────Title ",
+    " │             ",
+    " └──────────── ",
+])]
+#[case::right_without_borders(Alignment::Right, Borders::NONE, [
+    "         Title ",
+    "               ",
+    "               ",
+])]
+fn widgets_block_title_alignment_top<'line, Lines>(
+    #[case] alignment: Alignment,
+    #[case] borders: Borders,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<ratatui::text::Line<'line>>,
+{
+    let backend = TestBackend::new(15, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
 
-        let block1 = Block::new()
-            .borders(borders)
-            .title(Title::from(Span::styled("Title", Style::default())).alignment(alignment));
+    let block1 = Block::new()
+        .borders(borders)
+        .title(Title::from(Span::raw("Title")).alignment(alignment));
 
-        let block2 = Block::new()
-            .borders(borders)
-            .title_alignment(alignment)
-            .title("Title");
+    let block2 = Block::new()
+        .borders(borders)
+        .title_alignment(alignment)
+        .title("Title");
+    let area = Rect::new(1, 0, 13, 3);
+    let expected = Buffer::with_lines(expected);
 
-        let area = Rect::new(1, 0, 13, 3);
-
-        for block in [block1, block2] {
-            terminal
-                .draw(|frame| frame.render_widget(block, area))
-                .unwrap();
-            terminal.backend().assert_buffer(&expected);
-        }
-    }
-
-    // title top-left with all borders
-    test_case(
-        Alignment::Left,
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌Title──────┐ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title top-left without top border
-    test_case(
-        Alignment::Left,
-        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " │Title      │ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title top-left with no left border
-    test_case(
-        Alignment::Left,
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " Title───────┐ ",
-            "             │ ",
-            " ────────────┘ ",
-        ]),
-    );
-
-    // title top-left without right border
-    test_case(
-        Alignment::Left,
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌Title─────── ",
-            " │             ",
-            " └──────────── ",
-        ]),
-    );
-
-    // title top-left without borders
-    test_case(
-        Alignment::Left,
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            " Title         ",
-            "               ",
-            "               ",
-        ]),
-    );
-
-    // title center with all borders
-    test_case(
-        Alignment::Center,
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌───Title───┐ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title center without top border
-    test_case(
-        Alignment::Center,
-        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " │   Title   │ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title center with no left border
-    test_case(
-        Alignment::Center,
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ───Title────┐ ",
-            "             │ ",
-            " ────────────┘ ",
-        ]),
-    );
-
-    // title center without right border
-    test_case(
-        Alignment::Center,
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌───Title──── ",
-            " │             ",
-            " └──────────── ",
-        ]),
-    );
-
-    // title center without borders
-    test_case(
-        Alignment::Center,
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            "     Title     ",
-            "               ",
-            "               ",
-        ]),
-    );
-
-    // title top-right with all borders
-    test_case(
-        Alignment::Right,
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌──────Title┐ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title top-right without top border
-    test_case(
-        Alignment::Right,
-        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " │      Title│ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title top-right with no left border
-    test_case(
-        Alignment::Right,
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ───────Title┐ ",
-            "             │ ",
-            " ────────────┘ ",
-        ]),
-    );
-
-    // title top-right without right border
-    test_case(
-        Alignment::Right,
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌───────Title ",
-            " │             ",
-            " └──────────── ",
-        ]),
-    );
-
-    // title top-right without borders
-    test_case(
-        Alignment::Right,
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            "         Title ",
-            "               ",
-            "               ",
-        ]),
-    );
-}
-
-#[allow(clippy::too_many_lines)]
-#[test]
-fn widgets_block_title_alignment_bottom() {
-    #[allow(clippy::needless_pass_by_value)]
-    #[track_caller]
-    fn test_case(alignment: Alignment, borders: Borders, expected: Buffer) {
-        let backend = TestBackend::new(15, 3);
-        let mut terminal = Terminal::new(backend).unwrap();
-
-        let title = Title::from(Span::styled("Title", Style::default()))
-            .alignment(alignment)
-            .position(Position::Bottom);
-        let block = Block::new().borders(borders).title(title);
-        let area = Rect::new(1, 0, 13, 3);
+    for block in [block1, block2] {
         terminal
             .draw(|frame| frame.render_widget(block, area))
             .unwrap();
         terminal.backend().assert_buffer(&expected);
     }
-
-    // title bottom-left with all borders
-    test_case(
-        Alignment::Left,
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌───────────┐ ",
-            " │           │ ",
-            " └Title──────┘ ",
-        ]),
-    );
-
-    // title bottom-left without bottom border
-    test_case(
-        Alignment::Left,
-        Borders::LEFT | Borders::TOP | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " ┌───────────┐ ",
-            " │           │ ",
-            " │Title      │ ",
-        ]),
-    );
-
-    // title bottom-left with no left border
-    test_case(
-        Alignment::Left,
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ────────────┐ ",
-            "             │ ",
-            " Title───────┘ ",
-        ]),
-    );
-
-    // title bottom-left without right border
-    test_case(
-        Alignment::Left,
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌──────────── ",
-            " │             ",
-            " └Title─────── ",
-        ]),
-    );
-
-    // title bottom-left without borders
-    test_case(
-        Alignment::Left,
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            "               ",
-            "               ",
-            " Title         ",
-        ]),
-    );
-
-    // title center with all borders
-    test_case(
-        Alignment::Center,
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌───────────┐ ",
-            " │           │ ",
-            " └───Title───┘ ",
-        ]),
-    );
-
-    // title center without bottom border
-    test_case(
-        Alignment::Center,
-        Borders::LEFT | Borders::TOP | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " ┌───────────┐ ",
-            " │           │ ",
-            " │   Title   │ ",
-        ]),
-    );
-
-    // title center with no left border
-    test_case(
-        Alignment::Center,
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ────────────┐ ",
-            "             │ ",
-            " ───Title────┘ ",
-        ]),
-    );
-
-    // title center without right border
-    test_case(
-        Alignment::Center,
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌──────────── ",
-            " │             ",
-            " └───Title──── ",
-        ]),
-    );
-
-    // title center without borders
-    test_case(
-        Alignment::Center,
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            "               ",
-            "               ",
-            "     Title     ",
-        ]),
-    );
-
-    // title bottom-right with all borders
-    test_case(
-        Alignment::Right,
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌───────────┐ ",
-            " │           │ ",
-            " └──────Title┘ ",
-        ]),
-    );
-
-    // title bottom-right without bottom border
-    test_case(
-        Alignment::Right,
-        Borders::LEFT | Borders::TOP | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " ┌───────────┐ ",
-            " │           │ ",
-            " │      Title│ ",
-        ]),
-    );
-
-    // title bottom-right with no left border
-    test_case(
-        Alignment::Right,
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ────────────┐ ",
-            "             │ ",
-            " ───────Title┘ ",
-        ]),
-    );
-
-    // title bottom-right without right border
-    test_case(
-        Alignment::Right,
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌──────────── ",
-            " │             ",
-            " └───────Title ",
-        ]),
-    );
-
-    // title bottom-right without borders
-    test_case(
-        Alignment::Right,
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            "               ",
-            "               ",
-            "         Title ",
-        ]),
-    );
 }
 
-#[allow(clippy::too_many_lines)]
-#[test]
-fn widgets_block_multiple_titles() {
-    #[allow(clippy::needless_pass_by_value)]
-    #[track_caller]
-    fn test_case(title_a: Title, title_b: Title, borders: Borders, expected: Buffer) {
-        let backend = TestBackend::new(15, 3);
-        let mut terminal = Terminal::new(backend).unwrap();
+#[rstest]
+#[case::left(Alignment::Left, Borders::ALL, [
+    " ┌───────────┐ ",
+    " │           │ ",
+    " └Title──────┘ ",
+])]
+#[case::left(Alignment::Left, Borders::LEFT | Borders::TOP | Borders::RIGHT, [
+    " ┌───────────┐ ",
+    " │           │ ",
+    " │Title      │ ",
+])]
+#[case::left(Alignment::Left, Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " ────────────┐ ",
+    "             │ ",
+    " Title───────┘ ",
+])]
+#[case::left(Alignment::Left, Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌──────────── ",
+    " │             ",
+    " └Title─────── ",
+])]
+#[case::left(Alignment::Left, Borders::NONE, [
+    "               ",
+    "               ",
+    " Title         ",
+])]
+#[case::left(Alignment::Center, Borders::ALL, [
+    " ┌───────────┐ ",
+    " │           │ ",
+    " └───Title───┘ ",
+])]
+#[case::left(Alignment::Center, Borders::LEFT | Borders::TOP | Borders::RIGHT, [
+    " ┌───────────┐ ",
+    " │           │ ",
+    " │   Title   │ ",
+])]
+#[case::left(Alignment::Center, Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " ────────────┐ ",
+    "             │ ",
+    " ───Title────┘ ",
+])]
+#[case::left(Alignment::Center, Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌──────────── ",
+    " │             ",
+    " └───Title──── ",
+])]
+#[case::left(Alignment::Center, Borders::NONE, [
+    "               ",
+    "               ",
+    "     Title     ",
+])]
+#[case::left(Alignment::Right, Borders::ALL, [
+    " ┌───────────┐ ",
+    " │           │ ",
+    " └──────Title┘ ",
+])]
+#[case::left(Alignment::Right, Borders::LEFT | Borders::TOP | Borders::RIGHT, [
+    " ┌───────────┐ ",
+    " │           │ ",
+    " │      Title│ ",
+])]
+#[case::left(Alignment::Right, Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " ────────────┐ ",
+    "             │ ",
+    " ───────Title┘ ",
+])]
+#[case::left(Alignment::Right, Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌──────────── ",
+    " │             ",
+    " └───────Title ",
+])]
+#[case::left(Alignment::Right, Borders::NONE, [
+    "               ",
+    "               ",
+    "         Title ",
+])]
+fn widgets_block_title_alignment_bottom<'line, Lines>(
+    #[case] alignment: Alignment,
+    #[case] borders: Borders,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<ratatui::text::Line<'line>>,
+{
+    let backend = TestBackend::new(15, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
 
-        let block = Block::new().borders(borders).title(title_a).title(title_b);
+    let title = Title::from(Span::styled("Title", Style::default()))
+        .alignment(alignment)
+        .position(Position::Bottom);
+    let block = Block::default().title(title).borders(borders);
+    let area = Rect::new(1, 0, 13, 3);
+    terminal
+        .draw(|frame| frame.render_widget(block, area))
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
+}
 
-        let area = Rect::new(1, 0, 13, 3);
-
-        terminal
-            .draw(|f| {
-                f.render_widget(block, area);
-            })
-            .unwrap();
-
-        terminal.backend().assert_buffer(&expected);
-    }
-
-    // title bottom-left with all borders
-    test_case(
-        Title::from("foo"),
-        Title::from("bar"),
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌foo─bar────┐ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title top-left without top border
-    test_case(
-        Title::from("foo"),
-        Title::from("bar"),
-        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " │foo bar    │ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title top-left with no left border
-    test_case(
-        Title::from("foo"),
-        Title::from("bar"),
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " foo─bar─────┐ ",
-            "             │ ",
-            " ────────────┘ ",
-        ]),
-    );
-
-    // title top-left without right border
-    test_case(
-        Title::from("foo"),
-        Title::from("bar"),
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌foo─bar───── ",
-            " │             ",
-            " └──────────── ",
-        ]),
-    );
-
-    // title top-left without borders
-    test_case(
-        Title::from("foo"),
-        Title::from("bar"),
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            " foo bar       ",
-            "               ",
-            "               ",
-        ]),
-    );
-
-    // title center with all borders
-    test_case(
-        Title::from("foo").alignment(Alignment::Center),
-        Title::from("bar").alignment(Alignment::Center),
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌──foo─bar──┐ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title center without top border
-    test_case(
-        Title::from("foo").alignment(Alignment::Center),
-        Title::from("bar").alignment(Alignment::Center),
-        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " │  foo bar  │ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title center with no left border
-    test_case(
-        Title::from("foo").alignment(Alignment::Center),
-        Title::from("bar").alignment(Alignment::Center),
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ──foo─bar───┐ ",
-            "             │ ",
-            " ────────────┘ ",
-        ]),
-    );
-
-    // title center without right border
-    test_case(
-        Title::from("foo").alignment(Alignment::Center),
-        Title::from("bar").alignment(Alignment::Center),
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌──foo─bar─── ",
-            " │             ",
-            " └──────────── ",
-        ]),
-    );
-
-    // title center without borders
-    test_case(
-        Title::from("foo").alignment(Alignment::Center),
-        Title::from("bar").alignment(Alignment::Center),
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            "    foo bar    ",
-            "               ",
-            "               ",
-        ]),
-    );
-
-    // title top-right with all borders
-    test_case(
-        Title::from("foo").alignment(Alignment::Right),
-        Title::from("bar").alignment(Alignment::Right),
-        Borders::ALL,
-        Buffer::with_lines(vec![
-            " ┌────foo─bar┐ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title top-right without top border
-    test_case(
-        Title::from("foo").alignment(Alignment::Right),
-        Title::from("bar").alignment(Alignment::Right),
-        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
-        Buffer::with_lines(vec![
-            " │    foo bar│ ",
-            " │           │ ",
-            " └───────────┘ ",
-        ]),
-    );
-
-    // title top-right with no left border
-    test_case(
-        Title::from("foo").alignment(Alignment::Right),
-        Title::from("bar").alignment(Alignment::Right),
-        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ─────foo─bar┐ ",
-            "             │ ",
-            " ────────────┘ ",
-        ]),
-    );
-
-    // title top-right without right border
-    test_case(
-        Title::from("foo").alignment(Alignment::Right),
-        Title::from("bar").alignment(Alignment::Right),
-        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
-        Buffer::with_lines(vec![
-            " ┌─────foo─bar ",
-            " │             ",
-            " └──────────── ",
-        ]),
-    );
-
-    // title top-right without borders
-    test_case(
-        Title::from("foo").alignment(Alignment::Right),
-        Title::from("bar").alignment(Alignment::Right),
-        Borders::NONE,
-        Buffer::with_lines(vec![
-            "       foo bar ",
-            "               ",
-            "               ",
-        ]),
-    );
+#[rstest]
+#[case::left_with_all_borders(Title::from("foo"), Title::from("bar"), Borders::ALL, [
+    " ┌foo─bar────┐ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::left_without_top_border(Title::from("foo"), Title::from("bar"), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+    " │foo bar    │ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::left_without_left_border(Title::from("foo"), Title::from("bar"), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " foo─bar─────┐ ",
+    "             │ ",
+    " ────────────┘ ",
+])]
+#[case::left_without_right_border(Title::from("foo"), Title::from("bar"), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌foo─bar───── ",
+    " │             ",
+    " └──────────── ",
+])]
+#[case::left_without_borders(Title::from("foo"), Title::from("bar"), Borders::NONE, [
+    " foo bar       ",
+    "               ",
+    "               ",
+])]
+#[case::center_with_borders(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::ALL, [
+    " ┌──foo─bar──┐ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::center_without_top_border(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+    " │  foo bar  │ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::center_without_left_border(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " ──foo─bar───┐ ",
+    "             │ ",
+    " ────────────┘ ",
+])]
+#[case::center_without_right_border(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌──foo─bar─── ",
+    " │             ",
+    " └──────────── ",
+])]
+#[case::center_without_borders(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::NONE, [
+    "    foo bar    ",
+    "               ",
+    "               ",
+])]
+#[case::right_with_all_borders(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::ALL, [
+    " ┌────foo─bar┐ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::right_without_top_border(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+    " │    foo bar│ ",
+    " │           │ ",
+    " └───────────┘ ",
+])]
+#[case::right_without_left_border(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+    " ─────foo─bar┐ ",
+    "             │ ",
+    " ────────────┘ ",
+])]
+#[case::right_without_right_border(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+    " ┌─────foo─bar ",
+    " │             ",
+    " └──────────── ",
+])]
+#[case::right_without_borders(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::NONE, [
+    "       foo bar ",
+    "               ",
+    "               ",
+])]
+fn widgets_block_multiple_titles<'line, Lines>(
+    #[case] title_a: Title,
+    #[case] title_b: Title,
+    #[case] borders: Borders,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<ratatui::text::Line<'line>>,
+{
+    let backend = TestBackend::new(15, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let block = Block::default()
+        .title(title_a)
+        .title(title_b)
+        .borders(borders);
+    let area = Rect::new(1, 0, 13, 3);
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
 }

--- a/tests/widgets_calendar.rs
+++ b/tests/widgets_calendar.rs
@@ -12,10 +12,9 @@ use ratatui::{
 use time::{Date, Month};
 
 #[track_caller]
-fn test_render<W: Widget>(widget: W, expected: &Buffer, width: u16, height: u16) {
+fn test_render<W: Widget>(widget: W, width: u16, height: u16, expected: &Buffer) {
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).unwrap();
-
     terminal
         .draw(|f| f.render_widget(widget, f.size()))
         .unwrap();
@@ -28,14 +27,14 @@ fn days_layout() {
         Date::from_calendar_date(2023, Month::January, 1).unwrap(),
         CalendarEventStore::default(),
     );
-    let expected = Buffer::with_lines(vec![
+    let expected = Buffer::with_lines([
         "  1  2  3  4  5  6  7",
         "  8  9 10 11 12 13 14",
         " 15 16 17 18 19 20 21",
         " 22 23 24 25 26 27 28",
         " 29 30 31",
     ]);
-    test_render(c, &expected, 21, 5);
+    test_render(c, 21, 5, &expected);
 }
 
 #[test]
@@ -45,7 +44,7 @@ fn days_layout_show_surrounding() {
         CalendarEventStore::default(),
     )
     .show_surrounding(Style::default());
-    let expected = Buffer::with_lines(vec![
+    let expected = Buffer::with_lines([
         " 26 27 28 29 30  1  2",
         "  3  4  5  6  7  8  9",
         " 10 11 12 13 14 15 16",
@@ -53,7 +52,7 @@ fn days_layout_show_surrounding() {
         " 24 25 26 27 28 29 30",
         " 31  1  2  3  4  5  6",
     ]);
-    test_render(c, &expected, 21, 6);
+    test_render(c, 21, 6, &expected);
 }
 
 #[test]
@@ -63,7 +62,7 @@ fn show_month_header() {
         CalendarEventStore::default(),
     )
     .show_month_header(Style::default());
-    let expected = Buffer::with_lines(vec![
+    let expected = Buffer::with_lines([
         "    January 2023     ",
         "  1  2  3  4  5  6  7",
         "  8  9 10 11 12 13 14",
@@ -71,7 +70,7 @@ fn show_month_header() {
         " 22 23 24 25 26 27 28",
         " 29 30 31",
     ]);
-    test_render(c, &expected, 21, 6);
+    test_render(c, 21, 6, &expected);
 }
 
 #[test]
@@ -81,7 +80,7 @@ fn show_weekdays_header() {
         CalendarEventStore::default(),
     )
     .show_weekdays_header(Style::default());
-    let expected = Buffer::with_lines(vec![
+    let expected = Buffer::with_lines([
         " Su Mo Tu We Th Fr Sa",
         "  1  2  3  4  5  6  7",
         "  8  9 10 11 12 13 14",
@@ -89,7 +88,7 @@ fn show_weekdays_header() {
         " 22 23 24 25 26 27 28",
         " 29 30 31",
     ]);
-    test_render(c, &expected, 21, 6);
+    test_render(c, 21, 6, &expected);
 }
 
 #[test]
@@ -101,7 +100,7 @@ fn show_combo() {
     .show_weekdays_header(Style::default())
     .show_month_header(Style::default())
     .show_surrounding(Style::default());
-    let expected = Buffer::with_lines(vec![
+    let expected = Buffer::with_lines([
         "    January 2023     ",
         " Su Mo Tu We Th Fr Sa",
         "  1  2  3  4  5  6  7",
@@ -110,5 +109,5 @@ fn show_combo() {
         " 22 23 24 25 26 27 28",
         " 29 30 31  1  2  3  4",
     ]);
-    test_render(c, &expected, 21, 7);
+    test_render(c, 21, 7, &expected);
 }

--- a/tests/widgets_canvas.rs
+++ b/tests/widgets_canvas.rs
@@ -29,7 +29,7 @@ fn widgets_canvas_draw_labels() {
         })
         .unwrap();
 
-    let mut expected = Buffer::with_lines(vec!["    ", "    ", "     ", "     ", "test "]);
+    let mut expected = Buffer::with_lines(["", "", "", "", "test "]);
     for row in 0..5 {
         for col in 0..5 {
             expected.get_mut(col, row).set_bg(Color::Yellow);

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -14,9 +14,16 @@ fn create_labels<'a>(labels: &'a [&'a str]) -> Vec<Span<'a>> {
     labels.iter().map(|l| Span::from(*l)).collect()
 }
 
-fn axis_test_case<'a, S>(width: u16, height: u16, x_axis: Axis, y_axis: Axis, lines: Vec<S>)
-where
-    S: Into<text::Line<'a>>,
+#[track_caller]
+fn axis_test_case<'line, Lines>(
+    width: u16,
+    height: u16,
+    x_axis: Axis,
+    y_axis: Axis,
+    expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<text::Line<'line>>,
 {
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).unwrap();
@@ -26,8 +33,7 @@ where
             f.render_widget(chart, f.size());
         })
         .unwrap();
-    let expected = Buffer::with_lines(lines);
-    terminal.backend().assert_buffer(&expected);
+    terminal.backend().assert_buffer_lines(expected);
 }
 
 #[rstest]
@@ -62,195 +68,192 @@ fn widgets_chart_can_render_on_small_areas(#[case] width: u16, #[case] height: u
         .unwrap();
 }
 
-#[test]
-fn widgets_chart_handles_long_labels() {
-    let test_case = |x_labels, y_labels, x_alignment, lines| {
-        let mut x_axis = Axis::default().bounds([0.0, 1.0]);
-        if let Some((left_label, right_label)) = x_labels {
-            x_axis = x_axis
-                .labels(vec![Span::from(left_label), Span::from(right_label)])
-                .labels_alignment(x_alignment);
-        }
-
-        let mut y_axis = Axis::default().bounds([0.0, 1.0]);
-        if let Some((left_label, right_label)) = y_labels {
-            y_axis = y_axis.labels(vec![Span::from(left_label), Span::from(right_label)]);
-        }
-
-        axis_test_case(10, 5, x_axis, y_axis, lines);
-    };
-
-    test_case(
-        Some(("AAAA", "B")),
-        None,
-        Alignment::Left,
-        vec![
-            "          ",
-            "          ",
-            "          ",
-            "   ───────",
-            "AAA      B",
-        ],
-    );
-    test_case(
-        Some(("A", "BBBB")),
-        None,
-        Alignment::Left,
-        vec![
-            "          ",
-            "          ",
-            "          ",
-            " ─────────",
-            "A     BBBB",
-        ],
-    );
-    test_case(
-        Some(("AAAAAAAAAAA", "B")),
-        None,
-        Alignment::Left,
-        vec![
-            "          ",
-            "          ",
-            "          ",
-            "   ───────",
-            "AAA      B",
-        ],
-    );
-    test_case(
-        Some(("A", "B")),
-        Some(("CCCCCCC", "D")),
-        Alignment::Left,
-        vec![
-            "D  │      ",
-            "   │      ",
-            "CCC│      ",
-            "   └──────",
-            "   A     B",
-        ],
-    );
-    test_case(
-        Some(("AAAAAAAAAA", "B")),
-        Some(("C", "D")),
-        Alignment::Center,
-        vec![
-            "D  │      ",
-            "   │      ",
-            "C  │      ",
-            "   └──────",
-            "AAAAAAA  B",
-        ],
-    );
-    test_case(
-        Some(("AAAAAAA", "B")),
-        Some(("C", "D")),
-        Alignment::Right,
-        vec![
-            "D│        ",
-            " │        ",
-            "C│        ",
-            " └────────",
-            " AAAAA   B",
-        ],
-    );
-    test_case(
-        Some(("AAAAAAA", "BBBBBBB")),
-        Some(("C", "D")),
-        Alignment::Right,
-        vec![
-            "D│        ",
-            " │        ",
-            "C│        ",
-            " └────────",
-            " AAAAABBBB",
-        ],
-    );
+#[rstest]
+#[case(
+    Some(("AAAA", "B")),
+    None,
+    Alignment::Left,
+    vec![
+        "          ",
+        "          ",
+        "          ",
+        "   ───────",
+        "AAA      B",
+    ],
+)]
+#[case(
+    Some(("A", "BBBB")),
+    None,
+    Alignment::Left,
+    vec![
+        "          ",
+        "          ",
+        "          ",
+        " ─────────",
+        "A     BBBB",
+    ],
+)]
+#[case(
+    Some(("AAAAAAAAAAA", "B")),
+    None,
+    Alignment::Left,
+    vec![
+        "          ",
+        "          ",
+        "          ",
+        "   ───────",
+        "AAA      B",
+    ],
+)]
+#[case(
+    Some(("A", "B")),
+    Some(("CCCCCCC", "D")),
+    Alignment::Left,
+    vec![
+        "D  │      ",
+        "   │      ",
+        "CCC│      ",
+        "   └──────",
+        "   A     B",
+    ],
+)]
+#[case(
+    Some(("AAAAAAAAAA", "B")),
+    Some(("C", "D")),
+    Alignment::Center,
+    vec![
+        "D  │      ",
+        "   │      ",
+        "C  │      ",
+        "   └──────",
+        "AAAAAAA  B",
+    ],
+)]
+#[case(
+    Some(("AAAAAAA", "B")),
+    Some(("C", "D")),
+    Alignment::Right,
+    vec![
+        "D│        ",
+        " │        ",
+        "C│        ",
+        " └────────",
+        " AAAAA   B",
+    ],
+)]
+#[case(
+    Some(("AAAAAAA", "BBBBBBB")),
+    Some(("C", "D")),
+    Alignment::Right,
+    vec![
+        "D│        ",
+        " │        ",
+        "C│        ",
+        " └────────",
+        " AAAAABBBB",
+    ],
+)]
+fn widgets_chart_handles_long_labels<'line, Lines>(
+    #[case] x_labels: Option<(&str, &str)>,
+    #[case] y_labels: Option<(&str, &str)>,
+    #[case] x_alignment: Alignment,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<text::Line<'line>>,
+{
+    let mut x_axis = Axis::default().bounds([0.0, 1.0]);
+    if let Some((left_label, right_label)) = x_labels {
+        x_axis = x_axis
+            .labels(vec![Span::from(left_label), Span::from(right_label)])
+            .labels_alignment(x_alignment);
+    }
+    let mut y_axis = Axis::default().bounds([0.0, 1.0]);
+    if let Some((left_label, right_label)) = y_labels {
+        y_axis = y_axis.labels(vec![Span::from(left_label), Span::from(right_label)]);
+    }
+    axis_test_case(10, 5, x_axis, y_axis, expected);
 }
 
-#[test]
-fn widgets_chart_handles_x_axis_labels_alignments() {
-    let test_case = |y_alignment, lines| {
-        let x_axis = Axis::default()
-            .labels(vec![Span::from("AAAA"), Span::from("B"), Span::from("C")])
-            .labels_alignment(y_alignment);
-
-        let y_axis = Axis::default();
-
-        axis_test_case(10, 5, x_axis, y_axis, lines);
-    };
-
-    test_case(
-        Alignment::Left,
-        vec![
-            "          ",
-            "          ",
-            "          ",
-            "   ───────",
-            "AAA   B  C",
-        ],
-    );
-    test_case(
-        Alignment::Center,
-        vec![
-            "          ",
-            "          ",
-            "          ",
-            "  ────────",
-            "AAAA B   C",
-        ],
-    );
-    test_case(
-        Alignment::Right,
-        vec![
-            "          ",
-            "          ",
-            "          ",
-            "──────────",
-            "AAA  B   C",
-        ],
-    );
+#[rstest]
+#[case::left(
+    Alignment::Left,
+    vec![
+        "          ",
+        "          ",
+        "          ",
+        "   ───────",
+        "AAA   B  C",
+    ],
+)]
+#[case::center(
+    Alignment::Center,
+    vec![
+        "          ",
+        "          ",
+        "          ",
+        "  ────────",
+        "AAAA B   C",
+    ],
+)]
+#[case::right(
+    Alignment::Right,
+    vec![
+        "          ",
+        "          ",
+        "          ",
+        "──────────",
+        "AAA  B   C",
+    ],
+)]
+fn widgets_chart_handles_x_axis_labels_alignments<'line, Lines>(
+    #[case] y_alignment: Alignment,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<text::Line<'line>>,
+{
+    let x_axis = Axis::default()
+        .labels(vec![Span::from("AAAA"), Span::from("B"), Span::from("C")])
+        .labels_alignment(y_alignment);
+    let y_axis = Axis::default();
+    axis_test_case(10, 5, x_axis, y_axis, expected);
 }
 
-#[test]
-fn widgets_chart_handles_y_axis_labels_alignments() {
-    let test_case = |y_alignment, lines| {
-        let x_axis = Axis::default().labels(create_labels(&["AAAAA", "B"]));
-
-        let y_axis = Axis::default()
-            .labels(create_labels(&["C", "D"]))
-            .labels_alignment(y_alignment);
-
-        axis_test_case(20, 5, x_axis, y_axis, lines);
-    };
-    test_case(
-        Alignment::Left,
-        vec![
-            "D   │               ",
-            "    │               ",
-            "C   │               ",
-            "    └───────────────",
-            "AAAAA              B",
-        ],
-    );
-    test_case(
-        Alignment::Center,
-        vec![
-            "  D │               ",
-            "    │               ",
-            "  C │               ",
-            "    └───────────────",
-            "AAAAA              B",
-        ],
-    );
-    test_case(
-        Alignment::Right,
-        vec![
-            "   D│               ",
-            "    │               ",
-            "   C│               ",
-            "    └───────────────",
-            "AAAAA              B",
-        ],
-    );
+#[rstest]
+#[case::left(Alignment::Left, [
+    "D   │               ",
+    "    │               ",
+    "C   │               ",
+    "    └───────────────",
+    "AAAAA              B",
+])]
+#[case::center(Alignment::Center, [
+    "  D │               ",
+    "    │               ",
+    "  C │               ",
+    "    └───────────────",
+    "AAAAA              B",
+])]
+#[case::right(Alignment::Right, [
+    "   D│               ",
+    "    │               ",
+    "   C│               ",
+    "    └───────────────",
+    "AAAAA              B",
+])]
+fn widgets_chart_handles_y_axis_labels_alignments<'line, Lines>(
+    #[case] y_alignment: Alignment,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<text::Line<'line>>,
+{
+    let x_axis = Axis::default().labels(create_labels(&["AAAAA", "B"]));
+    let y_axis = Axis::default()
+        .labels(create_labels(&["C", "D"]))
+        .labels_alignment(y_alignment);
+    axis_test_case(20, 5, x_axis, y_axis, expected);
 }
 
 #[test]
@@ -431,7 +434,7 @@ fn widgets_chart_can_have_a_legend() {
             );
         })
         .unwrap();
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "┌Chart Test────────────────────────────────────────────────┐",
         "│10.0│Y Axis                                    ┌─────────┐│",
         "│    │  ••                                      │Dataset 1││",
@@ -611,7 +614,6 @@ fn widgets_chart_can_have_a_legend() {
     for (col, row) in x_axis_title {
         expected.get_mut(col, row).set_fg(Color::Yellow);
     }
-
     terminal.backend().assert_buffer(&expected);
 }
 
@@ -641,7 +643,7 @@ fn widgets_chart_top_line_styling_is_correct() {
         })
         .unwrap();
 
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "b│abc••••",
         " │       ",
         " │       ",

--- a/tests/widgets_gauge.rs
+++ b/tests/widgets_gauge.rs
@@ -35,7 +35,7 @@ fn widgets_gauge_renders() {
             f.render_widget(gauge, chunks[1]);
         })
         .unwrap();
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "                                        ",
         "                                        ",
         "  ┌Percentage────────────────────────┐  ",
@@ -82,7 +82,7 @@ fn widgets_gauge_renders_no_unicode() {
             f.render_widget(gauge, chunks[1]);
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec![
+    terminal.backend().assert_buffer_lines([
         "                                        ",
         "                                        ",
         "  ┌Percentage────────────────────────┐  ",
@@ -94,7 +94,6 @@ fn widgets_gauge_renders_no_unicode() {
         "                                        ",
         "                                        ",
     ]);
-    terminal.backend().assert_buffer(&expected);
 }
 
 #[test]
@@ -119,7 +118,7 @@ fn widgets_gauge_applies_styles() {
             f.render_widget(gauge, f.size());
         })
         .unwrap();
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "┌Test──────┐",
         "│████      │",
         "│███43%    │",
@@ -171,8 +170,7 @@ fn widgets_gauge_supports_large_labels() {
             f.render_widget(gauge, f.size());
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec!["4333333333"]);
-    terminal.backend().assert_buffer(&expected);
+    terminal.backend().assert_buffer_lines(["4333333333"]);
 }
 
 #[test]
@@ -209,7 +207,7 @@ fn widgets_line_gauge_renders() {
             );
         })
         .unwrap();
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "43% ────────────────",
         "┌Gauge 2───────────┐",
         "│21% ━━━━━━━━━━━━━━│",

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -8,6 +8,7 @@ use ratatui::{
     widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListState},
     Terminal,
 };
+use rstest::rstest;
 
 #[test]
 fn list_should_shows_the_length() {
@@ -45,7 +46,12 @@ fn widgets_list_should_highlight_the_selected_item() {
             f.render_stateful_widget(list, size, &mut state);
         })
         .unwrap();
-    let mut expected = Buffer::with_lines(vec!["   Item 1 ", ">> Item 2 ", "   Item 3 "]);
+    #[rustfmt::skip]
+    let mut expected = Buffer::with_lines([
+        "   Item 1 ",
+        ">> Item 2 ",
+        "   Item 3 ",
+    ]);
     for x in 0..10 {
         expected.get_mut(x, 1).set_bg(Color::Yellow);
     }
@@ -75,9 +81,12 @@ fn widgets_list_should_highlight_the_selected_item_wide_symbol() {
             f.render_stateful_widget(list, size, &mut state);
         })
         .unwrap();
-
-    let mut expected = Buffer::with_lines(vec!["   Item 1 ", "▶  Item 2 ", "   Item 3 "]);
-
+    #[rustfmt::skip]
+    let mut expected = Buffer::with_lines([
+        "   Item 1 ",
+        "▶  Item 2 ",
+        "   Item 3 ",
+    ]);
     for x in 0..10 {
         expected.get_mut(x, 1).set_bg(Color::Yellow);
     }
@@ -95,7 +104,7 @@ fn widgets_list_should_truncate_items() {
     let backend = TestBackend::new(10, 2);
     let mut terminal = Terminal::new(backend).unwrap();
 
-    let cases = vec![
+    let cases = [
         // An item is selected
         TruncateTestCase {
             selected: Some(0),
@@ -103,7 +112,7 @@ fn widgets_list_should_truncate_items() {
                 ListItem::new("A very long line"),
                 ListItem::new("A very long line"),
             ],
-            expected: Buffer::with_lines(vec![
+            expected: Buffer::with_lines([
                 format!(">> A ve{}  ", symbols::line::VERTICAL),
                 format!("   A ve{}  ", symbols::line::VERTICAL),
             ]),
@@ -115,7 +124,7 @@ fn widgets_list_should_truncate_items() {
                 ListItem::new("A very long line"),
                 ListItem::new("A very long line"),
             ],
-            expected: Buffer::with_lines(vec![
+            expected: Buffer::with_lines([
                 format!("A very {}  ", symbols::line::VERTICAL),
                 format!("A very {}  ", symbols::line::VERTICAL),
             ]),
@@ -159,8 +168,12 @@ fn widgets_list_should_clamp_offset_if_items_are_removed() {
             f.render_stateful_widget(list, size, &mut state);
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec!["   Item 2 ", "   Item 3 ", "   Item 4 ", ">> Item 5 "]);
-    terminal.backend().assert_buffer(&expected);
+    terminal.backend().assert_buffer_lines([
+        "   Item 2 ",
+        "   Item 3 ",
+        "   Item 4 ",
+        ">> Item 5 ",
+    ]);
 
     // render again with 1 items => check offset is clamped to 1
     state.select(Some(1));
@@ -172,8 +185,12 @@ fn widgets_list_should_clamp_offset_if_items_are_removed() {
             f.render_stateful_widget(list, size, &mut state);
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec!["   Item 3 ", "          ", "          ", "          "]);
-    terminal.backend().assert_buffer(&expected);
+    terminal.backend().assert_buffer_lines([
+        "   Item 3 ",
+        "          ",
+        "          ",
+        "          ",
+    ]);
 }
 
 #[test]
@@ -196,7 +213,7 @@ fn widgets_list_should_display_multiline_items() {
             f.render_stateful_widget(list, size, &mut state);
         })
         .unwrap();
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "   Item 1 ",
         "   Item 1a",
         ">> Item 2 ",
@@ -232,7 +249,7 @@ fn widgets_list_should_repeat_highlight_symbol() {
             f.render_stateful_widget(list, size, &mut state);
         })
         .unwrap();
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "   Item 1 ",
         "   Item 1a",
         ">> Item 2 ",
@@ -251,7 +268,6 @@ fn widgets_list_should_repeat_highlight_symbol() {
 fn widget_list_should_not_ignore_empty_string_items() {
     let backend = TestBackend::new(6, 4);
     let mut terminal = Terminal::new(backend).unwrap();
-
     terminal
         .draw(|f| {
             let items = vec![
@@ -268,134 +284,98 @@ fn widget_list_should_not_ignore_empty_string_items() {
             f.render_widget(list, f.size());
         })
         .unwrap();
-
-    let expected = Buffer::with_lines(vec!["Item 1", "", "", "Item 4"]);
-
-    terminal.backend().assert_buffer(&expected);
+    terminal
+        .backend()
+        .assert_buffer_lines(["Item 1", "", "", "Item 4"]);
 }
 
-#[allow(clippy::too_many_lines)]
-#[test]
-fn widgets_list_enable_always_highlight_spacing() {
-    let test_case = |state: &mut ListState, space: HighlightSpacing, expected: Buffer| {
-        let backend = TestBackend::new(30, 8);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let table = List::new(vec![
-                    ListItem::new(vec![Line::from("Item 1"), Line::from("Item 1a")]),
-                    ListItem::new(vec![Line::from("Item 2"), Line::from("Item 2b")]),
-                    ListItem::new(vec![Line::from("Item 3"), Line::from("Item 3c")]),
-                ])
-                .block(Block::bordered())
-                .highlight_symbol(">> ")
-                .highlight_spacing(space);
-                f.render_stateful_widget(table, size, state);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    };
-
-    assert_eq!(HighlightSpacing::default(), HighlightSpacing::WhenSelected);
-
-    let mut state = ListState::default();
-    // no selection, "WhenSelected" should only allocate if selected
-    test_case(
-        &mut state,
-        HighlightSpacing::default(),
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Item 1                      │",
-            "│Item 1a                     │",
-            "│Item 2                      │",
-            "│Item 2b                     │",
-            "│Item 3                      │",
-            "│Item 3c                     │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // no selection, "Always" should allocate regardless if selected or not
-    test_case(
-        &mut state,
-        HighlightSpacing::Always,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│   Item 1                   │",
-            "│   Item 1a                  │",
-            "│   Item 2                   │",
-            "│   Item 2b                  │",
-            "│   Item 3                   │",
-            "│   Item 3c                  │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // no selection, "Never" should never allocate regadless if selected or not
-    test_case(
-        &mut state,
-        HighlightSpacing::Never,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Item 1                      │",
-            "│Item 1a                     │",
-            "│Item 2                      │",
-            "│Item 2b                     │",
-            "│Item 3                      │",
-            "│Item 3c                     │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select first, "WhenSelected" should only allocate if selected
-    state.select(Some(0));
-    test_case(
-        &mut state,
-        HighlightSpacing::default(),
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│>> Item 1                   │",
-            "│   Item 1a                  │",
-            "│   Item 2                   │",
-            "│   Item 2b                  │",
-            "│   Item 3                   │",
-            "│   Item 3c                  │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select first, "Always" should allocate regardless if selected or not
-    state.select(Some(0));
-    test_case(
-        &mut state,
-        HighlightSpacing::Always,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│>> Item 1                   │",
-            "│   Item 1a                  │",
-            "│   Item 2                   │",
-            "│   Item 2b                  │",
-            "│   Item 3                   │",
-            "│   Item 3c                  │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select first, "Never" should never allocate regadless if selected or not
-    state.select(Some(0));
-    test_case(
-        &mut state,
-        HighlightSpacing::Never,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Item 1                      │",
-            "│Item 1a                     │",
-            "│Item 2                      │",
-            "│Item 2b                     │",
-            "│Item 3                      │",
-            "│Item 3c                     │",
-            "└────────────────────────────┘",
-        ]),
-    );
+#[rstest]
+#[case::none_when_selected(None, HighlightSpacing::WhenSelected, [
+    "┌─────────────┐",
+    "│Item 1       │",
+    "│Item 1a      │",
+    "│Item 2       │",
+    "│Item 2b      │",
+    "│Item 3       │",
+    "│Item 3c      │",
+    "└─────────────┘",
+])]
+#[case::none_always(None, HighlightSpacing::Always, [
+    "┌─────────────┐",
+    "│   Item 1    │",
+    "│   Item 1a   │",
+    "│   Item 2    │",
+    "│   Item 2b   │",
+    "│   Item 3    │",
+    "│   Item 3c   │",
+    "└─────────────┘",
+])]
+#[case::none_never(None, HighlightSpacing::Never, [
+    "┌─────────────┐",
+    "│Item 1       │",
+    "│Item 1a      │",
+    "│Item 2       │",
+    "│Item 2b      │",
+    "│Item 3       │",
+    "│Item 3c      │",
+    "└─────────────┘",
+])]
+#[case::first_when_selected(Some(0), HighlightSpacing::WhenSelected, [
+    "┌─────────────┐",
+    "│>> Item 1    │",
+    "│   Item 1a   │",
+    "│   Item 2    │",
+    "│   Item 2b   │",
+    "│   Item 3    │",
+    "│   Item 3c   │",
+    "└─────────────┘",
+])]
+#[case::first_always(Some(0), HighlightSpacing::Always, [
+    "┌─────────────┐",
+    "│>> Item 1    │",
+    "│   Item 1a   │",
+    "│   Item 2    │",
+    "│   Item 2b   │",
+    "│   Item 3    │",
+    "│   Item 3c   │",
+    "└─────────────┘",
+])]
+#[case::first_never(Some(0), HighlightSpacing::Never, [
+    "┌─────────────┐",
+    "│Item 1       │",
+    "│Item 1a      │",
+    "│Item 2       │",
+    "│Item 2b      │",
+    "│Item 3       │",
+    "│Item 3c      │",
+    "└─────────────┘",
+])]
+fn widgets_list_enable_always_highlight_spacing<'line, Lines>(
+    #[case] selected: Option<usize>,
+    #[case] space: HighlightSpacing,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let mut state = ListState::default().with_selected(selected);
+    let backend = TestBackend::new(15, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = List::new(vec![
+                ListItem::new(vec![Line::from("Item 1"), Line::from("Item 1a")]),
+                ListItem::new(vec![Line::from("Item 2"), Line::from("Item 2b")]),
+                ListItem::new(vec![Line::from("Item 3"), Line::from("Item 3c")]),
+            ])
+            .block(Block::bordered())
+            .highlight_symbol(">> ")
+            .highlight_spacing(space);
+            f.render_stateful_widget(table, size, &mut state);
+        })
+        .unwrap();
+    terminal
+        .backend()
+        .assert_buffer(&Buffer::with_lines(expected));
 }

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -9,19 +9,17 @@ use ratatui::{
 
 /// Tests the [`Paragraph`] widget against the expected [`Buffer`] by rendering it onto an equal
 /// area and comparing the rendered and expected content.
-#[allow(clippy::needless_pass_by_value)]
-fn test_case(paragraph: Paragraph, expected: Buffer) {
+#[track_caller]
+fn test_case(paragraph: Paragraph, expected: &Buffer) {
     let backend = TestBackend::new(expected.area.width, expected.area.height);
     let mut terminal = Terminal::new(backend).unwrap();
-
     terminal
         .draw(|f| {
             let size = f.size();
             f.render_widget(paragraph, size);
         })
         .unwrap();
-
-    terminal.backend().assert_buffer(&expected);
+    terminal.backend().assert_buffer(expected);
 }
 
 #[test]
@@ -35,7 +33,7 @@ fn widgets_paragraph_renders_double_width_graphemes() {
 
     test_case(
         paragraph,
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌────────┐",
             "│コンピュ│",
             "│ータ上で│",
@@ -66,8 +64,7 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
             f.render_widget(paragraph, size);
         })
         .unwrap();
-
-    let expected = Buffer::with_lines(vec![
+    terminal.backend().assert_buffer_lines([
         // The internal width is 8 so only 4 slots for double-width characters.
         "┌────────┐",
         "│aコンピ │", // Here we have 1 latin character so only 3 double-width ones can fit.
@@ -77,7 +74,6 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
         "│、      │",
         "└────────┘",
     ]);
-    terminal.backend().assert_buffer(&expected);
 }
 
 #[test]
@@ -88,7 +84,7 @@ fn widgets_paragraph_can_wrap_with_a_trailing_nbsp() {
 
     test_case(
         paragraph,
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│NBSP\u{00a0}             │",
             "└──────────────────┘",
@@ -104,7 +100,7 @@ fn widgets_paragraph_can_scroll_horizontally() {
 
     test_case(
         paragraph.clone().alignment(Alignment::Left).scroll((0, 7)),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│在可以水平滚动了！│",
             "│ph can scroll hori│",
@@ -120,7 +116,7 @@ fn widgets_paragraph_can_scroll_horizontally() {
     // only support Alignment::Left
     test_case(
         paragraph.clone().alignment(Alignment::Right).scroll((0, 7)),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│段落现在可以水平滚│",
             "│Paragraph can scro│",
@@ -149,7 +145,7 @@ fn widgets_paragraph_can_wrap_its_content() {
 
     test_case(
         paragraph.clone().alignment(Alignment::Left),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│The library is    │",
             "│based on the      │",
@@ -164,7 +160,7 @@ fn widgets_paragraph_can_wrap_its_content() {
     );
     test_case(
         paragraph.clone().alignment(Alignment::Center),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│  The library is  │",
             "│   based on the   │",
@@ -179,7 +175,7 @@ fn widgets_paragraph_can_wrap_its_content() {
     );
     test_case(
         paragraph.clone().alignment(Alignment::Right),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│    The library is│",
             "│      based on the│",
@@ -208,7 +204,7 @@ fn widgets_paragraph_works_with_padding() {
 
     test_case(
         paragraph.clone().alignment(Alignment::Left),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌────────────────────┐",
             "│                    │",
             "│  The library is    │",
@@ -224,8 +220,8 @@ fn widgets_paragraph_works_with_padding() {
         ]),
     );
     test_case(
-        paragraph.alignment(Alignment::Right),
-        Buffer::with_lines(vec![
+        paragraph.clone().alignment(Alignment::Right),
+        &Buffer::with_lines([
             "┌────────────────────┐",
             "│                    │",
             "│    The library is  │",
@@ -250,7 +246,7 @@ fn widgets_paragraph_works_with_padding() {
 
     test_case(
         paragraph.alignment(Alignment::Right),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌────────────────────┐",
             "│                    │",
             "│   This is always   │",
@@ -284,7 +280,7 @@ fn widgets_paragraph_can_align_spans() {
 
     test_case(
         paragraph.clone().alignment(Alignment::Left),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│  This string will│",
             "│      override the│",
@@ -299,7 +295,7 @@ fn widgets_paragraph_can_align_spans() {
     );
     test_case(
         paragraph.alignment(Alignment::Center),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│  This string will│",
             "│      override the│",
@@ -333,7 +329,7 @@ fn widgets_paragraph_can_align_spans() {
 
     test_case(
         paragraph.clone().alignment(Alignment::Right),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│This string       │",
             "│will override the │",
@@ -348,7 +344,7 @@ fn widgets_paragraph_can_align_spans() {
     );
     test_case(
         paragraph.alignment(Alignment::Left),
-        Buffer::with_lines(vec![
+        &Buffer::with_lines([
             "┌──────────────────┐",
             "│This string       │",
             "│will override the │",

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -9,760 +9,628 @@ use ratatui::{
     widgets::{Block, Borders, Cell, HighlightSpacing, Row, Table, TableState},
     Terminal,
 };
+use rstest::rstest;
 
-#[test]
-fn widgets_table_column_spacing_can_be_changed() {
-    let test_case = |column_spacing, expected| {
-        let backend = TestBackend::new(30, 10);
-        let mut terminal = Terminal::new(backend).unwrap();
-
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let table = Table::new(
-                    vec![
-                        Row::new(vec!["Row11", "Row12", "Row13"]),
-                        Row::new(vec!["Row21", "Row22", "Row23"]),
-                        Row::new(vec!["Row31", "Row32", "Row33"]),
-                        Row::new(vec!["Row41", "Row42", "Row43"]),
-                    ],
-                    [
-                        Constraint::Length(5),
-                        Constraint::Length(5),
-                        Constraint::Length(5),
-                    ],
-                )
-                .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::bordered())
-                .column_spacing(column_spacing);
-                f.render_widget(table, size);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    };
-
-    // no space between columns
-    test_case(
-        0,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1Head2Head3             │",
-            "│                            │",
-            "│Row11Row12Row13             │",
-            "│Row21Row22Row23             │",
-            "│Row31Row32Row33             │",
-            "│Row41Row42Row43             │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // one space between columns
-    test_case(
-        1,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1 Head2 Head3           │",
-            "│                            │",
-            "│Row11 Row12 Row13           │",
-            "│Row21 Row22 Row23           │",
-            "│Row31 Row32 Row33           │",
-            "│Row41 Row42 Row43           │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // enough space to just not hide the third column
-    test_case(
-        6,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1      Head2      Head3 │",
-            "│                            │",
-            "│Row11      Row12      Row13 │",
-            "│Row21      Row22      Row23 │",
-            "│Row31      Row32      Row33 │",
-            "│Row41      Row42      Row43 │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // enough space to hide part of the third column
-    test_case(
-        7,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1       Head       Head3│",
-            "│                            │",
-            "│Row11       Row1       Row13│",
-            "│Row21       Row2       Row23│",
-            "│Row31       Row3       Row33│",
-            "│Row41       Row4       Row43│",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
+#[rstest]
+#[case::no_space_between_columns(0, [
+    "┌────────────────────────────┐",
+    "│Head1Head2Head3             │",
+    "│                            │",
+    "│Row11Row12Row13             │",
+    "│Row21Row22Row23             │",
+    "│Row31Row32Row33             │",
+    "│Row41Row42Row43             │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::one_space_between_columns(1, [
+    "┌────────────────────────────┐",
+    "│Head1 Head2 Head3           │",
+    "│                            │",
+    "│Row11 Row12 Row13           │",
+    "│Row21 Row22 Row23           │",
+    "│Row31 Row32 Row33           │",
+    "│Row41 Row42 Row43           │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::large_width_just_before_pushing_a_column_off(6, [
+    "┌────────────────────────────┐",
+    "│Head1      Head2      Head3 │",
+    "│                            │",
+    "│Row11      Row12      Row13 │",
+    "│Row21      Row22      Row23 │",
+    "│Row31      Row32      Row33 │",
+    "│Row41      Row42      Row43 │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::large_width_pushes_part_of_third_column_off(7, [
+    "┌────────────────────────────┐",
+    "│Head1       Head       Head3│",
+    "│                            │",
+    "│Row11       Row1       Row13│",
+    "│Row21       Row2       Row23│",
+    "│Row31       Row3       Row33│",
+    "│Row41       Row4       Row43│",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+fn widgets_table_column_spacing_can_be_changed<'line, Lines>(
+    #[case] column_spacing: u16,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let backend = TestBackend::new(30, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(
+                vec![
+                    Row::new(vec!["Row11", "Row12", "Row13"]),
+                    Row::new(vec!["Row21", "Row22", "Row23"]),
+                    Row::new(vec!["Row31", "Row32", "Row33"]),
+                    Row::new(vec!["Row41", "Row42", "Row43"]),
+                ],
+                [
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                ],
+            )
+            .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+            .block(Block::bordered())
+            .column_spacing(column_spacing);
+            f.render_widget(table, size);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
 }
 
-#[test]
-fn widgets_table_columns_widths_can_use_fixed_length_constraints() {
-    let test_case = |widths, expected| {
-        let backend = TestBackend::new(30, 10);
-        let mut terminal = Terminal::new(backend).unwrap();
-
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let table = Table::new(
-                    vec![
-                        Row::new(vec!["Row11", "Row12", "Row13"]),
-                        Row::new(vec!["Row21", "Row22", "Row23"]),
-                        Row::new(vec!["Row31", "Row32", "Row33"]),
-                        Row::new(vec!["Row41", "Row42", "Row43"]),
-                    ],
-                    widths,
-                )
-                .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::bordered());
-                f.render_widget(table, size);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    };
-
-    // columns of zero width show nothing
-    test_case(
-        &[
-            Constraint::Length(0),
-            Constraint::Length(0),
-            Constraint::Length(0),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of 1 width trim
-    test_case(
-        &[
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│H H H                       │",
-            "│                            │",
-            "│R R R                       │",
-            "│R R R                       │",
-            "│R R R                       │",
-            "│R R R                       │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of large width just before pushing a column off
-    test_case(
-        &[
-            Constraint::Length(8),
-            Constraint::Length(8),
-            Constraint::Length(8),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1    Head2    Head3     │",
-            "│                            │",
-            "│Row11    Row12    Row13     │",
-            "│Row21    Row22    Row23     │",
-            "│Row31    Row32    Row33     │",
-            "│Row41    Row42    Row43     │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
+#[rstest]
+#[case::zero_width_shows_nothing( &[
+    Constraint::Length(0),
+    Constraint::Length(0),
+    Constraint::Length(0),
+], [
+    "┌────────────────────────────┐",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::slim_columns_trim_data(&[
+    Constraint::Length(1),
+    Constraint::Length(1),
+    Constraint::Length(1),
+], [
+    "┌────────────────────────────┐",
+    "│H H H                       │",
+    "│                            │",
+    "│R R R                       │",
+    "│R R R                       │",
+    "│R R R                       │",
+    "│R R R                       │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::large_width_just_before_pushing_a_column_off(&[
+    Constraint::Length(8),
+    Constraint::Length(8),
+    Constraint::Length(8),
+], [
+    "┌────────────────────────────┐",
+    "│Head1    Head2    Head3     │",
+    "│                            │",
+    "│Row11    Row12    Row13     │",
+    "│Row21    Row22    Row23     │",
+    "│Row31    Row32    Row33     │",
+    "│Row41    Row42    Row43     │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+fn widgets_table_columns_widths_can_use_fixed_length_constraints<'line, Lines>(
+    #[case] widths: &[Constraint],
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let backend = TestBackend::new(30, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(
+                vec![
+                    Row::new(vec!["Row11", "Row12", "Row13"]),
+                    Row::new(vec!["Row21", "Row22", "Row23"]),
+                    Row::new(vec!["Row31", "Row32", "Row33"]),
+                    Row::new(vec!["Row41", "Row42", "Row43"]),
+                ],
+                widths,
+            )
+            .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+            .block(Block::bordered());
+            f.render_widget(table, size);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
 }
 
-#[test]
-fn widgets_table_columns_widths_can_use_percentage_constraints() {
-    #[allow(clippy::needless_pass_by_value)]
-    #[track_caller]
-    fn test_case(widths: &[Constraint], expected: Buffer) {
-        let backend = TestBackend::new(30, 10);
-        let mut terminal = Terminal::new(backend).unwrap();
-
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let table = Table::new(
-                    vec![
-                        Row::new(vec!["Row11", "Row12", "Row13"]),
-                        Row::new(vec!["Row21", "Row22", "Row23"]),
-                        Row::new(vec!["Row31", "Row32", "Row33"]),
-                        Row::new(vec!["Row41", "Row42", "Row43"]),
-                    ],
-                    widths,
-                )
-                .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::bordered())
-                .column_spacing(0);
-                f.render_widget(table, size);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    }
-
-    // columns of zero width show nothing
-    test_case(
-        &[
-            Constraint::Percentage(0),
-            Constraint::Percentage(0),
-            Constraint::Percentage(0),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of not enough width trims the data
-    test_case(
-        &[
-            Constraint::Percentage(11),
-            Constraint::Percentage(11),
-            Constraint::Percentage(11),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│HeaHeaHea                   │",
-            "│                            │",
-            "│RowRowRow                   │",
-            "│RowRowRow                   │",
-            "│RowRowRow                   │",
-            "│RowRowRow                   │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of large width just before pushing a column off
-    test_case(
-        &[
-            Constraint::Percentage(33),
-            Constraint::Percentage(33),
-            Constraint::Percentage(33),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1    Head2    Head3     │",
-            "│                            │",
-            "│Row11    Row12    Row13     │",
-            "│Row21    Row22    Row23     │",
-            "│Row31    Row32    Row33     │",
-            "│Row41    Row42    Row43     │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // percentages summing to 100 should give equal widths
-    test_case(
-        &[Constraint::Percentage(50), Constraint::Percentage(50)],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1         Head2         │",
-            "│                            │",
-            "│Row11         Row12         │",
-            "│Row21         Row22         │",
-            "│Row31         Row32         │",
-            "│Row41         Row42         │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
+#[rstest]
+#[case::zero_width_shows_nothing(&[
+    Constraint::Percentage(0),
+    Constraint::Percentage(0),
+    Constraint::Percentage(0),
+], [
+    "┌────────────────────────────┐",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::slim_columns_trim_data(&[
+    Constraint::Percentage(11),
+    Constraint::Percentage(11),
+    Constraint::Percentage(11),
+], [
+    "┌────────────────────────────┐",
+    "│HeaHeaHea                   │",
+    "│                            │",
+    "│RowRowRow                   │",
+    "│RowRowRow                   │",
+    "│RowRowRow                   │",
+    "│RowRowRow                   │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::large_width_just_before_pushing_a_column_off(&[
+    Constraint::Percentage(33),
+    Constraint::Percentage(33),
+    Constraint::Percentage(33),
+], [
+    "┌────────────────────────────┐",
+    "│Head1    Head2    Head3     │",
+    "│                            │",
+    "│Row11    Row12    Row13     │",
+    "│Row21    Row22    Row23     │",
+    "│Row31    Row32    Row33     │",
+    "│Row41    Row42    Row43     │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::sum_100_equal_widths(&[Constraint::Percentage(50), Constraint::Percentage(50)], [
+    "┌────────────────────────────┐",
+    "│Head1         Head2         │",
+    "│                            │",
+    "│Row11         Row12         │",
+    "│Row21         Row22         │",
+    "│Row31         Row32         │",
+    "│Row41         Row42         │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+fn widgets_table_columns_widths_can_use_percentage_constraints<'line, Lines>(
+    #[case] widths: &[Constraint],
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let backend = TestBackend::new(30, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(
+                vec![
+                    Row::new(vec!["Row11", "Row12", "Row13"]),
+                    Row::new(vec!["Row21", "Row22", "Row23"]),
+                    Row::new(vec!["Row31", "Row32", "Row33"]),
+                    Row::new(vec!["Row41", "Row42", "Row43"]),
+                ],
+                widths,
+            )
+            .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+            .block(Block::bordered())
+            .column_spacing(0);
+            f.render_widget(table, size);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
 }
 
-#[test]
-fn widgets_table_columns_widths_can_use_mixed_constraints() {
-    #[allow(clippy::needless_pass_by_value)]
-    #[track_caller]
-    fn test_case(widths: &[Constraint], expected: Buffer) {
-        let backend = TestBackend::new(30, 10);
-        let mut terminal = Terminal::new(backend).unwrap();
-
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let table = Table::new(
-                    vec![
-                        Row::new(vec!["Row11", "Row12", "Row13"]),
-                        Row::new(vec!["Row21", "Row22", "Row23"]),
-                        Row::new(vec!["Row31", "Row32", "Row33"]),
-                        Row::new(vec!["Row41", "Row42", "Row43"]),
-                    ],
-                    widths,
-                )
-                .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::bordered());
-                f.render_widget(table, size);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    }
-
-    // columns of zero width show nothing
-    test_case(
-        &[
-            Constraint::Percentage(0),
-            Constraint::Length(0),
-            Constraint::Percentage(0),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of not enough width trims the data
-    test_case(
-        &[
-            Constraint::Percentage(11),
-            Constraint::Length(20),
-            Constraint::Percentage(11),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Hea Head2                Hea│",
-            "│                            │",
-            "│Row Row12                Row│",
-            "│Row Row22                Row│",
-            "│Row Row32                Row│",
-            "│Row Row42                Row│",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of large width just before pushing a column off
-    test_case(
-        &[
-            Constraint::Percentage(33),
-            Constraint::Length(10),
-            Constraint::Percentage(33),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1     Head2      Head3  │",
-            "│                            │",
-            "│Row11     Row12      Row13  │",
-            "│Row21     Row22      Row23  │",
-            "│Row31     Row32      Row33  │",
-            "│Row41     Row42      Row43  │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of large size (>100% total) hide the last column
-    test_case(
-        &[
-            Constraint::Percentage(60),
-            Constraint::Length(10),
-            Constraint::Percentage(60),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1      Head2      Head3 │",
-            "│                            │",
-            "│Row11      Row12      Row13 │",
-            "│Row21      Row22      Row23 │",
-            "│Row31      Row32      Row33 │",
-            "│Row41      Row42      Row43 │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
+#[rstest]
+#[case::zero_width_shows_nothing(&[
+    Constraint::Percentage(0),
+    Constraint::Length(0),
+    Constraint::Percentage(0),
+], [
+    "┌────────────────────────────┐",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::slim_columns_trim_data(&[
+    Constraint::Percentage(11),
+    Constraint::Length(20),
+    Constraint::Percentage(11),
+], [
+    "┌────────────────────────────┐",
+    "│Hea Head2                Hea│",
+    "│                            │",
+    "│Row Row12                Row│",
+    "│Row Row22                Row│",
+    "│Row Row32                Row│",
+    "│Row Row42                Row│",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::large_width_just_before_pushing_a_column_off(&[
+    Constraint::Percentage(33),
+    Constraint::Length(10),
+    Constraint::Percentage(33),
+], [
+    "┌────────────────────────────┐",
+    "│Head1     Head2      Head3  │",
+    "│                            │",
+    "│Row11     Row12      Row13  │",
+    "│Row21     Row22      Row23  │",
+    "│Row31     Row32      Row33  │",
+    "│Row41     Row42      Row43  │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::more_than_100(&[
+    Constraint::Percentage(60),
+    Constraint::Length(10),
+    Constraint::Percentage(60),
+], [
+    "┌────────────────────────────┐",
+    "│Head1      Head2      Head3 │",
+    "│                            │",
+    "│Row11      Row12      Row13 │",
+    "│Row21      Row22      Row23 │",
+    "│Row31      Row32      Row33 │",
+    "│Row41      Row42      Row43 │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+fn widgets_table_columns_widths_can_use_mixed_constraints<'line, Lines>(
+    #[case] widths: &[Constraint],
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let backend = TestBackend::new(30, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(
+                vec![
+                    Row::new(vec!["Row11", "Row12", "Row13"]),
+                    Row::new(vec!["Row21", "Row22", "Row23"]),
+                    Row::new(vec!["Row31", "Row32", "Row33"]),
+                    Row::new(vec!["Row41", "Row42", "Row43"]),
+                ],
+                widths,
+            )
+            .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+            .block(Block::bordered());
+            f.render_widget(table, size);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
 }
 
-#[test]
-fn widgets_table_columns_widths_can_use_ratio_constraints() {
-    #[allow(clippy::needless_pass_by_value)]
-    #[track_caller]
-    fn test_case(widths: &[Constraint], expected: Buffer) {
-        let backend = TestBackend::new(30, 10);
-        let mut terminal = Terminal::new(backend).unwrap();
-
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let table = Table::new(
-                    vec![
-                        Row::new(vec!["Row11", "Row12", "Row13"]),
-                        Row::new(vec!["Row21", "Row22", "Row23"]),
-                        Row::new(vec!["Row31", "Row32", "Row33"]),
-                        Row::new(vec!["Row41", "Row42", "Row43"]),
-                    ],
-                    widths,
-                )
-                .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::bordered())
-                .column_spacing(0);
-                f.render_widget(table, size);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    }
-
-    // columns of zero width show nothing
-    test_case(
-        &[
-            Constraint::Ratio(0, 1),
-            Constraint::Ratio(0, 1),
-            Constraint::Ratio(0, 1),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of not enough width trims the data
-    test_case(
-        &[
-            Constraint::Ratio(1, 9),
-            Constraint::Ratio(1, 9),
-            Constraint::Ratio(1, 9),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│HeaHeaHea                   │",
-            "│                            │",
-            "│RowRowRow                   │",
-            "│RowRowRow                   │",
-            "│RowRowRow                   │",
-            "│RowRowRow                   │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // columns of large width just before pushing a column off
-    test_case(
-        &[
-            Constraint::Ratio(1, 3),
-            Constraint::Ratio(1, 3),
-            Constraint::Ratio(1, 3),
-        ],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1    Head2     Head3    │",
-            "│                            │",
-            "│Row11    Row12     Row13    │",
-            "│Row21    Row22     Row23    │",
-            "│Row31    Row32     Row33    │",
-            "│Row41    Row42     Row43    │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // percentages summing to 100 should give equal widths
-    test_case(
-        &[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)],
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1         Head2         │",
-            "│                            │",
-            "│Row11         Row12         │",
-            "│Row21         Row22         │",
-            "│Row31         Row32         │",
-            "│Row41         Row42         │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
+#[rstest]
+#[case::zero_shows_nothing(&[
+    Constraint::Ratio(0, 1),
+    Constraint::Ratio(0, 1),
+    Constraint::Ratio(0, 1),
+], [
+    "┌────────────────────────────┐",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::slim_trims_data(&[
+    Constraint::Ratio(1, 9),
+    Constraint::Ratio(1, 9),
+    Constraint::Ratio(1, 9),
+], [
+    "┌────────────────────────────┐",
+    "│HeaHeaHea                   │",
+    "│                            │",
+    "│RowRowRow                   │",
+    "│RowRowRow                   │",
+    "│RowRowRow                   │",
+    "│RowRowRow                   │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::three(&[Constraint::Ratio(1, 3), Constraint::Ratio(1, 3), Constraint::Ratio(1, 3)], [
+    "┌────────────────────────────┐",
+    "│Head1    Head2     Head3    │",
+    "│                            │",
+    "│Row11    Row12     Row13    │",
+    "│Row21    Row22     Row23    │",
+    "│Row31    Row32     Row33    │",
+    "│Row41    Row42     Row43    │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+#[case::two(&[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)], [
+    "┌────────────────────────────┐",
+    "│Head1         Head2         │",
+    "│                            │",
+    "│Row11         Row12         │",
+    "│Row21         Row22         │",
+    "│Row31         Row32         │",
+    "│Row41         Row42         │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+])]
+fn widgets_table_columns_widths_can_use_ratio_constraints<'line, Lines>(
+    #[case] widths: &[Constraint],
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let backend = TestBackend::new(30, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(
+                vec![
+                    Row::new(vec!["Row11", "Row12", "Row13"]),
+                    Row::new(vec!["Row21", "Row22", "Row23"]),
+                    Row::new(vec!["Row31", "Row32", "Row33"]),
+                    Row::new(vec!["Row41", "Row42", "Row43"]),
+                ],
+                widths,
+            )
+            .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+            .block(Block::bordered())
+            .column_spacing(0);
+            f.render_widget(table, size);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
 }
 
-#[test]
-fn widgets_table_can_have_rows_with_multi_lines() {
-    let test_case = |state: &mut TableState, expected: Buffer| {
-        let backend = TestBackend::new(30, 8);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let table = Table::new(
-                    vec![
-                        Row::new(vec!["Row11", "Row12", "Row13"]),
-                        Row::new(vec!["Row21", "Row22", "Row23"]).height(2),
-                        Row::new(vec!["Row31", "Row32", "Row33"]),
-                        Row::new(vec!["Row41", "Row42", "Row43"]).height(2),
-                    ],
-                    [
-                        Constraint::Length(5),
-                        Constraint::Length(5),
-                        Constraint::Length(5),
-                    ],
-                )
-                .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::bordered())
-                .highlight_symbol(">> ")
-                .column_spacing(1);
-                f.render_stateful_widget(table, size, state);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    };
-
-    let mut state = TableState::default();
-    // no selection
-    test_case(
-        &mut state,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1 Head2 Head3           │",
-            "│                            │",
-            "│Row11 Row12 Row13           │",
-            "│Row21 Row22 Row23           │",
-            "│                            │",
-            "│Row31 Row32 Row33           │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select first
-    state.select(Some(0));
-    test_case(
-        &mut state,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│   Head1 Head2 Head3        │",
-            "│                            │",
-            "│>> Row11 Row12 Row13        │",
-            "│   Row21 Row22 Row23        │",
-            "│                            │",
-            "│   Row31 Row32 Row33        │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select second (we don't show partially the 4th row)
-    state.select(Some(1));
-    test_case(
-        &mut state,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│   Head1 Head2 Head3        │",
-            "│                            │",
-            "│   Row11 Row12 Row13        │",
-            "│>> Row21 Row22 Row23        │",
-            "│                            │",
-            "│   Row31 Row32 Row33        │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select 4th (we don't show partially the 1st row)
-    state.select(Some(3));
-    test_case(
-        &mut state,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│   Head1 Head2 Head3        │",
-            "│                            │",
-            "│   Row31 Row32 Row33        │",
-            "│>> Row41 Row42 Row43        │",
-            "│                            │",
-            "│                            │",
-            "└────────────────────────────┘",
-        ]),
-    );
+#[rstest]
+#[case::none(
+    None,
+    [
+        "┌────────────────────────────┐",
+        "│Head1 Head2 Head3           │",
+        "│                            │",
+        "│Row11 Row12 Row13           │",
+        "│Row21 Row22 Row23           │",
+        "│                            │",
+        "│Row31 Row32 Row33           │",
+        "└────────────────────────────┘",
+    ],
+)]
+#[case::first(
+    Some(0),
+    [
+        "┌────────────────────────────┐",
+        "│   Head1 Head2 Head3        │",
+        "│                            │",
+        "│>> Row11 Row12 Row13        │",
+        "│   Row21 Row22 Row23        │",
+        "│                            │",
+        "│   Row31 Row32 Row33        │",
+        "└────────────────────────────┘",
+    ],
+)]
+#[case::second_no_partially_fourth(
+    Some(1),
+    [
+        "┌────────────────────────────┐",
+        "│   Head1 Head2 Head3        │",
+        "│                            │",
+        "│   Row11 Row12 Row13        │",
+        "│>> Row21 Row22 Row23        │",
+        "│                            │",
+        "│   Row31 Row32 Row33        │",
+        "└────────────────────────────┘",
+    ],
+)]
+#[case::fourth_no_partially_first(
+    Some(3),
+    [
+        "┌────────────────────────────┐",
+        "│   Head1 Head2 Head3        │",
+        "│                            │",
+        "│   Row31 Row32 Row33        │",
+        "│>> Row41 Row42 Row43        │",
+        "│                            │",
+        "│                            │",
+        "└────────────────────────────┘",
+    ],
+)]
+fn widgets_table_can_have_rows_with_multi_lines<'line, Lines>(
+    #[case] selected: Option<usize>,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let mut state = TableState::new().with_selected(selected);
+    let backend = TestBackend::new(30, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(
+                vec![
+                    Row::new(vec!["Row11", "Row12", "Row13"]),
+                    Row::new(vec!["Row21", "Row22", "Row23"]).height(2),
+                    Row::new(vec!["Row31", "Row32", "Row33"]),
+                    Row::new(vec!["Row41", "Row42", "Row43"]).height(2),
+                ],
+                [
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                ],
+            )
+            .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+            .block(Block::bordered())
+            .highlight_symbol(">> ")
+            .column_spacing(1);
+            f.render_stateful_widget(table, size, &mut state);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
 }
 
-#[allow(clippy::too_many_lines)]
-#[test]
-fn widgets_table_enable_always_highlight_spacing() {
-    let test_case = |state: &mut TableState, space: HighlightSpacing, expected: Buffer| {
-        let backend = TestBackend::new(30, 8);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                let table = Table::new(
-                    vec![
-                        Row::new(vec!["Row11", "Row12", "Row13"]),
-                        Row::new(vec!["Row21", "Row22", "Row23"]).height(2),
-                        Row::new(vec!["Row31", "Row32", "Row33"]),
-                        Row::new(vec!["Row41", "Row42", "Row43"]).height(2),
-                    ],
-                    [
-                        Constraint::Length(5),
-                        Constraint::Length(5),
-                        Constraint::Length(5),
-                    ],
-                )
-                .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::bordered())
-                .highlight_symbol(">> ")
-                .highlight_spacing(space)
-                .column_spacing(1);
-                f.render_stateful_widget(table, size, state);
-            })
-            .unwrap();
-        terminal.backend().assert_buffer(&expected);
-    };
-
-    assert_eq!(HighlightSpacing::default(), HighlightSpacing::WhenSelected);
-
-    let mut state = TableState::default();
-    // no selection, "WhenSelected" should only allocate if selected
-    test_case(
-        &mut state,
-        HighlightSpacing::default(),
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1 Head2 Head3           │",
-            "│                            │",
-            "│Row11 Row12 Row13           │",
-            "│Row21 Row22 Row23           │",
-            "│                            │",
-            "│Row31 Row32 Row33           │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // no selection, "Always" should allocate regardless if selected or not
-    test_case(
-        &mut state,
-        HighlightSpacing::Always,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│   Head1 Head2 Head3        │",
-            "│                            │",
-            "│   Row11 Row12 Row13        │",
-            "│   Row21 Row22 Row23        │",
-            "│                            │",
-            "│   Row31 Row32 Row33        │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // no selection, "Never" should never allocate regadless if selected or not
-    test_case(
-        &mut state,
-        HighlightSpacing::Never,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1 Head2 Head3           │",
-            "│                            │",
-            "│Row11 Row12 Row13           │",
-            "│Row21 Row22 Row23           │",
-            "│                            │",
-            "│Row31 Row32 Row33           │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select first, "WhenSelected" should only allocate if selected
-    state.select(Some(0));
-    test_case(
-        &mut state,
-        HighlightSpacing::default(),
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│   Head1 Head2 Head3        │",
-            "│                            │",
-            "│>> Row11 Row12 Row13        │",
-            "│   Row21 Row22 Row23        │",
-            "│                            │",
-            "│   Row31 Row32 Row33        │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select first, "Always" should allocate regardless if selected or not
-    state.select(Some(0));
-    test_case(
-        &mut state,
-        HighlightSpacing::Always,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│   Head1 Head2 Head3        │",
-            "│                            │",
-            "│>> Row11 Row12 Row13        │",
-            "│   Row21 Row22 Row23        │",
-            "│                            │",
-            "│   Row31 Row32 Row33        │",
-            "└────────────────────────────┘",
-        ]),
-    );
-
-    // select first, "Never" should never allocate regadless if selected or not
-    state.select(Some(0));
-    test_case(
-        &mut state,
-        HighlightSpacing::Never,
-        Buffer::with_lines(vec![
-            "┌────────────────────────────┐",
-            "│Head1 Head2 Head3           │",
-            "│                            │",
-            "│Row11 Row12 Row13           │",
-            "│Row21 Row22 Row23           │",
-            "│                            │",
-            "│Row31 Row32 Row33           │",
-            "└────────────────────────────┘",
-        ]),
-    );
+#[rstest]
+#[case::none_when_selected(None, HighlightSpacing::WhenSelected, [
+    "┌────────────────────────────┐",
+    "│Head1 Head2 Head3           │",
+    "│                            │",
+    "│Row11 Row12 Row13           │",
+    "│Row21 Row22 Row23           │",
+    "│                            │",
+    "│Row31 Row32 Row33           │",
+    "└────────────────────────────┘",
+])]
+#[case::none_always(
+    None, HighlightSpacing::Always, [
+    "┌────────────────────────────┐",
+    "│   Head1 Head2 Head3        │",
+    "│                            │",
+    "│   Row11 Row12 Row13        │",
+    "│   Row21 Row22 Row23        │",
+    "│                            │",
+    "│   Row31 Row32 Row33        │",
+    "└────────────────────────────┘",
+])]
+#[case::none_never(None, HighlightSpacing::Never, [
+    "┌────────────────────────────┐",
+    "│Head1 Head2 Head3           │",
+    "│                            │",
+    "│Row11 Row12 Row13           │",
+    "│Row21 Row22 Row23           │",
+    "│                            │",
+    "│Row31 Row32 Row33           │",
+    "└────────────────────────────┘",
+])]
+#[case::first_when_selected(Some(0), HighlightSpacing::WhenSelected, [
+    "┌────────────────────────────┐",
+    "│   Head1 Head2 Head3        │",
+    "│                            │",
+    "│>> Row11 Row12 Row13        │",
+    "│   Row21 Row22 Row23        │",
+    "│                            │",
+    "│   Row31 Row32 Row33        │",
+    "└────────────────────────────┘",
+])]
+#[case::first_always(Some(0), HighlightSpacing::Always, [
+    "┌────────────────────────────┐",
+    "│   Head1 Head2 Head3        │",
+    "│                            │",
+    "│>> Row11 Row12 Row13        │",
+    "│   Row21 Row22 Row23        │",
+    "│                            │",
+    "│   Row31 Row32 Row33        │",
+    "└────────────────────────────┘",
+])]
+#[case::first_never(Some(0), HighlightSpacing::Never, [
+    "┌────────────────────────────┐",
+    "│Head1 Head2 Head3           │",
+    "│                            │",
+    "│Row11 Row12 Row13           │",
+    "│Row21 Row22 Row23           │",
+    "│                            │",
+    "│Row31 Row32 Row33           │",
+    "└────────────────────────────┘",
+])]
+fn widgets_table_enable_always_highlight_spacing<'line, Lines>(
+    #[case] selected: Option<usize>,
+    #[case] space: HighlightSpacing,
+    #[case] expected: Lines,
+) where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let mut state = TableState::new().with_selected(selected);
+    let backend = TestBackend::new(30, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(
+                vec![
+                    Row::new(vec!["Row11", "Row12", "Row13"]),
+                    Row::new(vec!["Row21", "Row22", "Row23"]).height(2),
+                    Row::new(vec!["Row31", "Row32", "Row33"]),
+                    Row::new(vec!["Row41", "Row42", "Row43"]).height(2),
+                ],
+                [
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                ],
+            )
+            .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+            .block(Block::bordered())
+            .highlight_symbol(">> ")
+            .highlight_spacing(space)
+            .column_spacing(1);
+            f.render_stateful_widget(table, size, &mut state);
+        })
+        .unwrap();
+    terminal.backend().assert_buffer_lines(expected);
 }
 
 #[test]
@@ -804,7 +672,7 @@ fn widgets_table_can_have_elements_styled_individually() {
         })
         .unwrap();
 
-    let mut expected = Buffer::with_lines(vec![
+    let mut expected = Buffer::with_lines([
         "│   Head1  Head2  Head3      │",
         "│                            │",
         "│>> Row11  Row12  Row13      │",
@@ -866,33 +734,19 @@ fn widgets_table_should_render_even_if_empty() {
             f.render_widget(table, size);
         })
         .unwrap();
-
-    let expected = Buffer::with_lines(vec![
+    terminal.backend().assert_buffer_lines([
         "│Head1  Head2  Head3         │",
         "│                            │",
         "│                            │",
         "│                            │",
     ]);
-
-    terminal.backend().assert_buffer(&expected);
 }
 
+// based on https://github.com/fdehau/tui-rs/issues/470#issuecomment-852562848
 #[test]
 fn widgets_table_columns_dont_panic() {
-    let test_case = |state: &mut TableState, table: Table, width: u16| {
-        let backend = TestBackend::new(width, 8);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|f| {
-                let size = f.size();
-                f.render_stateful_widget(table, size, state);
-            })
-            .unwrap();
-    };
-
-    // based on https://github.com/fdehau/tui-rs/issues/470#issuecomment-852562848
-    let table1_width = 98;
-    let table1 = Table::new(
+    let table_width = 98;
+    let table = Table::new(
         vec![Row::new(vec!["r1", "r2", "r3", "r4"])],
         [
             Constraint::Percentage(15),
@@ -910,7 +764,15 @@ fn widgets_table_columns_dont_panic() {
 
     // select first, which would cause a panic before fix
     state.select(Some(0));
-    test_case(&mut state, table1.clone(), table1_width);
+
+    let backend = TestBackend::new(table_width, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            f.render_stateful_widget(table, size, &mut state);
+        })
+        .unwrap();
 }
 
 #[test]
@@ -945,7 +807,7 @@ fn widgets_table_should_clamp_offset_if_rows_are_removed() {
             f.render_stateful_widget(table, size, &mut state);
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec![
+    terminal.backend().assert_buffer_lines([
         "┌────────────────────────────┐",
         "│Head1 Head2 Head3           │",
         "│                            │",
@@ -955,7 +817,6 @@ fn widgets_table_should_clamp_offset_if_rows_are_removed() {
         "│Row51 Row52 Row53           │",
         "└────────────────────────────┘",
     ]);
-    terminal.backend().assert_buffer(&expected);
 
     // render with 1 item => offset will be at 1
     state.select(Some(1));
@@ -976,7 +837,7 @@ fn widgets_table_should_clamp_offset_if_rows_are_removed() {
             f.render_stateful_widget(table, size, &mut state);
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec![
+    terminal.backend().assert_buffer_lines([
         "┌────────────────────────────┐",
         "│Head1 Head2 Head3           │",
         "│                            │",
@@ -986,5 +847,4 @@ fn widgets_table_should_clamp_offset_if_rows_are_removed() {
         "│                            │",
         "└────────────────────────────┘",
     ]);
-    terminal.backend().assert_buffer(&expected);
 }

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -26,8 +26,7 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
             );
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec![" "]);
-    terminal.backend().assert_buffer(&expected);
+    terminal.backend().assert_buffer_lines([" "]);
 }
 
 #[test]
@@ -48,7 +47,7 @@ fn widgets_tabs_should_truncate_the_last_item() {
             );
         })
         .unwrap();
-    let mut expected = Buffer::with_lines(vec![format!(" Tab1 {} T ", symbols::line::VERTICAL)]);
+    let mut expected = Buffer::with_lines([format!(" Tab1 {} T ", symbols::line::VERTICAL)]);
     expected.set_style(Rect::new(1, 0, 4, 1), Style::new().reversed());
     terminal.backend().assert_buffer(&expected);
 }


### PR DESCRIPTION
- Simplify `assert_buffer_eq!` logic.
- Deprecate `assert_buffer_eq!`.
- Introduce `TestBackend::assert_buffer_lines`.

Also simplify many tests involving buffer comparisons.

For the deprecation, just use `assert_eq` instead of `assert_buffer_eq`:

```diff
-assert_buffer_eq!(actual, expected);
+assert_eq!(actual, expected);
```

---

I noticed `assert_buffer_eq!` creating no test coverage reports and looked into this macro. First I simplified it. Then I noticed a bunch of `assert_eq!(buffer, …)` and other indirect usages of this macro (like `TestBackend::assert_buffer`).

The good thing here is that it's mainly used in tests so not many changes to the library code.