### PR TITLE
refactor(example): remove pointless new method

### DIFF
--- a/examples/demo2/app.rs
+++ b/examples/demo2/app.rs
@@ -38,14 +38,10 @@ enum Tab {
 }
 
 pub fn run(terminal: &mut Terminal<impl Backend>) -> Result<()> {
-    App::new().run(terminal)
+    App::default().run(terminal)
 }
 
 impl App {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Run the app until the user quits.
     pub fn run(&mut self, terminal: &mut Terminal<impl Backend>) -> Result<()> {
         while self.is_running() {

--- a/examples/demo2/main.rs
+++ b/examples/demo2/main.rs
@@ -39,7 +39,7 @@ pub use theme::*;
 fn main() -> Result<()> {
     errors::init_hooks()?;
     let terminal = &mut term::init()?;
-    App::new().run(terminal)?;
+    App::default().run(terminal)?;
     term::restore()?;
     Ok(())
 }


### PR DESCRIPTION
Use `App::default()` directly.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
