### PR TITLE
chore: Add package categories field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Florian Dehau <work@fdehau.com>", "The Ratatui Developers"]
 description = "A library that's all about cooking up terminal user interfaces"
 documentation = "https://docs.rs/ratatui/latest/ratatui/"
 keywords = ["tui", "terminal", "dashboard"]
+categories = ["command-line-interface"]
 repository = "https://github.com/ratatui-org/ratatui"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

Add the package categories field in Cargo.toml, with value `["command-line-interface"]`. This fixes the (currently non-default) clippy cargo group lint [`clippy::cargo_common_metadata`](https://rust-lang.github.io/rust-clippy/master/index.html#/cargo_common_metadata).

As per discussion in [Cargo package categories suggestions](https://github.com/ratatui-org/ratatui/discussions/1034), this lint is not suggested to be run by default in CI, but rather as an occasional one-off as part of the larger [`clippy::cargo`](https://doc.rust-lang.org/stable/clippy/lints.html#cargo) lint group.