### PR TITLE
perf(canvas): const world data

### DIFF
--- a/src/widgets/canvas/map.rs
+++ b/src/widgets/canvas/map.rs
@@ -27,7 +27,7 @@ pub enum MapResolution {
 }
 
 impl MapResolution {
-    fn data(self) -> &'static [(f64, f64)] {
+    const fn data(self) -> &'static [(f64, f64)] {
         match self {
             Self::Low => &WORLD_LOW_RESOLUTION,
             Self::High => &WORLD_HIGH_RESOLUTION,

--- a/src/widgets/canvas/world.rs
+++ b/src/widgets/canvas/world.rs
@@ -1,5 +1,5 @@
 /// [Source data](http://www.gnuplotting.org/plotting-the-world-revisited)
-pub static WORLD_HIGH_RESOLUTION: [(f64, f64); 5125] = [
+pub const WORLD_HIGH_RESOLUTION: [(f64, f64); 5125] = [
     (-163.7128, -78.5956),
     (-163.1058, -78.2233),
     (-161.2451, -78.3801),
@@ -5127,7 +5127,7 @@ pub static WORLD_HIGH_RESOLUTION: [(f64, f64); 5125] = [
     (180.0, -84.71338),
 ];
 
-pub static WORLD_LOW_RESOLUTION: [(f64, f64); 1166] = [
+pub const WORLD_LOW_RESOLUTION: [(f64, f64); 1166] = [
     (-92.32, 48.24),
     (-88.13, 48.92),
     (-83.11, 46.27),


### PR DESCRIPTION
I suspect this was done `static` instead of `const` based on C/C++. The usage stays the same, I don't know any reason why it should stay `static`. Or am I overlooking something? But `MapResolution::data` can be `const` with this change.