### PR TITLE
chore(README): badges now are in the terminal theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Running this example produces the following output:
 [GitHub Sponsors]: https://github.com/sponsors/ratatui-org
 [Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square&color=F05B50&logoColor=F05B50&labelColor=102040
 [License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square&color=1370D3&labelColor=102040
-[CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github&color=4B8C0F&labelColor=102040
+[CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github&labelColor=102040
 [CI Workflow]: https://github.com/ratatui-org/ratatui/actions/workflows/ci.yml
 [Codecov Badge]:
     https://img.shields.io/codecov/c/github/ratatui-org/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST&color=C43AC3&labelColor=102040&logoColor=C43AC3
@@ -339,7 +339,7 @@ Running this example produces the following output:
 [Discord Badge]:
     https://img.shields.io/discord/1070692720437383208?label=discord&logo=discord&style=flat-square&color=1370D3&logoColor=1370D3&labelColor=102040
 [Discord Server]: https://discord.gg/pMCEU9hNEj
-[Docs Badge]: https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square&color=F05B50&logoColor=F05B50&labelColor=102040
+[Docs Badge]: https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square&logoColor=F05B50&labelColor=102040
 [Matrix Badge]:
     https://img.shields.io/matrix/ratatui-general%3Amatrix.org?style=flat-square&logo=matrix&label=Matrix&color=4B8C0F&labelColor=102040
 [Matrix]: https://matrix.to/#/#ratatui:matrix.org

--- a/README.md
+++ b/README.md
@@ -327,24 +327,23 @@ Running this example produces the following output:
 [Termwiz]: https://crates.io/crates/termwiz
 [tui-rs]: https://crates.io/crates/tui
 [GitHub Sponsors]: https://github.com/sponsors/ratatui-org
-[Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square
-[License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square
-[CI Badge]:
-    https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github
+[Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square&color=F05B50&logoColor=F05B50&labelColor=102040
+[License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square&color=1370D3&labelColor=102040
+[CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github&color=4B8C0F&labelColor=102040
 [CI Workflow]: https://github.com/ratatui-org/ratatui/actions/workflows/ci.yml
 [Codecov Badge]:
-    https://img.shields.io/codecov/c/github/ratatui-org/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST
+    https://img.shields.io/codecov/c/github/ratatui-org/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST&color=C43AC3&labelColor=102040&logoColor=C43AC3
 [Codecov]: https://app.codecov.io/gh/ratatui-org/ratatui
 [Deps.rs Badge]: https://deps.rs/repo/github/ratatui-org/ratatui/status.svg?style=flat-square
 [Deps.rs]: https://deps.rs/repo/github/ratatui-org/ratatui
 [Discord Badge]:
-    https://img.shields.io/discord/1070692720437383208?label=discord&logo=discord&style=flat-square
+    https://img.shields.io/discord/1070692720437383208?label=discord&logo=discord&style=flat-square&color=1370D3&logoColor=1370D3&labelColor=102040
 [Discord Server]: https://discord.gg/pMCEU9hNEj
-[Docs Badge]: https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square
+[Docs Badge]: https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square&color=F05B50&logoColor=F05B50&labelColor=102040
 [Matrix Badge]:
-    https://img.shields.io/matrix/ratatui-general%3Amatrix.org?style=flat-square&logo=matrix&label=Matrix
+    https://img.shields.io/matrix/ratatui-general%3Amatrix.org?style=flat-square&logo=matrix&label=Matrix&color=4B8C0F&labelColor=102040
 [Matrix]: https://matrix.to/#/#ratatui:matrix.org
-[Sponsors Badge]: https://img.shields.io/github/sponsors/ratatui-org?logo=github&style=flat-square
+[Sponsors Badge]: https://img.shields.io/github/sponsors/ratatui-org?logo=github&style=flat-square&color=1370D3&labelColor=102040
 
 <!-- cargo-rdme end -->
 

--- a/README.md
+++ b/README.md
@@ -327,23 +327,23 @@ Running this example produces the following output:
 [Termwiz]: https://crates.io/crates/termwiz
 [tui-rs]: https://crates.io/crates/tui
 [GitHub Sponsors]: https://github.com/sponsors/ratatui-org
-[Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square&color=F05B50&logoColor=F05B50&labelColor=102040
-[License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square&color=1370D3&labelColor=102040
-[CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github&labelColor=102040
+[Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square&logoColor=E05D44&color=E05D44
+[License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square&color=1370D3
+[CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github
 [CI Workflow]: https://github.com/ratatui-org/ratatui/actions/workflows/ci.yml
 [Codecov Badge]:
-    https://img.shields.io/codecov/c/github/ratatui-org/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST&color=C43AC3&labelColor=102040&logoColor=C43AC3
+    https://img.shields.io/codecov/c/github/ratatui-org/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST&color=C43AC3&logoColor=C43AC3
 [Codecov]: https://app.codecov.io/gh/ratatui-org/ratatui
 [Deps.rs Badge]: https://deps.rs/repo/github/ratatui-org/ratatui/status.svg?style=flat-square
 [Deps.rs]: https://deps.rs/repo/github/ratatui-org/ratatui
 [Discord Badge]:
-    https://img.shields.io/discord/1070692720437383208?label=discord&logo=discord&style=flat-square&color=1370D3&logoColor=1370D3&labelColor=102040
+    https://img.shields.io/discord/1070692720437383208?label=discord&logo=discord&style=flat-square&color=1370D3&logoColor=1370D3
 [Discord Server]: https://discord.gg/pMCEU9hNEj
-[Docs Badge]: https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square&logoColor=F05B50&labelColor=102040
+[Docs Badge]: https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square&logoColor=E05D44
 [Matrix Badge]:
-    https://img.shields.io/matrix/ratatui-general%3Amatrix.org?style=flat-square&logo=matrix&label=Matrix&color=4B8C0F&labelColor=102040
+    https://img.shields.io/matrix/ratatui-general%3Amatrix.org?style=flat-square&logo=matrix&label=Matrix&color=C43AC3
 [Matrix]: https://matrix.to/#/#ratatui:matrix.org
-[Sponsors Badge]: https://img.shields.io/github/sponsors/ratatui-org?logo=github&style=flat-square&color=1370D3&labelColor=102040
+[Sponsors Badge]: https://img.shields.io/github/sponsors/ratatui-org?logo=github&style=flat-square&color=1370D3
 
 <!-- cargo-rdme end -->
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
The badges in the readme were all the default theme. Giving them prettier colors that match the terminal gif is better. I've used the colors from the VHS repo.
```json
{
    "name": "Aardvark Blue",
    "black": "#191919",
    "red": "#aa342e",
    "green": "#4b8c0f",
    "yellow": "#dbba00",
    "blue": "#1370d3",
    "magenta": "#c43ac3",
    "cyan": "#008eb0",
    "white": "#bebebe",
    "brightBlack": "#454545",
    "brightRed": "#f05b50",
    "brightGreen": "#95dc55",
    "brightYellow": "#ffe763",
    "brightBlue": "#60a4ec",
    "brightMagenta": "#e26be2",
    "brightCyan": "#60b6cb",
    "brightWhite": "#f7f7f7",
    "background": "#102040",
    "foreground": "#dddddd",
    "cursor": "#007acc",
    "selection": "#bfdbfe",
    "meta": {
      "isDark": true,
      "credits": null
    }
  },
``` 
![grafik](https://github.com/ratatui-org/ratatui/assets/100917739/148994f7-5734-4b4f-aaf9-3416fe1df073)
The dependencies badge couldn't unfortunately be themed