### PR TITLE
perf(table): const TableState::new

### DIFF
--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -60,8 +60,11 @@ impl TableState {
     /// # use ratatui::{prelude::*, widgets::*};
     /// let state = TableState::new();
     /// ```
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            offset: 0,
+            selected: None,
+        }
     }
 
     /// Sets the index of the first row to be displayed


### PR DESCRIPTION
Personally I think there should be either `TableState::default()` or `TableState::new()` but not both (#978). Here we have both, so at least allow for `const fn new`.