### PR TITLE
Add `is_at_start` and `is_at_end` methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ description to help the reviewer (follow the provided template). Make sure to hi
 which may need additional attention or you are uncertain about. Any idea with a large scale impact
 on the crate or its users should ideally be discussed in a "Feature Request" issue beforehand.
 
-### Keep PRs small, intentional and focused
+### Keep PRs small, intentional, and focused
 
 Try to do one pull request per change. The time taken to review a PR grows exponential with the size
 of the change. Small focused PRs will generally be much more faster to review. PRs that include both
@@ -171,7 +171,7 @@ time to update. However, if a deprecation is blocking for us to implement a new 
 
 ### Use of unsafe for optimization purposes
 
-We don't currently use any unsafe code in Ratatui, and would like to keep it that way. However there
+We don't currently use any unsafe code in Ratatui, and would like to keep it that way. However, there
 may be specific cases that this becomes necessary in order to avoid slowness. Please see [this
 discussion](https://github.com/ratatui-org/ratatui/discussions/66) for more about the decision.
 
@@ -193,10 +193,10 @@ This project was forked from [`tui-rs`](https://github.com/fdehau/tui-rs/) in Fe
 [blessing of the original author](https://github.com/fdehau/tui-rs/issues/654), Florian Dehau
 ([@fdehau](https://github.com/fdehau)).
 
-The original repository contains all the issues, PRs and discussion that were raised originally, and
+The original repository contains all the issues, PRs, and discussion that were raised originally, and
 it is useful to refer to when contributing code, documentation, or issues with Ratatui.
 
-We imported all the PRs from the original repository and implemented many of the smaller ones and
+We imported all the PRs from the original repository, implemented many of the smaller ones, and
 made notes on the leftovers. These are marked as draft PRs and labelled as [imported from
 tui](https://github.com/ratatui-org/ratatui/pulls?q=is%3Apr+is%3Aopen+label%3A%22imported+from+tui%22).
 We have documented the current state of those PRs, and anyone is welcome to pick them up and

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -455,20 +455,17 @@ impl ScrollbarState {
     pub fn first(&mut self) {
         self.position = 0;
     }
-    
+
     /// Returns true if the scroll position is at (or above) the start of the scrollable content.
-    pub fn is_at_start(&self) -> bool {
-        self.position <= 0
+    #[must_use = "returns whether the scroll position is at the start"]
+    pub const fn is_at_start(&self) -> bool {
+        self.position == 0
     }
 
     /// Returns true if the scroll position is at (or below) the end of the scrollable content.
-    pub fn is_at_end(&self) -> bool {
+    #[must_use = "returns whether the scroll position is at the end"]
+    pub const fn is_at_end(&self) -> bool {
         self.position + self.viewport_content_length >= self.content_length.saturating_sub(1)
-    }
-
-    /// Returns the current scroll position.
-    pub const fn get_position(&self) -> usize {
-        self.position
     }
 
     /// Changes the scroll position based on the provided [`ScrollDirection`].

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -455,10 +455,20 @@ impl ScrollbarState {
     pub fn first(&mut self) {
         self.position = 0;
     }
+    
+    /// Returns true if the scroll position is at (or above) the start of the scrollable content.
+    pub fn is_at_start(&self) -> bool {
+        self.position <= 0
+    }
 
-    /// Sets the scroll position to the end of the scrollable content.
-    pub fn last(&mut self) {
-        self.position = self.content_length.saturating_sub(1);
+    /// Returns true if the scroll position is at (or below) the end of the scrollable content.
+    pub fn is_at_end(&self) -> bool {
+        self.position + self.viewport_content_length >= self.content_length.saturating_sub(1)
+    }
+
+    /// Returns the current scroll position.
+    pub const fn get_position(&self) -> usize {
+        self.position
     }
 
     /// Changes the scroll position based on the provided [`ScrollDirection`].
@@ -1081,4 +1091,42 @@ mod tests {
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines(vec![expected]), "{description}");
     }
+
+    #[rstest]
+    #[case(0, 0, true, "position_0")]
+    #[case(0, 1, true, "position_1")]
+    #[case(0, 2, true, "position_2")]
+    #[case(1, 0, false, "position_3")]
+    #[case(1, 1, false, "position_4")]
+    #[case(2, 2, false, "position_5")]
+    fn test_is_at_start(
+        #[case] position: usize,
+        #[case] content_length: usize,
+        #[case] expected: bool,
+        #[case] description: &str,
+    ) {
+        let state = ScrollbarState::new(content_length).position(position);
+        assert_eq!(state.is_at_start(), expected, "{description}");
+    }
+
+    // FIXME: these tests don't work
+    // #[rstest]
+    // #[case(0, 0, true, "position_0")]
+    // #[case(1, 0, true, "position_1")]
+    // #[case(2, 0, true, "position_2")]
+    // #[case(0, 1, false, "position_3")]
+    // #[case(0, 2, false, "position_4")]
+    // #[case(1, 1, true, "position_5")]
+    // #[case(1, 2, false, "position_6")]
+    // #[case(2, 2, true, "position_7")]
+    // #[case(3, 2, true, "position_8")]
+    // fn test_is_at_end(
+    //     #[case] position: usize,
+    //     #[case] content_length: usize,
+    //     #[case] expected: bool,
+    //     #[case] description: &str,
+    // ) {
+    //     let state = ScrollbarState::new(content_length).position(position);
+    //     assert_eq!(state.is_at_end(), expected, "{description}");
+    // }
 }


### PR DESCRIPTION
Fixes #1018.

This is still a work in progress. Looking for help/feedback with the tests. 

For this to work reliably and as expected, I believe that the `Scroll` object needs to "write back" to this `ScrollbarState` object, so that this `ScrollbarState` understands its viewport size. This communication is at the heart of most of the scrollbar deficiencies, as far as I can tell.