### PR TITLE
perf(block): use Block::bordered

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ fn handle_events() -> io::Result<bool> {
 fn ui(frame: &mut Frame) {
     frame.render_widget(
         Paragraph::new("Hello World!")
-            .block(Block::default().title("Greeting").borders(Borders::ALL)),
+            .block(Block::bordered().title("Greeting")),
         frame.size(),
     );
 }
@@ -207,11 +207,11 @@ fn ui(frame: &mut Frame) {
     )
     .split(main_layout[1]);
     frame.render_widget(
-        Block::default().borders(Borders::ALL).title("Left"),
+        Block::bordered().title("Left"),
         inner_layout[0],
     );
     frame.render_widget(
-        Block::default().borders(Borders::ALL).title("Right"),
+        Block::bordered().title("Right"),
         inner_layout[1],
     );
 }

--- a/benches/block.rs
+++ b/benches/block.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::{Alignment, Rect},
     widgets::{
         block::{Position, Title},
-        Block, Borders, Padding, Widget,
+        Block, Padding, Widget,
     },
 };
 
@@ -29,15 +29,14 @@ fn block(c: &mut Criterion) {
         // Render with all features
         group.bench_with_input(
             format!("render_all_feature/{width}x{height}"),
-            &Block::new()
-                .borders(Borders::ALL)
+            &Block::bordered()
+                .padding(Padding::new(5, 5, 2, 2))
                 .title("test title")
                 .title(
                     Title::from("bottom left title")
                         .alignment(Alignment::Right)
                         .position(Position::Bottom),
-                )
-                .padding(Padding::new(5, 5, 2, 2)),
+                ),
             |b, block| render(b, block, buffer_size),
         );
     }

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -26,7 +26,7 @@ use crossterm::{
 };
 use ratatui::{
     prelude::*,
-    widgets::{Bar, BarChart, BarGroup, Block, Borders, Paragraph},
+    widgets::{Bar, BarChart, BarGroup, Block, Paragraph},
 };
 
 struct Company<'a> {
@@ -159,7 +159,7 @@ fn ui(frame: &mut Frame, app: &App) {
     let [left, right] = horizontal.areas(bottom);
 
     let barchart = BarChart::default()
-        .block(Block::default().title("Data1").borders(Borders::ALL))
+        .block(Block::bordered().title("Data1"))
         .data(&app.data)
         .bar_width(9)
         .bar_style(Style::default().fg(Color::Yellow))
@@ -217,7 +217,7 @@ fn draw_bar_with_group_labels(f: &mut Frame, app: &App, area: Rect) {
     let groups = create_groups(app, false);
 
     let mut barchart = BarChart::default()
-        .block(Block::default().title("Data1").borders(Borders::ALL))
+        .block(Block::bordered().title("Data1"))
         .bar_width(7)
         .group_gap(3);
 
@@ -246,7 +246,7 @@ fn draw_horizontal_bars(f: &mut Frame, app: &App, area: Rect) {
     let groups = create_groups(app, true);
 
     let mut barchart = BarChart::default()
-        .block(Block::default().title("Data1").borders(Borders::ALL))
+        .block(Block::bordered().title("Data1"))
         .bar_width(1)
         .group_gap(1)
         .bar_gap(0)
@@ -292,9 +292,7 @@ fn draw_legend(f: &mut Frame, area: Rect) {
         )]),
     ];
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .style(Style::default().fg(Color::White));
+    let block = Block::bordered().style(Style::default().fg(Color::White));
     let paragraph = Paragraph::new(text).block(block);
     f.render_widget(paragraph, area);
 }

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -160,23 +160,20 @@ fn render_border_type(
     frame: &mut Frame,
     area: Rect,
 ) {
-    let block = Block::new()
-        .borders(Borders::ALL)
+    let block = Block::bordered()
         .border_type(border_type)
         .title(format!("BorderType::{border_type:#?}"));
     frame.render_widget(paragraph.clone().block(block), area);
 }
 fn render_styled_borders(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
-    let block = Block::new()
-        .borders(Borders::ALL)
+    let block = Block::bordered()
         .border_style(Style::new().blue().on_white().bold().italic())
         .title("Styled borders");
     frame.render_widget(paragraph.clone().block(block), area);
 }
 
 fn render_styled_block(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
-    let block = Block::new()
-        .borders(Borders::ALL)
+    let block = Block::bordered()
         .style(Style::new().blue().on_white().bold().italic())
         .title("Styled block");
     frame.render_widget(paragraph.clone().block(block), area);
@@ -184,8 +181,7 @@ fn render_styled_block(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
 
 // Note: this currently renders incorrectly, see https://github.com/ratatui-org/ratatui/issues/349
 fn render_styled_title(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
-    let block = Block::new()
-        .borders(Borders::ALL)
+    let block = Block::bordered()
         .title("Styled title")
         .title_style(Style::new().blue().on_white().bold().italic());
     frame.render_widget(paragraph.clone().block(block), area);
@@ -196,21 +192,19 @@ fn render_styled_title_content(paragraph: &Paragraph, frame: &mut Frame, area: R
         "Styled ".blue().on_white().bold().italic(),
         "title content".red().on_white().bold().italic(),
     ]);
-    let block = Block::new().borders(Borders::ALL).title(title);
+    let block = Block::bordered().title(title);
     frame.render_widget(paragraph.clone().block(block), area);
 }
 
 fn render_multiple_titles(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
-    let block = Block::new()
-        .borders(Borders::ALL)
+    let block = Block::bordered()
         .title("Multiple".blue().on_white().bold().italic())
         .title("Titles".red().on_white().bold().italic());
     frame.render_widget(paragraph.clone().block(block), area);
 }
 
 fn render_multiple_title_positions(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
-    let block = Block::new()
-        .borders(Borders::ALL)
+    let block = Block::bordered()
         .title(
             Title::from("top left")
                 .position(Position::Top)
@@ -245,16 +239,15 @@ fn render_multiple_title_positions(paragraph: &Paragraph, frame: &mut Frame, are
 }
 
 fn render_padding(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
-    let block = Block::new()
-        .borders(Borders::ALL)
-        .title("Padding")
-        .padding(Padding::new(5, 10, 1, 2));
+    let block = Block::bordered()
+        .padding(Padding::new(5, 10, 1, 2))
+        .title("Padding");
     frame.render_widget(paragraph.clone().block(block), area);
 }
 
 fn render_nested_blocks(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
-    let outer_block = Block::new().borders(Borders::ALL).title("Outer block");
-    let inner_block = Block::new().borders(Borders::ALL).title("Inner block");
+    let outer_block = Block::bordered().title("Outer block");
+    let inner_block = Block::bordered().title("Inner block");
     let inner = outer_block.inner(area);
     frame.render_widget(outer_block, area);
     frame.render_widget(paragraph.clone().block(inner_block), inner);

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -137,7 +137,7 @@ impl App {
 
     fn map_canvas(&self) -> impl Widget + '_ {
         Canvas::default()
-            .block(Block::default().borders(Borders::ALL).title("World"))
+            .block(Block::bordered().title("World"))
             .marker(self.marker)
             .paint(|ctx| {
                 ctx.draw(&Map {
@@ -152,7 +152,7 @@ impl App {
 
     fn pong_canvas(&self) -> impl Widget + '_ {
         Canvas::default()
-            .block(Block::default().borders(Borders::ALL).title("Pong"))
+            .block(Block::bordered().title("Pong"))
             .marker(self.marker)
             .paint(|ctx| {
                 ctx.draw(&self.ball);
@@ -167,7 +167,7 @@ impl App {
         let bottom = 0.0;
         let top = f64::from(area.height).mul_add(2.0, -4.0);
         Canvas::default()
-            .block(Block::default().borders(Borders::ALL).title("Rects"))
+            .block(Block::bordered().title("Rects"))
             .marker(self.marker)
             .x_bounds([left, right])
             .y_bounds([bottom, top])

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -26,7 +26,7 @@ use crossterm::{
 };
 use ratatui::{
     prelude::*,
-    widgets::{block::Title, Axis, Block, Borders, Chart, Dataset, GraphType, LegendPosition},
+    widgets::{block::Title, Axis, Block, Chart, Dataset, GraphType, LegendPosition},
 };
 
 #[derive(Clone)]
@@ -184,11 +184,7 @@ fn render_chart1(f: &mut Frame, area: Rect, app: &App) {
     ];
 
     let chart = Chart::new(datasets)
-        .block(
-            Block::default()
-                .title("Chart 1".cyan().bold())
-                .borders(Borders::ALL),
-        )
+        .block(Block::bordered().title("Chart 1".cyan().bold()))
         .x_axis(
             Axis::default()
                 .title("X Axis")
@@ -217,13 +213,11 @@ fn render_line_chart(f: &mut Frame, area: Rect) {
 
     let chart = Chart::new(datasets)
         .block(
-            Block::default()
-                .title(
-                    Title::default()
-                        .content("Line chart".cyan().bold())
-                        .alignment(Alignment::Center),
-                )
-                .borders(Borders::ALL),
+            Block::bordered().title(
+                Title::default()
+                    .content("Line chart".cyan().bold())
+                    .alignment(Alignment::Center),
+            ),
         )
         .x_axis(
             Axis::default()
@@ -269,7 +263,7 @@ fn render_scatter(f: &mut Frame, area: Rect) {
 
     let chart = Chart::new(datasets)
         .block(
-            Block::new().borders(Borders::all()).title(
+            Block::bordered().title(
                 Title::default()
                     .content("Scatter chart".cyan().bold())
                     .alignment(Alignment::Center),

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -230,12 +230,12 @@ fn render_indexed_colors(frame: &mut Frame, area: Rect) {
 }
 
 fn title_block(title: String) -> Block<'static> {
-    Block::default()
+    Block::new()
         .borders(Borders::TOP)
-        .border_style(Style::new().dark_gray())
-        .title(title)
         .title_alignment(Alignment::Center)
+        .border_style(Style::new().dark_gray())
         .title_style(Style::new().reset())
+        .title(title)
 }
 
 fn render_indexed_grayscale(frame: &mut Frame, area: Rect) {

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -436,7 +436,7 @@ impl ConstraintBlock {
         } else {
             main_color
         };
-        Block::default()
+        Block::new()
             .fg(Self::TEXT_COLOR)
             .bg(selected_color)
             .render(area, buf);

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -197,7 +197,7 @@ impl App {
         );
         Paragraph::new(width_bar.dark_gray())
             .centered()
-            .block(Block::default().padding(Padding {
+            .block(Block::new().padding(Padding {
                 left: 0,
                 right: 0,
                 top: 1,

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -14,7 +14,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         .iter()
         .map(|t| text::Line::from(Span::styled(*t, Style::default().fg(Color::Green))))
         .collect::<Tabs>()
-        .block(Block::default().borders(Borders::ALL).title(app.title))
+        .block(Block::bordered().title(app.title))
         .highlight_style(Style::default().fg(Color::Yellow))
         .select(app.tabs.index);
     f.render_widget(tabs, chunks[0]);
@@ -46,7 +46,7 @@ fn draw_gauges(f: &mut Frame, app: &mut App, area: Rect) {
     ])
     .margin(1)
     .split(area);
-    let block = Block::default().borders(Borders::ALL).title("Graphs");
+    let block = Block::bordered().title("Graphs");
     f.render_widget(block, area);
 
     let label = format!("{:.2}%", app.progress * 100.0);
@@ -110,7 +110,7 @@ fn draw_charts(f: &mut Frame, app: &mut App, area: Rect) {
                 .map(|i| ListItem::new(vec![text::Line::from(Span::raw(*i))]))
                 .collect();
             let tasks = List::new(tasks)
-                .block(Block::default().borders(Borders::ALL).title("List"))
+                .block(Block::bordered().title("List"))
                 .highlight_style(Style::default().add_modifier(Modifier::BOLD))
                 .highlight_symbol("> ");
             f.render_stateful_widget(tasks, chunks[0], &mut app.tasks.state);
@@ -138,12 +138,12 @@ fn draw_charts(f: &mut Frame, app: &mut App, area: Rect) {
                     ListItem::new(content)
                 })
                 .collect();
-            let logs = List::new(logs).block(Block::default().borders(Borders::ALL).title("List"));
+            let logs = List::new(logs).block(Block::bordered().title("List"));
             f.render_stateful_widget(logs, chunks[1], &mut app.logs.state);
         }
 
         let barchart = BarChart::default()
-            .block(Block::default().borders(Borders::ALL).title("Bar chart"))
+            .block(Block::bordered().title("Bar chart"))
             .data(&app.barchart)
             .bar_width(3)
             .bar_gap(2)
@@ -195,14 +195,12 @@ fn draw_charts(f: &mut Frame, app: &mut App, area: Rect) {
         ];
         let chart = Chart::new(datasets)
             .block(
-                Block::default()
-                    .title(Span::styled(
-                        "Chart",
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD),
-                    ))
-                    .borders(Borders::ALL),
+                Block::bordered().title(Span::styled(
+                    "Chart",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )),
             )
             .x_axis(
                 Axis::default()
@@ -254,7 +252,7 @@ fn draw_text(f: &mut Frame, area: Rect) {
             "One more thing is that it should display unicode characters: 10€"
         ),
     ];
-    let block = Block::default().borders(Borders::ALL).title(Span::styled(
+    let block = Block::bordered().title(Span::styled(
         "Footer",
         Style::default()
             .fg(Color::Magenta)
@@ -292,11 +290,11 @@ fn draw_second_tab(f: &mut Frame, app: &mut App, area: Rect) {
             .style(Style::default().fg(Color::Yellow))
             .bottom_margin(1),
     )
-    .block(Block::default().title("Servers").borders(Borders::ALL));
+    .block(Block::bordered().title("Servers"));
     f.render_widget(table, chunks[0]);
 
     let map = Canvas::default()
-        .block(Block::default().title("World").borders(Borders::ALL))
+        .block(Block::bordered().title("World"))
         .paint(|ctx| {
             ctx.draw(&Map {
                 color: Color::White,
@@ -390,6 +388,6 @@ fn draw_third_tab(f: &mut Frame, _app: &mut App, area: Rect) {
             Constraint::Ratio(1, 3),
         ],
     )
-    .block(Block::default().title("Colors").borders(Borders::ALL));
+    .block(Block::bordered().title("Colors"));
     f.render_widget(table, chunks[0]);
 }

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -51,7 +51,7 @@ fn draw_gauges(f: &mut Frame, app: &mut App, area: Rect) {
 
     let label = format!("{:.2}%", app.progress * 100.0);
     let gauge = Gauge::default()
-        .block(Block::default().title("Gauge:"))
+        .block(Block::new().title("Gauge:"))
         .gauge_style(
             Style::default()
                 .fg(Color::Magenta)
@@ -64,7 +64,7 @@ fn draw_gauges(f: &mut Frame, app: &mut App, area: Rect) {
     f.render_widget(gauge, chunks[0]);
 
     let sparkline = Sparkline::default()
-        .block(Block::default().title("Sparkline:"))
+        .block(Block::new().title("Sparkline:"))
         .style(Style::default().fg(Color::Green))
         .data(&app.sparkline.points)
         .bar_set(if app.enhanced_graphics {
@@ -75,7 +75,7 @@ fn draw_gauges(f: &mut Frame, app: &mut App, area: Rect) {
     f.render_widget(sparkline, chunks[1]);
 
     let line_gauge = LineGauge::default()
-        .block(Block::default().title("LineGauge:"))
+        .block(Block::new().title("LineGauge:"))
         .gauge_style(Style::default().fg(Color::Magenta))
         .line_set(if app.enhanced_graphics {
             symbols::line::THICK

--- a/examples/demo2/tabs/traceroute.rs
+++ b/examples/demo2/tabs/traceroute.rs
@@ -49,10 +49,10 @@ fn render_hops(selected_row: usize, area: Rect, buf: &mut Buffer) {
         .iter()
         .map(|hop| Row::new(vec![hop.host, hop.address]))
         .collect_vec();
-    let block = Block::default()
-        .title("Traceroute bad.horse".bold().white())
+    let block = Block::new()
+        .padding(Padding::new(1, 1, 1, 1))
         .title_alignment(Alignment::Center)
-        .padding(Padding::new(1, 1, 1, 1));
+        .title("Traceroute bad.horse".bold().white());
     StatefulWidget::render(
         Table::new(rows, [Constraint::Max(100), Constraint::Length(15)])
             .header(Row::new(vec!["Host", "Address"]).set_style(THEME.traceroute.header))

--- a/examples/docsrs.rs
+++ b/examples/docsrs.rs
@@ -51,8 +51,7 @@ fn main() -> io::Result<()> {
 
 fn hello_world(frame: &mut Frame) {
     frame.render_widget(
-        Paragraph::new("Hello World!")
-            .block(Block::default().title("Greeting").borders(Borders::ALL)),
+        Paragraph::new("Hello World!").block(Block::bordered().title("Greeting")),
         frame.size(),
     );
 }
@@ -87,8 +86,8 @@ fn layout(frame: &mut Frame) {
         Block::new().borders(Borders::TOP).title("Status Bar"),
         status_bar,
     );
-    frame.render_widget(Block::default().borders(Borders::ALL).title("Left"), left);
-    frame.render_widget(Block::default().borders(Borders::ALL).title("Right"), right);
+    frame.render_widget(Block::bordered().title("Left"), left);
+    frame.render_widget(Block::bordered().title("Right"), right);
 }
 
 fn styling(frame: &mut Frame) {

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -206,11 +206,11 @@ impl App {
 
 fn title_block(title: &str) -> Block {
     let title = Title::from(title).alignment(Alignment::Center);
-    Block::default()
-        .title(title)
+    Block::new()
         .borders(Borders::NONE)
-        .fg(CUSTOM_LABEL_COLOR)
         .padding(Padding::vertical(1))
+        .title(title)
+        .fg(CUSTOM_LABEL_COLOR)
 }
 
 fn init_error_hooks() -> color_eyre::Result<()> {

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -236,7 +236,7 @@ fn run_app<B: Backend>(
 fn ui(f: &mut Frame, downloads: &Downloads) {
     let area = f.size();
 
-    let block = Block::default().title(block::Title::from("Progress").alignment(Alignment::Center));
+    let block = Block::new().title(block::Title::from("Progress").alignment(Alignment::Center));
     f.render_widget(block, area);
 
     let vertical = Layout::vertical([Constraint::Length(2), Constraint::Length(4)]).margin(1);

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -26,7 +26,7 @@ use itertools::Itertools;
 use ratatui::{
     layout::Constraint::*,
     prelude::*,
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Paragraph},
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -190,10 +190,9 @@ fn render_example_combination(
     title: &str,
     constraints: Vec<(Constraint, Constraint)>,
 ) {
-    let block = Block::default()
+    let block = Block::bordered()
         .title(title.gray())
         .style(Style::reset())
-        .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::DarkGray));
     let inner = block.inner(area);
     frame.render_widget(block, area);

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -189,13 +189,13 @@ impl Widget for &mut App<'_> {
 impl App<'_> {
     fn render_todo(&mut self, area: Rect, buf: &mut Buffer) {
         // We create two blocks, one is for the header (outer) and the other is for list (inner).
-        let outer_block = Block::default()
+        let outer_block = Block::new()
             .borders(Borders::NONE)
-            .fg(TEXT_COLOR)
-            .bg(TODO_HEADER_BG)
+            .title_alignment(Alignment::Center)
             .title("TODO List")
-            .title_alignment(Alignment::Center);
-        let inner_block = Block::default()
+            .fg(TEXT_COLOR)
+            .bg(TODO_HEADER_BG);
+        let inner_block = Block::new()
             .borders(Borders::NONE)
             .fg(TEXT_COLOR)
             .bg(NORMAL_ROW_COLOR);
@@ -246,16 +246,16 @@ impl App<'_> {
         };
 
         // We show the list item's info under the list in this paragraph
-        let outer_info_block = Block::default()
+        let outer_info_block = Block::new()
             .borders(Borders::NONE)
-            .fg(TEXT_COLOR)
-            .bg(TODO_HEADER_BG)
+            .title_alignment(Alignment::Center)
             .title("TODO Info")
-            .title_alignment(Alignment::Center);
-        let inner_info_block = Block::default()
+            .fg(TEXT_COLOR)
+            .bg(TODO_HEADER_BG);
+        let inner_info_block = Block::new()
             .borders(Borders::NONE)
-            .bg(NORMAL_ROW_COLOR)
-            .padding(Padding::horizontal(1));
+            .padding(Padding::horizontal(1))
+            .bg(NORMAL_ROW_COLOR);
 
         // This is a similar process to what we did for list. outer_info_area will be used for
         // header inner_info_area will be used for the list info.

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -37,7 +37,7 @@ use crossterm::{
 };
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Paragraph},
 };
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
@@ -142,11 +142,9 @@ fn ui(f: &mut Frame, app: &App) {
         Line::from("try first without the panic handler to see the difference"),
     ];
 
-    let b = Block::default()
-        .title("Panic Handler Demo")
-        .borders(Borders::ALL);
+    let paragraph = Paragraph::new(text)
+        .block(Block::bordered().title("Panic Handler Demo"))
+        .centered();
 
-    let p = Paragraph::new(text).block(b).centered();
-
-    f.render_widget(p, f.size());
+    f.render_widget(paragraph, f.size());
 }

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -105,7 +105,7 @@ fn ui(f: &mut Frame, app: &App) {
     let mut long_line = s.repeat(usize::from(size.width) / s.len() + 4);
     long_line.push('\n');
 
-    let block = Block::default().black();
+    let block = Block::new().black();
     f.render_widget(block, size);
 
     let layout = Layout::vertical([Constraint::Ratio(1, 4); 4]).split(size);

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -26,7 +26,7 @@ use crossterm::{
 };
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Paragraph, Wrap},
+    widgets::{Block, Paragraph, Wrap},
 };
 
 struct App {
@@ -127,8 +127,7 @@ fn ui(f: &mut Frame, app: &App) {
     ];
 
     let create_block = |title| {
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .style(Style::default().fg(Color::Gray))
             .title(Span::styled(
                 title,

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -25,7 +25,7 @@ use crossterm::{
 };
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    widgets::{Block, Clear, Paragraph, Wrap},
 };
 
 struct App {
@@ -98,14 +98,11 @@ fn ui(f: &mut Frame, app: &App) {
         .wrap(Wrap { trim: true });
     f.render_widget(paragraph, instructions);
 
-    let block = Block::default()
-        .title("Content")
-        .borders(Borders::ALL)
-        .on_blue();
+    let block = Block::bordered().title("Content").on_blue();
     f.render_widget(block, content);
 
     if app.show_popup {
-        let block = Block::default().title("Popup").borders(Borders::ALL);
+        let block = Block::bordered().title("Popup");
         let area = centered_rect(60, 20, area);
         f.render_widget(Clear, area); //this clears out the background
         f.render_widget(block, area);

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -151,18 +151,18 @@ fn ui(f: &mut Frame, app: &App) {
     .split(f.size());
     let sparkline = Sparkline::default()
         .block(
-            Block::default()
-                .title("Data1")
-                .borders(Borders::LEFT | Borders::RIGHT),
+            Block::new()
+                .borders(Borders::LEFT | Borders::RIGHT)
+                .title("Data1"),
         )
         .data(&app.data1)
         .style(Style::default().fg(Color::Yellow));
     f.render_widget(sparkline, chunks[0]);
     let sparkline = Sparkline::default()
         .block(
-            Block::default()
-                .title("Data2")
-                .borders(Borders::LEFT | Borders::RIGHT),
+            Block::new()
+                .borders(Borders::LEFT | Borders::RIGHT)
+                .title("Data2"),
         )
         .data(&app.data2)
         .style(Style::default().bg(Color::Green));
@@ -170,9 +170,9 @@ fn ui(f: &mut Frame, app: &App) {
     // Multiline
     let sparkline = Sparkline::default()
         .block(
-            Block::default()
-                .title("Data3")
-                .borders(Borders::LEFT | Borders::RIGHT),
+            Block::new()
+                .borders(Borders::LEFT | Borders::RIGHT)
+                .title("Data3"),
         )
         .data(&app.data3)
         .style(Style::default().fg(Color::Red));

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -331,10 +331,9 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect) {
         .style(Style::new().fg(app.colors.row_fg).bg(app.colors.buffer_bg))
         .centered()
         .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::new().fg(app.colors.footer_border_color))
-                .border_type(BorderType::Double),
+            Block::bordered()
+                .border_type(BorderType::Double)
+                .border_style(Style::new().fg(app.colors.footer_border_color)),
         );
     f.render_widget(info_footer, area);
 }

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -205,8 +205,7 @@ impl SelectedTab {
 
     /// A block surrounding the tab's content
     fn block(self) -> Block<'static> {
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .border_set(symbols::border::PROPORTIONAL_TALL)
             .padding(Padding::horizontal(1))
             .border_style(self.palette().c700)

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -36,7 +36,7 @@ use crossterm::{
 };
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, List, ListItem, Paragraph},
+    widgets::{Block, List, ListItem, Paragraph},
 };
 
 enum InputMode {
@@ -238,7 +238,7 @@ fn ui(f: &mut Frame, app: &App) {
             InputMode::Normal => Style::default(),
             InputMode::Editing => Style::default().fg(Color::Yellow),
         })
-        .block(Block::default().borders(Borders::ALL).title("Input"));
+        .block(Block::bordered().title("Input"));
     f.render_widget(input, input_area);
     match app.input_mode {
         InputMode::Normal =>
@@ -268,7 +268,6 @@ fn ui(f: &mut Frame, app: &App) {
             ListItem::new(content)
         })
         .collect();
-    let messages =
-        List::new(messages).block(Block::default().borders(Borders::ALL).title("Messages"));
+    let messages = List::new(messages).block(Block::bordered().title("Messages"));
     f.render_widget(messages, messages_area);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,8 +139,7 @@
 //!
 //! fn ui(frame: &mut Frame) {
 //!     frame.render_widget(
-//!         Paragraph::new("Hello World!")
-//!             .block(Block::default().title("Greeting").borders(Borders::ALL)),
+//!         Paragraph::new("Hello World!").block(Block::bordered().title("Greeting")),
 //!         frame.size(),
 //!     );
 //! }
@@ -184,14 +183,8 @@
 //!         [Constraint::Percentage(50), Constraint::Percentage(50)],
 //!     )
 //!     .split(main_layout[1]);
-//!     frame.render_widget(
-//!         Block::default().borders(Borders::ALL).title("Left"),
-//!         inner_layout[0],
-//!     );
-//!     frame.render_widget(
-//!         Block::default().borders(Borders::ALL).title("Right"),
-//!         inner_layout[1],
-//!     );
+//!     frame.render_widget(Block::bordered().title("Left"), inner_layout[0]);
+//!     frame.render_widget(Block::bordered().title("Right"), inner_layout[1]);
 //! }
 //! ```
 //!

--- a/src/style.rs
+++ b/src/style.rs
@@ -552,32 +552,26 @@ impl From<(Color, Color, Modifier, Modifier)> for Style {
 mod tests {
     use super::*;
 
-    fn styles() -> Vec<Style> {
-        vec![
-            Style::default(),
-            Style::default().fg(Color::Yellow),
-            Style::default().bg(Color::Yellow),
-            Style::default().add_modifier(Modifier::BOLD),
-            Style::default().remove_modifier(Modifier::BOLD),
-            Style::default().add_modifier(Modifier::ITALIC),
-            Style::default().remove_modifier(Modifier::ITALIC),
-            Style::default().add_modifier(Modifier::ITALIC | Modifier::BOLD),
-            Style::default().remove_modifier(Modifier::ITALIC | Modifier::BOLD),
-        ]
-    }
-
     #[test]
     fn combined_patch_gives_same_result_as_individual_patch() {
-        let styles = styles();
+        let styles = [
+            Style::new(),
+            Style::new().fg(Color::Yellow),
+            Style::new().bg(Color::Yellow),
+            Style::new().add_modifier(Modifier::BOLD),
+            Style::new().remove_modifier(Modifier::BOLD),
+            Style::new().add_modifier(Modifier::ITALIC),
+            Style::new().remove_modifier(Modifier::ITALIC),
+            Style::new().add_modifier(Modifier::ITALIC | Modifier::BOLD),
+            Style::new().remove_modifier(Modifier::ITALIC | Modifier::BOLD),
+        ];
         for &a in &styles {
             for &b in &styles {
                 for &c in &styles {
                     for &d in &styles {
-                        let combined = a.patch(b.patch(c.patch(d)));
-
                         assert_eq!(
-                            Style::default().patch(a).patch(b).patch(c).patch(d),
-                            Style::default().patch(combined)
+                            Style::new().patch(a).patch(b).patch(c).patch(d),
+                            Style::new().patch(a.patch(b.patch(c.patch(d))))
                         );
                     }
                 }
@@ -589,7 +583,7 @@ mod tests {
     fn combine_individual_modifiers() {
         use crate::{buffer::Buffer, layout::Rect};
 
-        let mods = vec![
+        let mods = [
             Modifier::BOLD,
             Modifier::DIM,
             Modifier::ITALIC,
@@ -603,14 +597,12 @@ mod tests {
 
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
 
-        for m in &mods {
+        for m in mods {
             buffer.get_mut(0, 0).set_style(Style::reset());
-            buffer
-                .get_mut(0, 0)
-                .set_style(Style::default().add_modifier(*m));
+            buffer.get_mut(0, 0).set_style(Style::new().add_modifier(m));
             let style = buffer.get(0, 0).style();
-            assert!(style.add_modifier.contains(*m));
-            assert!(!style.sub_modifier.contains(*m));
+            assert!(style.add_modifier.contains(m));
+            assert!(!style.sub_modifier.contains(m));
         }
     }
 

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -133,11 +133,7 @@ macro_rules! modifier {
 ///     "world".green().on_yellow().not_bold(),
 /// ]);
 /// let paragraph = Paragraph::new(line).italic().underlined();
-/// let block = Block::default()
-///     .title("Title")
-///     .borders(Borders::ALL)
-///     .on_white()
-///     .bold();
+/// let block = Block::bordered().title("Title").on_white().bold();
 /// ```
 pub trait Stylize<'a, T>: Sized {
     #[must_use = "`bg` returns the modified style without modifying the original"]

--- a/src/terminal/frame.rs
+++ b/src/terminal/frame.rs
@@ -65,7 +65,7 @@ impl Frame<'_> {
     /// # let backend = TestBackend::new(5, 5);
     /// # let mut terminal = Terminal::new(backend).unwrap();
     /// # let mut frame = terminal.get_frame();
-    /// let block = Block::default();
+    /// let block = Block::new();
     /// let area = Rect::new(0, 0, 5, 5);
     /// frame.render_widget(block, area);
     /// ```
@@ -87,7 +87,7 @@ impl Frame<'_> {
     /// # let backend = TestBackend::new(5, 5);
     /// # let mut terminal = Terminal::new(backend).unwrap();
     /// # let mut frame = terminal.get_frame();
-    /// let block = Block::default();
+    /// let block = Block::new();
     /// let area = Rect::new(0, 0, 5, 5);
     /// frame.render_widget_ref(block, area);
     /// ```

--- a/src/text.rs
+++ b/src/text.rs
@@ -25,21 +25,20 @@
 //! // Converted to Line(vec![
 //! //   Span { content: Cow::Borrowed("My title"), style: Style { .. } }
 //! // ])
-//! let block = Block::default().title("My title");
+//! let block = Block::new().title("My title");
 //!
 //! // A simple string with a unique style.
 //! // Converted to Line(vec![
 //! //   Span { content: Cow::Borrowed("My title"), style: Style { fg: Some(Color::Yellow), .. }
 //! // ])
-//! let block =
-//!     Block::default().title(Span::styled("My title", Style::default().fg(Color::Yellow)));
+//! let block = Block::new().title(Span::styled("My title", Style::default().fg(Color::Yellow)));
 //!
 //! // A string with multiple styles.
 //! // Converted to Line(vec![
 //! //   Span { content: Cow::Borrowed("My"), style: Style { fg: Some(Color::Yellow), .. } },
 //! //   Span { content: Cow::Borrowed(" title"), .. }
 //! // ])
-//! let block = Block::default().title(vec![
+//! let block = Block::new().title(vec![
 //!     Span::styled("My", Style::default().fg(Color::Yellow)),
 //!     Span::raw(" title"),
 //! ]);

--- a/src/widgets/barchart.rs
+++ b/src/widgets/barchart.rs
@@ -45,7 +45,7 @@ pub use bar_group::BarGroup;
 /// use ratatui::{prelude::*, widgets::*};
 ///
 /// BarChart::default()
-///     .block(Block::default().title("BarChart").borders(Borders::ALL))
+///     .block(Block::bordered().title("BarChart"))
 ///     .bar_width(3)
 ///     .bar_gap(1)
 ///     .group_gap(3)
@@ -615,10 +615,7 @@ mod tests {
     use itertools::iproduct;
 
     use super::*;
-    use crate::{
-        assert_buffer_eq,
-        widgets::{BorderType, Borders},
-    };
+    use crate::{assert_buffer_eq, widgets::BorderType};
 
     #[test]
     fn default() {
@@ -646,10 +643,9 @@ mod tests {
     #[test]
     fn block() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 5));
-        let block = Block::default()
-            .title("Block")
+        let block = Block::bordered()
             .border_type(BorderType::Double)
-            .borders(Borders::ALL);
+            .title("Block");
         let widget = BarChart::default()
             .data(&[("foo", 1), ("bar", 2)])
             .block(block);

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -41,12 +41,12 @@ pub use title::{Position, Title};
 /// ```
 /// use ratatui::{prelude::*, widgets::*};
 ///
-/// Block::default()
-///     .title("Block")
+/// Block::new()
+///     .border_type(BorderType::Rounded)
 ///     .borders(Borders::LEFT | Borders::RIGHT)
 ///     .border_style(Style::default().fg(Color::White))
-///     .border_type(BorderType::Rounded)
-///     .style(Style::default().bg(Color::Black));
+///     .style(Style::default().bg(Color::Black))
+///     .title("Block");
 /// ```
 ///
 /// You may also use multiple titles like in the following:
@@ -56,7 +56,7 @@ pub use title::{Position, Title};
 ///     widgets::{block::*, *},
 /// };
 ///
-/// Block::default()
+/// Block::new()
 ///     .title("Title 1")
 ///     .title(Title::from("Title 2").position(Position::Bottom));
 /// ```
@@ -224,7 +224,7 @@ impl<'a> Block<'a> {
     ///     widgets::{block::*, *},
     /// };
     ///
-    /// Block::default()
+    /// Block::new()
     ///     .title("Title") // By default in the top left corner
     ///     .title(Title::from("Left").alignment(Alignment::Left)) // also on the left
     ///     .title(Title::from("Right").alignment(Alignment::Right))
@@ -330,12 +330,12 @@ impl<'a> Block<'a> {
     ///     widgets::{block::*, *},
     /// };
     ///
-    /// Block::default()
+    /// Block::new()
+    ///     .title_alignment(Alignment::Center)
     ///     // This title won't be aligned in the center
     ///     .title(Title::from("right").alignment(Alignment::Right))
     ///     .title("foo")
-    ///     .title("bar")
-    ///     .title_alignment(Alignment::Center);
+    ///     .title("bar");
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn title_alignment(mut self, alignment: Alignment) -> Self {
@@ -357,12 +357,12 @@ impl<'a> Block<'a> {
     ///     widgets::{block::*, *},
     /// };
     ///
-    /// Block::default()
+    /// Block::new()
+    ///     .title_position(Position::Bottom)
     ///     // This title won't be aligned in the center
     ///     .title(Title::from("top").position(Position::Top))
     ///     .title("foo")
-    ///     .title("bar")
-    ///     .title_position(Position::Bottom);
+    ///     .title("bar");
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn title_position(mut self, position: Position) -> Self {
@@ -876,33 +876,33 @@ mod tests {
     fn inner_takes_into_account_the_borders() {
         // No borders
         assert_eq!(
-            Block::default().inner(Rect::default()),
+            Block::new().inner(Rect::default()),
             Rect::new(0, 0, 0, 0),
             "no borders, width=0, height=0"
         );
         assert_eq!(
-            Block::default().inner(Rect::new(0, 0, 1, 1)),
+            Block::new().inner(Rect::new(0, 0, 1, 1)),
             Rect::new(0, 0, 1, 1),
             "no borders, width=1, height=1"
         );
 
         // Left border
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::LEFT)
                 .inner(Rect::new(0, 0, 0, 1)),
             Rect::new(0, 0, 0, 1),
             "left, width=0"
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::LEFT)
                 .inner(Rect::new(0, 0, 1, 1)),
             Rect::new(1, 0, 0, 1),
             "left, width=1"
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::LEFT)
                 .inner(Rect::new(0, 0, 2, 1)),
             Rect::new(1, 0, 1, 1),
@@ -911,21 +911,21 @@ mod tests {
 
         // Top border
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::TOP)
                 .inner(Rect::new(0, 0, 1, 0)),
             Rect::new(0, 0, 1, 0),
             "top, height=0"
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::TOP)
                 .inner(Rect::new(0, 0, 1, 1)),
             Rect::new(0, 1, 1, 0),
             "top, height=1"
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::TOP)
                 .inner(Rect::new(0, 0, 1, 2)),
             Rect::new(0, 1, 1, 1),
@@ -934,21 +934,21 @@ mod tests {
 
         // Right border
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::RIGHT)
                 .inner(Rect::new(0, 0, 0, 1)),
             Rect::new(0, 0, 0, 1),
             "right, width=0"
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::RIGHT)
                 .inner(Rect::new(0, 0, 1, 1)),
             Rect::new(0, 0, 0, 1),
             "right, width=1"
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::RIGHT)
                 .inner(Rect::new(0, 0, 2, 1)),
             Rect::new(0, 0, 1, 1),
@@ -957,21 +957,21 @@ mod tests {
 
         // Bottom border
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::BOTTOM)
                 .inner(Rect::new(0, 0, 1, 0)),
             Rect::new(0, 0, 1, 0),
             "bottom, height=0"
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::BOTTOM)
                 .inner(Rect::new(0, 0, 1, 1)),
             Rect::new(0, 0, 1, 0),
             "bottom, height=1"
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .borders(Borders::BOTTOM)
                 .inner(Rect::new(0, 0, 1, 2)),
             Rect::new(0, 0, 1, 1),
@@ -1004,17 +1004,17 @@ mod tests {
     #[test]
     fn inner_takes_into_account_the_title() {
         assert_eq!(
-            Block::default().title("Test").inner(Rect::new(0, 0, 0, 1)),
+            Block::new().title("Test").inner(Rect::new(0, 0, 0, 1)),
             Rect::new(0, 1, 0, 0),
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .title(Title::from("Test").alignment(Alignment::Center))
                 .inner(Rect::new(0, 0, 0, 1)),
             Rect::new(0, 1, 0, 0),
         );
         assert_eq!(
-            Block::default()
+            Block::new()
                 .title(Title::from("Test").alignment(Alignment::Right))
                 .inner(Rect::new(0, 0, 0, 1)),
             Rect::new(0, 1, 0, 0),
@@ -1025,67 +1025,67 @@ mod tests {
     fn inner_takes_into_account_border_and_title() {
         let test_rect = Rect::new(0, 0, 0, 2);
 
-        let top_top = Block::default()
-            .title(Title::from("Test").position(Position::Top))
-            .borders(Borders::TOP);
+        let top_top = Block::new()
+            .borders(Borders::TOP)
+            .title(Title::from("Test").position(Position::Top));
         assert_eq!(top_top.inner(test_rect), Rect::new(0, 1, 0, 1));
 
-        let top_bot = Block::default()
-            .title(Title::from("Test").position(Position::Top))
-            .borders(Borders::BOTTOM);
+        let top_bot = Block::new()
+            .borders(Borders::BOTTOM)
+            .title(Title::from("Test").position(Position::Top));
         assert_eq!(top_bot.inner(test_rect), Rect::new(0, 1, 0, 0));
 
-        let bot_top = Block::default()
-            .title(Title::from("Test").position(Position::Bottom))
-            .borders(Borders::TOP);
+        let bot_top = Block::new()
+            .borders(Borders::TOP)
+            .title(Title::from("Test").position(Position::Bottom));
         assert_eq!(bot_top.inner(test_rect), Rect::new(0, 1, 0, 0));
 
-        let bot_bot = Block::default()
-            .title(Title::from("Test").position(Position::Bottom))
-            .borders(Borders::BOTTOM);
+        let bot_bot = Block::new()
+            .borders(Borders::BOTTOM)
+            .title(Title::from("Test").position(Position::Bottom));
         assert_eq!(bot_bot.inner(test_rect), Rect::new(0, 0, 0, 1));
     }
 
     #[test]
     fn have_title_at_position_takes_into_account_all_positioning_declarations() {
-        let block = Block::default();
+        let block = Block::new();
         assert!(!block.have_title_at_position(Position::Top));
         assert!(!block.have_title_at_position(Position::Bottom));
 
-        let block = Block::default().title(Title::from("Test").position(Position::Top));
+        let block = Block::new().title(Title::from("Test").position(Position::Top));
         assert!(block.have_title_at_position(Position::Top));
         assert!(!block.have_title_at_position(Position::Bottom));
 
-        let block = Block::default().title(Title::from("Test").position(Position::Bottom));
+        let block = Block::new().title(Title::from("Test").position(Position::Bottom));
         assert!(!block.have_title_at_position(Position::Top));
         assert!(block.have_title_at_position(Position::Bottom));
 
-        let block = Block::default()
+        let block = Block::new()
             .title(Title::from("Test").position(Position::Top))
             .title_position(Position::Bottom);
         assert!(block.have_title_at_position(Position::Top));
         assert!(!block.have_title_at_position(Position::Bottom));
 
-        let block = Block::default()
+        let block = Block::new()
             .title(Title::from("Test").position(Position::Bottom))
             .title_position(Position::Top);
         assert!(!block.have_title_at_position(Position::Top));
         assert!(block.have_title_at_position(Position::Bottom));
 
-        let block = Block::default()
+        let block = Block::new()
             .title(Title::from("Test").position(Position::Top))
             .title(Title::from("Test").position(Position::Bottom));
         assert!(block.have_title_at_position(Position::Top));
         assert!(block.have_title_at_position(Position::Bottom));
 
-        let block = Block::default()
+        let block = Block::new()
             .title(Title::from("Test").position(Position::Top))
             .title(Title::from("Test"))
             .title_position(Position::Bottom);
         assert!(block.have_title_at_position(Position::Top));
         assert!(block.have_title_at_position(Position::Bottom));
 
-        let block = Block::default()
+        let block = Block::new()
             .title(Title::from("Test"))
             .title(Title::from("Test").position(Position::Bottom))
             .title_position(Position::Top);
@@ -1134,35 +1134,35 @@ mod tests {
     #[test]
     fn block_style() {
         // nominal style
-        let block = Block::default().style(Style::new().red());
+        let block = Block::new().style(Style::new().red());
         assert_eq!(block.style, Style::new().red());
 
         // auto-convert from Color
-        let block = Block::default().style(Color::Red);
+        let block = Block::new().style(Color::Red);
         assert_eq!(block.style, Style::new().red());
 
         // auto-convert from (Color, Color)
-        let block = Block::default().style((Color::Red, Color::Blue));
+        let block = Block::new().style((Color::Red, Color::Blue));
         assert_eq!(block.style, Style::new().red().on_blue());
 
         // auto-convert from Modifier
-        let block = Block::default().style(Modifier::BOLD | Modifier::ITALIC);
+        let block = Block::new().style(Modifier::BOLD | Modifier::ITALIC);
         assert_eq!(block.style, Style::new().bold().italic());
 
         // auto-convert from (Modifier, Modifier)
-        let block = Block::default().style((Modifier::BOLD | Modifier::ITALIC, Modifier::DIM));
+        let block = Block::new().style((Modifier::BOLD | Modifier::ITALIC, Modifier::DIM));
         assert_eq!(block.style, Style::new().bold().italic().not_dim());
 
         // auto-convert from (Color, Modifier)
-        let block = Block::default().style((Color::Red, Modifier::BOLD));
+        let block = Block::new().style((Color::Red, Modifier::BOLD));
         assert_eq!(block.style, Style::new().red().bold());
 
         // auto-convert from (Color, Color, Modifier)
-        let block = Block::default().style((Color::Red, Color::Blue, Modifier::BOLD));
+        let block = Block::new().style((Color::Red, Color::Blue, Modifier::BOLD));
         assert_eq!(block.style, Style::new().red().on_blue().bold());
 
         // auto-convert from (Color, Color, Modifier, Modifier)
-        let block = Block::default().style((
+        let block = Block::new().style((
             Color::Red,
             Color::Blue,
             Modifier::BOLD | Modifier::ITALIC,
@@ -1176,7 +1176,7 @@ mod tests {
 
     #[test]
     fn can_be_stylized() {
-        let block = Block::default().black().on_white().bold().not_dim();
+        let block = Block::new().black().on_white().bold().not_dim();
         assert_eq!(
             block.style,
             Style::default()
@@ -1240,9 +1240,9 @@ mod tests {
         ];
         for (alignment, expected) in tests {
             let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 1));
-            Block::default()
-                .title("test")
+            Block::new()
                 .title_alignment(alignment)
+                .title("test")
                 .render(buffer.area, &mut buffer);
             assert_buffer_eq!(buffer, Buffer::with_lines(vec![expected]));
         }
@@ -1257,9 +1257,9 @@ mod tests {
         ];
         for (block_title_alignment, alignment, expected) in tests {
             let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 1));
-            Block::default()
-                .title(Title::from("test").alignment(alignment))
+            Block::new()
                 .title_alignment(block_title_alignment)
+                .title(Title::from("test").alignment(alignment))
                 .render(buffer.area, &mut buffer);
             assert_buffer_eq!(buffer, Buffer::with_lines(vec![expected]));
         }
@@ -1269,9 +1269,9 @@ mod tests {
     #[test]
     fn render_right_aligned_empty_title() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
-            .title("")
+        Block::new()
             .title_alignment(Alignment::Right)
+            .title("")
             .render(buffer.area, &mut buffer);
         assert_buffer_eq!(
             buffer,
@@ -1286,9 +1286,9 @@ mod tests {
     #[test]
     fn title_position() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 2));
-        Block::default()
-            .title("test")
+        Block::new()
             .title_position(Position::Bottom)
+            .title("test")
             .render(buffer.area, &mut buffer);
         assert_buffer_eq!(buffer, Buffer::with_lines(vec!["    ", "test"]));
     }
@@ -1297,9 +1297,9 @@ mod tests {
     fn title_content_style() {
         for alignment in [Alignment::Left, Alignment::Center, Alignment::Right] {
             let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
-            Block::default()
-                .title("test".yellow())
+            Block::new()
                 .title_alignment(alignment)
+                .title("test".yellow())
                 .render(buffer.area, &mut buffer);
 
             let mut expected_buffer = Buffer::with_lines(vec!["test"]);
@@ -1313,10 +1313,10 @@ mod tests {
     fn block_title_style() {
         for alignment in [Alignment::Left, Alignment::Center, Alignment::Right] {
             let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
-            Block::default()
-                .title("test")
-                .title_style(Style::new().yellow())
+            Block::new()
                 .title_alignment(alignment)
+                .title_style(Style::new().yellow())
+                .title("test")
                 .render(buffer.area, &mut buffer);
 
             let mut expected_buffer = Buffer::with_lines(vec!["test"]);
@@ -1330,10 +1330,10 @@ mod tests {
     fn title_style_overrides_block_title_style() {
         for alignment in [Alignment::Left, Alignment::Center, Alignment::Right] {
             let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
-            Block::default()
-                .title("test".yellow())
-                .title_style(Style::new().green().on_red())
+            Block::new()
                 .title_alignment(alignment)
+                .title_style(Style::new().green().on_red())
+                .title("test".yellow())
                 .render(buffer.area, &mut buffer);
 
             let mut expected_buffer = Buffer::with_lines(vec!["test"]);

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -499,14 +499,14 @@ impl<'a> Block<'a> {
             inner.x = inner.x.saturating_add(1).min(inner.right());
             inner.width = inner.width.saturating_sub(1);
         }
-        if self.borders.intersects(Borders::TOP) || self.have_title_at_position(Position::Top) {
+        if self.borders.intersects(Borders::TOP) || self.has_title_at_position(Position::Top) {
             inner.y = inner.y.saturating_add(1).min(inner.bottom());
             inner.height = inner.height.saturating_sub(1);
         }
         if self.borders.intersects(Borders::RIGHT) {
             inner.width = inner.width.saturating_sub(1);
         }
-        if self.borders.intersects(Borders::BOTTOM) || self.have_title_at_position(Position::Bottom)
+        if self.borders.intersects(Borders::BOTTOM) || self.has_title_at_position(Position::Bottom)
         {
             inner.height = inner.height.saturating_sub(1);
         }
@@ -524,7 +524,7 @@ impl<'a> Block<'a> {
         inner
     }
 
-    fn have_title_at_position(&self, position: Position) -> bool {
+    fn has_title_at_position(&self, position: Position) -> bool {
         self.titles
             .iter()
             .any(|title| title.position.unwrap_or(self.titles_position) == position)
@@ -1047,50 +1047,50 @@ mod tests {
     }
 
     #[test]
-    fn have_title_at_position_takes_into_account_all_positioning_declarations() {
+    fn has_title_at_position_takes_into_account_all_positioning_declarations() {
         let block = Block::new();
-        assert!(!block.have_title_at_position(Position::Top));
-        assert!(!block.have_title_at_position(Position::Bottom));
+        assert!(!block.has_title_at_position(Position::Top));
+        assert!(!block.has_title_at_position(Position::Bottom));
 
         let block = Block::new().title(Title::from("Test").position(Position::Top));
-        assert!(block.have_title_at_position(Position::Top));
-        assert!(!block.have_title_at_position(Position::Bottom));
+        assert!(block.has_title_at_position(Position::Top));
+        assert!(!block.has_title_at_position(Position::Bottom));
 
         let block = Block::new().title(Title::from("Test").position(Position::Bottom));
-        assert!(!block.have_title_at_position(Position::Top));
-        assert!(block.have_title_at_position(Position::Bottom));
+        assert!(!block.has_title_at_position(Position::Top));
+        assert!(block.has_title_at_position(Position::Bottom));
 
         let block = Block::new()
             .title(Title::from("Test").position(Position::Top))
             .title_position(Position::Bottom);
-        assert!(block.have_title_at_position(Position::Top));
-        assert!(!block.have_title_at_position(Position::Bottom));
+        assert!(block.has_title_at_position(Position::Top));
+        assert!(!block.has_title_at_position(Position::Bottom));
 
         let block = Block::new()
             .title(Title::from("Test").position(Position::Bottom))
             .title_position(Position::Top);
-        assert!(!block.have_title_at_position(Position::Top));
-        assert!(block.have_title_at_position(Position::Bottom));
+        assert!(!block.has_title_at_position(Position::Top));
+        assert!(block.has_title_at_position(Position::Bottom));
 
         let block = Block::new()
             .title(Title::from("Test").position(Position::Top))
             .title(Title::from("Test").position(Position::Bottom));
-        assert!(block.have_title_at_position(Position::Top));
-        assert!(block.have_title_at_position(Position::Bottom));
+        assert!(block.has_title_at_position(Position::Top));
+        assert!(block.has_title_at_position(Position::Bottom));
 
         let block = Block::new()
             .title(Title::from("Test").position(Position::Top))
             .title(Title::from("Test"))
             .title_position(Position::Bottom);
-        assert!(block.have_title_at_position(Position::Top));
-        assert!(block.have_title_at_position(Position::Bottom));
+        assert!(block.has_title_at_position(Position::Top));
+        assert!(block.has_title_at_position(Position::Bottom));
 
         let block = Block::new()
             .title(Title::from("Test"))
             .title(Title::from("Test").position(Position::Bottom))
             .title_position(Position::Top);
-        assert!(block.have_title_at_position(Position::Top));
-        assert!(block.have_title_at_position(Position::Bottom));
+        assert!(block.has_title_at_position(Position::Top));
+        assert!(block.has_title_at_position(Position::Bottom));
     }
 
     #[test]

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -1130,9 +1130,9 @@ mod tests {
             .padding(_DEFAULT_PADDING);
     }
 
-    /// This test ensures that we have some coverage on the [`Style::from()`] implementations
+    /// Ensure Style from/into works the way a user would use it.
     #[test]
-    fn block_style() {
+    fn style_into_works_from_user_view() {
         // nominal style
         let block = Block::new().style(Style::new().red());
         assert_eq!(block.style, Style::new().red());

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -173,6 +173,11 @@ impl<'a> Block<'a> {
     }
 
     /// Create a new block with [all borders](Borders::ALL) shown
+    ///
+    /// ```
+    /// # use ratatui::widgets::{Block, Borders};
+    /// assert_eq!(Block::bordered(), Block::new().borders(Borders::ALL));
+    /// ```
     pub const fn bordered() -> Self {
         let mut block = Self::new();
         block.borders = Borders::ALL;
@@ -377,9 +382,7 @@ impl<'a> Block<'a> {
     /// This example shows a `Block` with blue borders.
     /// ```
     /// # use ratatui::{prelude::*, widgets::*};
-    /// Block::default()
-    ///     .borders(Borders::ALL)
-    ///     .border_style(Style::new().blue());
+    /// Block::bordered().border_style(Style::new().blue());
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub fn border_style<S: Into<Style>>(mut self, style: S) -> Self {
@@ -409,17 +412,13 @@ impl<'a> Block<'a> {
     ///
     /// # Examples
     ///
-    /// Simply show all borders.
-    /// ```
-    /// # use ratatui::{prelude::*, widgets::*};
-    /// Block::default().borders(Borders::ALL);
-    /// ```
-    ///
     /// Display left and right borders.
     /// ```
     /// # use ratatui::{prelude::*, widgets::*};
-    /// Block::default().borders(Borders::LEFT | Borders::RIGHT);
+    /// Block::new().borders(Borders::LEFT | Borders::RIGHT);
     /// ```
+    ///
+    /// To show all borders you can abbreviate this with [`Block::bordered`]
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn borders(mut self, flag: Borders) -> Self {
         self.borders = flag;
@@ -437,10 +436,9 @@ impl<'a> Block<'a> {
     ///
     /// ```
     /// # use ratatui::{prelude::*, widgets::*};
-    /// Block::default()
-    ///     .title("Block")
-    ///     .borders(Borders::ALL)
-    ///     .border_type(BorderType::Rounded);
+    /// Block::bordered()
+    ///     .border_type(BorderType::Rounded)
+    ///     .title("Block");
     /// // Renders
     /// // ╭Block╮
     /// // │     │
@@ -460,7 +458,7 @@ impl<'a> Block<'a> {
     ///
     /// ```
     /// # use ratatui::{prelude::*, widgets::*};
-    /// Block::default().title("Block").borders(Borders::ALL).border_set(symbols::border::DOUBLE);
+    /// Block::bordered().border_set(symbols::border::DOUBLE).title("Block");
     /// // Renders
     /// // ╔Block╗
     /// // ║     ║
@@ -479,8 +477,8 @@ impl<'a> Block<'a> {
     /// ```
     /// # use ratatui::{prelude::*, widgets::*};
     /// # fn render_nested_block(frame: &mut Frame) {
-    /// let outer_block = Block::default().title("Outer").borders(Borders::ALL);
-    /// let inner_block = Block::default().title("Inner").borders(Borders::ALL);
+    /// let outer_block = Block::bordered().title("Outer");
+    /// let inner_block = Block::bordered().title("Inner");
     ///
     /// let outer_area = frame.size();
     /// let inner_area = outer_block.inner(outer_area);
@@ -541,9 +539,7 @@ impl<'a> Block<'a> {
     /// This renders a `Block` with no padding (the default).
     /// ```
     /// # use ratatui::{prelude::*, widgets::*};
-    /// Block::default()
-    ///     .borders(Borders::ALL)
-    ///     .padding(Padding::zero());
+    /// Block::bordered().padding(Padding::zero());
     /// // Renders
     /// // ┌───────┐
     /// // │content│
@@ -554,9 +550,7 @@ impl<'a> Block<'a> {
     /// Notice the two spaces before and after the content.
     /// ```
     /// # use ratatui::{prelude::*, widgets::*};
-    /// Block::default()
-    ///     .borders(Borders::ALL)
-    ///     .padding(Padding::horizontal(2));
+    /// Block::bordered().padding(Padding::horizontal(2));
     /// // Renders
     /// // ┌───────────┐
     /// // │  content  │
@@ -986,30 +980,22 @@ mod tests {
 
         // All borders
         assert_eq!(
-            Block::default()
-                .borders(Borders::ALL)
-                .inner(Rect::default()),
+            Block::bordered().inner(Rect::default()),
             Rect::new(0, 0, 0, 0),
             "all borders, width=0, height=0"
         );
         assert_eq!(
-            Block::default()
-                .borders(Borders::ALL)
-                .inner(Rect::new(0, 0, 1, 1)),
+            Block::bordered().inner(Rect::new(0, 0, 1, 1)),
             Rect::new(1, 1, 0, 0),
             "all borders, width=1, height=1"
         );
         assert_eq!(
-            Block::default()
-                .borders(Borders::ALL)
-                .inner(Rect::new(0, 0, 2, 2)),
+            Block::bordered().inner(Rect::new(0, 0, 2, 2)),
             Rect::new(1, 1, 0, 0),
             "all borders, width=2, height=2"
         );
         assert_eq!(
-            Block::default()
-                .borders(Borders::ALL)
-                .inner(Rect::new(0, 0, 3, 3)),
+            Block::bordered().inner(Rect::new(0, 0, 3, 3)),
             Rect::new(1, 1, 1, 1),
             "all borders, width=3, height=3"
         );
@@ -1134,14 +1120,13 @@ mod tests {
     const fn block_can_be_const() {
         const _DEFAULT_STYLE: Style = Style::new();
         const _DEFAULT_PADDING: Padding = Padding::uniform(1);
-        const _DEFAULT_BLOCK: Block = Block::new()
+        const _DEFAULT_BLOCK: Block = Block::bordered()
             // the following methods are no longer const because they use Into<Style>
             // .style(_DEFAULT_STYLE)           // no longer const
             // .border_style(_DEFAULT_STYLE)    // no longer const
             // .title_style(_DEFAULT_STYLE)     // no longer const
             .title_alignment(Alignment::Left)
             .title_position(Position::Top)
-            .borders(Borders::ALL)
             .padding(_DEFAULT_PADDING);
     }
 
@@ -1361,9 +1346,8 @@ mod tests {
     #[test]
     fn title_border_style() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
+        Block::bordered()
             .title("test")
-            .borders(Borders::ALL)
             .border_style(Style::new().yellow())
             .render(buffer.area, &mut buffer);
 
@@ -1398,8 +1382,7 @@ mod tests {
     #[test]
     fn render_plain_border() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .border_type(BorderType::Plain)
             .render(buffer.area, &mut buffer);
         assert_buffer_eq!(
@@ -1415,8 +1398,7 @@ mod tests {
     #[test]
     fn render_rounded_border() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .border_type(BorderType::Rounded)
             .render(buffer.area, &mut buffer);
         assert_buffer_eq!(
@@ -1432,8 +1414,7 @@ mod tests {
     #[test]
     fn render_double_border() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .border_type(BorderType::Double)
             .render(buffer.area, &mut buffer);
         assert_buffer_eq!(
@@ -1449,8 +1430,7 @@ mod tests {
     #[test]
     fn render_quadrant_inside() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .border_type(BorderType::QuadrantInside)
             .render(buffer.area, &mut buffer);
         assert_buffer_eq!(
@@ -1466,8 +1446,7 @@ mod tests {
     #[test]
     fn render_border_quadrant_outside() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .border_type(BorderType::QuadrantOutside)
             .render(buffer.area, &mut buffer);
         assert_buffer_eq!(
@@ -1483,8 +1462,7 @@ mod tests {
     #[test]
     fn render_solid_border() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .border_type(BorderType::Thick)
             .render(buffer.area, &mut buffer);
         assert_buffer_eq!(
@@ -1500,8 +1478,7 @@ mod tests {
     #[test]
     fn render_custom_border_set() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));
-        Block::default()
-            .borders(Borders::ALL)
+        Block::bordered()
             .border_set(border::Set {
                 top_left: "1",
                 top_right: "2",

--- a/src/widgets/canvas.rs
+++ b/src/widgets/canvas.rs
@@ -567,7 +567,7 @@ impl<'a> Context<'a> {
 /// };
 ///
 /// Canvas::default()
-///     .block(Block::default().title("Canvas").borders(Borders::ALL))
+///     .block(Block::bordered().title("Canvas"))
 ///     .x_bounds([-180.0, 180.0])
 ///     .y_bounds([-90.0, 90.0])
 ///     .paint(|ctx| {

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -8,7 +8,7 @@ use crate::{
     prelude::*,
     widgets::{
         canvas::{Canvas, Line as CanvasLine, Points},
-        Block, Borders,
+        Block,
     },
 };
 
@@ -1050,9 +1050,7 @@ impl WidgetRef for Chart<'_> {
 
         if let Some(legend_area) = layout.legend_area {
             buf.set_style(legend_area, original_style);
-            Block::default()
-                .borders(Borders::ALL)
-                .render(legend_area, buf);
+            Block::bordered().render(legend_area, buf);
 
             for (i, (dataset_name, dataset_style)) in self
                 .datasets

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -475,7 +475,7 @@ struct ChartLayout {
 ///
 /// // Create the chart and link all the parts together
 /// let chart = Chart::new(datasets)
-///     .block(Block::default().title("Chart"))
+///     .block(Block::new().title("Chart"))
 ///     .x_axis(x_axis)
 ///     .y_axis(y_axis);
 /// ```

--- a/src/widgets/clear.rs
+++ b/src/widgets/clear.rs
@@ -11,7 +11,7 @@ use crate::prelude::*;
 /// use ratatui::{prelude::*, widgets::*};
 ///
 /// fn draw_on_clear(f: &mut Frame, area: Rect) {
-///     let block = Block::default().title("Block").borders(Borders::ALL);
+///     let block = Block::bordered().title("Block");
 ///     f.render_widget(Clear, area); // <- this will clear/reset the area first
 ///     f.render_widget(block, area); // now render the block widget
 /// }

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -17,7 +17,7 @@ use crate::{prelude::*, widgets::Block};
 /// use ratatui::{prelude::*, widgets::*};
 ///
 /// Gauge::default()
-///     .block(Block::default().borders(Borders::ALL).title("Progress"))
+///     .block(Block::bordered().title("Progress"))
 ///     .gauge_style(
 ///         Style::default()
 ///             .fg(Color::White)
@@ -249,7 +249,7 @@ fn get_unicode_block<'a>(frac: f64) -> &'a str {
 /// use ratatui::{prelude::*, widgets::*};
 ///
 /// LineGauge::default()
-///     .block(Block::default().borders(Borders::ALL).title("Progress"))
+///     .block(Block::bordered().title("Progress"))
 ///     .gauge_style(
 ///         Style::default()
 ///             .fg(Color::White)

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -384,7 +384,7 @@ where
 /// # let area = Rect::default();
 /// let items = ["Item 1", "Item 2", "Item 3"];
 /// let list = List::new(items)
-///     .block(Block::default().title("List").borders(Borders::ALL))
+///     .block(Block::bordered().title("List"))
 ///     .style(Style::default().fg(Color::White))
 ///     .highlight_style(Style::default().add_modifier(Modifier::ITALIC))
 ///     .highlight_symbol(">>")
@@ -405,7 +405,7 @@ where
 /// let mut state = ListState::default();
 /// let items = ["Item 1", "Item 2", "Item 3"];
 /// let list = List::new(items)
-///     .block(Block::default().title("List").borders(Borders::ALL))
+///     .block(Block::bordered().title("List"))
 ///     .highlight_style(Style::new().add_modifier(Modifier::REVERSED))
 ///     .highlight_symbol(">>")
 ///     .repeat_highlight_symbol(true);
@@ -537,7 +537,7 @@ impl<'a> List<'a> {
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
     /// # let items = vec!["Item 1"];
-    /// let block = Block::default().title("List").borders(Borders::ALL);
+    /// let block = Block::bordered().title("List");
     /// let list = List::new(items).block(block);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -1049,7 +1049,7 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use super::*;
-    use crate::{assert_buffer_eq, widgets::Borders};
+    use crate::assert_buffer_eq;
 
     #[test]
     fn test_list_state_selected() {
@@ -1229,7 +1229,7 @@ mod tests {
 
         let list = List::new(items)
             .highlight_symbol(">>")
-            .block(Block::default().borders(Borders::all()));
+            .block(Block::bordered());
         // attempt to render into an area of the buffer with zero height after
         // setting the block borders
         Widget::render(list, Rect::new(0, 0, 15, 2), &mut buffer);
@@ -1474,7 +1474,7 @@ mod tests {
     #[test]
     fn test_list_with_empty_strings() {
         let items = list_items(vec!["Item 0", "", "", "Item 1", "Item 2"]);
-        let list = List::new(items).block(Block::default().title("List").borders(Borders::ALL));
+        let list = List::new(items).block(Block::bordered().title("List"));
         let buffer = render_widget(list, 10, 7);
 
         let expected = Buffer::with_lines(vec![
@@ -1499,7 +1499,7 @@ mod tests {
     #[test]
     fn test_list_block() {
         let items = list_items(vec!["Item 0", "Item 1", "Item 2"]);
-        let list = List::new(items).block(Block::default().title("List").borders(Borders::ALL));
+        let list = List::new(items).block(Block::bordered().title("List"));
         let buffer = render_widget(list, 10, 7);
 
         let expected = Buffer::with_lines(vec![

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -31,7 +31,7 @@ const fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Align
 ///     "Third line".into(),
 /// ];
 /// Paragraph::new(text)
-///     .block(Block::new().title("Paragraph").borders(Borders::ALL))
+///     .block(Block::bordered().title("Paragraph"))
 ///     .style(Style::new().white().on_black())
 ///     .alignment(Alignment::Center)
 ///     .wrap(Wrap { trim: true });
@@ -126,8 +126,7 @@ impl<'a> Paragraph<'a> {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
-    /// let paragraph = Paragraph::new("Hello, world!")
-    ///     .block(Block::default().title("Paragraph").borders(Borders::ALL));
+    /// let paragraph = Paragraph::new("Hello, world!").block(Block::bordered().title("Paragraph"));
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub fn block(mut self, block: Block<'a>) -> Self {
@@ -527,8 +526,7 @@ mod test {
         // We use the slightly unconventional "worlds" instead of "world" here to make sure when we
         // can truncate this without triggering the typos linter.
         let text = "Hello, worlds!";
-        let truncated_paragraph =
-            Paragraph::new(text).block(Block::default().title("Title").borders(Borders::ALL));
+        let truncated_paragraph = Paragraph::new(text).block(Block::bordered().title("Title"));
         let wrapped_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: false });
         let trimmed_paragraph = truncated_paragraph.clone().wrap(Wrap { trim: true });
 

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -625,10 +625,10 @@ mod test {
 
     #[test]
     fn test_render_paragraph_with_block_with_bottom_title_and_border() {
-        let block = Block::default()
-            .title("Title")
+        let block = Block::new()
+            .borders(Borders::BOTTOM)
             .title_position(Position::Bottom)
-            .borders(Borders::BOTTOM);
+            .title("Title");
         let paragraph = Paragraph::new("Hello, world!").block(block);
 
         test_case(

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -24,7 +24,7 @@ use crate::{prelude::*, widgets::Block};
 /// use ratatui::{prelude::*, widgets::*};
 ///
 /// Sparkline::default()
-///     .block(Block::default().title("Sparkline").borders(Borders::ALL))
+///     .block(Block::bordered().title("Sparkline"))
 ///     .data(&[0, 2, 3, 4, 1, 4, 10])
 ///     .max(5)
 ///     .direction(RenderDirection::RightToLeft)

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -75,7 +75,7 @@ use crate::{layout::Flex, prelude::*, widgets::Block};
 ///     // It has an optional footer, which is simply a Row always visible at the bottom.
 ///     .footer(Row::new(vec!["Updated on Dec 28"]))
 ///     // As any other widget, a Table can be wrapped in a Block.
-///     .block(Block::default().title("Table"))
+///     .block(Block::new().title("Table"))
 ///     // The selected row and its content can also be styled.
 ///     .highlight_style(Style::new().reversed())
 ///     // ...and potentially show a symbol in front of the selection.
@@ -178,7 +178,7 @@ use crate::{layout::Flex, prelude::*, widgets::Block};
 /// ];
 /// let widths = [Constraint::Length(5), Constraint::Length(5), Constraint::Length(10)];
 /// let table = Table::new(rows, widths)
-///     .block(Block::default().title("Table"))
+///     .block(Block::new().title("Table"))
 ///     .highlight_style(Style::new().add_modifier(Modifier::REVERSED))
 ///     .highlight_symbol(">>");
 ///

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -418,7 +418,7 @@ impl<'a> Table<'a> {
     /// # use ratatui::{prelude::*, widgets::*};
     /// # let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// # let widths = [Constraint::Length(5), Constraint::Length(5)];
-    /// let block = Block::default().title("Table").borders(Borders::ALL);
+    /// let block = Block::bordered().title("Table");
     /// let table = Table::new(rows, widths).block(block);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -842,7 +842,7 @@ mod tests {
     use std::vec;
 
     use super::*;
-    use crate::{layout::Constraint::*, style::Style, text::Line, widgets::Borders};
+    use crate::{layout::Constraint::*, style::Style, text::Line};
 
     #[test]
     fn new() {
@@ -930,7 +930,7 @@ mod tests {
 
     #[test]
     fn block() {
-        let block = Block::default().title("Table").borders(Borders::ALL);
+        let block = Block::bordered().title("Table");
         let table = Table::default().block(block.clone());
         assert_eq!(table.block, Some(block));
     }
@@ -1027,7 +1027,7 @@ mod tests {
                 Row::new(vec!["Cell1", "Cell2"]),
                 Row::new(vec!["Cell3", "Cell4"]),
             ];
-            let block = Block::new().borders(Borders::ALL).title("Block");
+            let block = Block::bordered().title("Block");
             let table = Table::new(rows, vec![Constraint::Length(5); 2]).block(block);
             Widget::render(table, Rect::new(0, 0, 15, 3), &mut buf);
             let expected = Buffer::with_lines(vec![

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -17,7 +17,7 @@ const DEFAULT_HIGHLIGHT_STYLE: Style = Style::new().add_modifier(Modifier::REVER
 /// use ratatui::{prelude::*, widgets::*};
 ///
 /// Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"])
-///     .block(Block::default().title("Tabs").borders(Borders::ALL))
+///     .block(Block::bordered().title("Tabs"))
 ///     .style(Style::default().white())
 ///     .highlight_style(Style::default().yellow())
 ///     .select(2)
@@ -333,7 +333,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{assert_buffer_eq, widgets::Borders};
+    use crate::assert_buffer_eq;
 
     #[test]
     fn new() {
@@ -414,8 +414,8 @@ mod tests {
 
     #[test]
     fn render_with_block() {
-        let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"])
-            .block(Block::default().title("Tabs").borders(Borders::ALL));
+        let tabs =
+            Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"]).block(Block::bordered().title("Tabs"));
         let mut expected = Buffer::with_lines(vec![
             "┌Tabs────────────────────────┐",
             "│ Tab1 │ Tab2 │ Tab3 │ Tab4  │",

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -62,7 +62,7 @@ fn assert_buffer(state: &mut AppState, expected: &Buffer) {
                 .split(f.size());
             let list = List::new(items)
                 .highlight_symbol(">>")
-                .block(Block::default().borders(Borders::RIGHT));
+                .block(Block::new().borders(Borders::RIGHT));
             f.render_stateful_widget(list, layout[0], &mut state.list);
 
             let table = Table::new(

--- a/tests/stylize.rs
+++ b/tests/stylize.rs
@@ -5,7 +5,7 @@ use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Style, Stylize},
-    widgets::{BarChart, Block, Borders, Paragraph},
+    widgets::{BarChart, Block, Paragraph},
     Terminal,
 };
 
@@ -61,11 +61,10 @@ fn barchart_can_be_stylized() {
 
 #[test]
 fn block_can_be_stylized() -> io::Result<()> {
-    let block = Block::default()
+    let block = Block::bordered()
         .title("Title".light_blue())
         .on_cyan()
-        .cyan()
-        .borders(Borders::ALL);
+        .cyan();
 
     let area = Rect::new(0, 0, 8, 3);
     let mut terminal = Terminal::new(TestBackend::new(11, 4))?;

--- a/tests/widgets_barchart.rs
+++ b/tests/widgets_barchart.rs
@@ -2,7 +2,7 @@ use ratatui::{
     backend::TestBackend,
     buffer::Buffer,
     style::{Color, Style},
-    widgets::{Bar, BarChart, BarGroup, Block, Borders},
+    widgets::{Bar, BarChart, BarGroup, Block},
     Terminal,
 };
 
@@ -16,7 +16,7 @@ fn widgets_barchart_not_full_below_max_value() {
             .draw(|f| {
                 let size = f.size();
                 let barchart = BarChart::default()
-                    .block(Block::default().borders(Borders::ALL))
+                    .block(Block::bordered())
                     .data(&[("empty", 0), ("half", 50), ("almost", 99), ("full", 100)])
                     .max(100)
                     .bar_width(7)
@@ -53,7 +53,7 @@ fn widgets_barchart_group() {
             .draw(|f| {
                 let size = f.size();
                 let barchart = BarChart::default()
-                    .block(Block::default().borders(Borders::ALL))
+                    .block(Block::bordered())
                     .data(
                         BarGroup::default().label("Mar".into()).bars(&[
                             Bar::default()

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -53,7 +53,7 @@ fn widgets_block_titles_overlap() {
 
     // Left overrides the center
     test_case(
-        Block::default()
+        Block::new()
             .title(Title::from("aaaaa").alignment(Alignment::Left))
             .title(Title::from("bbb").alignment(Alignment::Center))
             .title(Title::from("ccc").alignment(Alignment::Right)),
@@ -63,7 +63,7 @@ fn widgets_block_titles_overlap() {
 
     // Left alignment overrides the center alignment which overrides the right alignment
     test_case(
-        Block::default()
+        Block::new()
             .title(Title::from("aaaaa").alignment(Alignment::Left))
             .title(Title::from("bbbbb").alignment(Alignment::Center))
             .title(Title::from("ccccc").alignment(Alignment::Right)),
@@ -73,7 +73,7 @@ fn widgets_block_titles_overlap() {
 
     // Multiple left alignment overrides the center alignment and the right alignment
     test_case(
-        Block::default()
+        Block::new()
             .title(Title::from("aaaaa").alignment(Alignment::Left))
             .title(Title::from("aaaaa").alignment(Alignment::Left))
             .title(Title::from("bbbbb").alignment(Alignment::Center))
@@ -84,7 +84,7 @@ fn widgets_block_titles_overlap() {
 
     // The right alignment doesn't override the center alignment, but pierces through it
     test_case(
-        Block::default()
+        Block::new()
             .title(Title::from("bbbbb").alignment(Alignment::Center))
             .title(Title::from("ccccccccccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 11, 1),
@@ -115,69 +115,69 @@ fn widgets_block_renders_on_small_areas() {
     ];
     for (borders, symbol) in one_cell_test_cases {
         test_case(
-            Block::default().title("Test").borders(borders),
+            Block::new().borders(borders).title("Test"),
             Rect::new(0, 0, 0, 0),
             Buffer::empty(Rect::new(0, 0, 0, 0)),
         );
         test_case(
-            Block::default().title("Test").borders(borders),
+            Block::new().borders(borders).title("Test"),
             Rect::new(0, 0, 1, 0),
             Buffer::empty(Rect::new(0, 0, 1, 0)),
         );
         test_case(
-            Block::default().title("Test").borders(borders),
+            Block::new().borders(borders).title("Test"),
             Rect::new(0, 0, 0, 1),
             Buffer::empty(Rect::new(0, 0, 0, 1)),
         );
         test_case(
-            Block::default().title("Test").borders(borders),
+            Block::new().borders(borders).title("Test"),
             Rect::new(0, 0, 1, 1),
             Buffer::with_lines(vec![symbol]),
         );
     }
     test_case(
-        Block::default().title("Test").borders(Borders::LEFT),
+        Block::new().borders(Borders::LEFT).title("Test"),
         Rect::new(0, 0, 4, 1),
         Buffer::with_lines(vec!["│Tes"]),
     );
     test_case(
-        Block::default().title("Test").borders(Borders::RIGHT),
+        Block::new().borders(Borders::RIGHT).title("Test"),
         Rect::new(0, 0, 4, 1),
         Buffer::with_lines(vec!["Tes│"]),
     );
     test_case(
-        Block::default().title("Test").borders(Borders::RIGHT),
+        Block::new().borders(Borders::RIGHT).title("Test"),
         Rect::new(0, 0, 4, 1),
         Buffer::with_lines(vec!["Tes│"]),
     );
     test_case(
-        Block::default()
-            .title("Test")
-            .borders(Borders::LEFT | Borders::RIGHT),
+        Block::new()
+            .borders(Borders::LEFT | Borders::RIGHT)
+            .title("Test"),
         Rect::new(0, 0, 4, 1),
         Buffer::with_lines(vec!["│Te│"]),
     );
     test_case(
-        Block::default().title("Test").borders(Borders::TOP),
+        Block::new().borders(Borders::TOP).title("Test"),
         Rect::new(0, 0, 4, 1),
         Buffer::with_lines(vec!["Test"]),
     );
     test_case(
-        Block::default().title("Test").borders(Borders::TOP),
+        Block::new().borders(Borders::TOP).title("Test"),
         Rect::new(0, 0, 5, 1),
         Buffer::with_lines(vec!["Test─"]),
     );
     test_case(
-        Block::default()
-            .title("Test")
-            .borders(Borders::LEFT | Borders::TOP),
+        Block::new()
+            .borders(Borders::LEFT | Borders::TOP)
+            .title("Test"),
         Rect::new(0, 0, 5, 1),
         Buffer::with_lines(vec!["┌Test"]),
     );
     test_case(
-        Block::default()
-            .title("Test")
-            .borders(Borders::LEFT | Borders::TOP),
+        Block::new()
+            .borders(Borders::LEFT | Borders::TOP)
+            .title("Test"),
         Rect::new(0, 0, 6, 1),
         Buffer::with_lines(vec!["┌Test─"]),
     );
@@ -192,14 +192,14 @@ fn widgets_block_title_alignment() {
         let backend = TestBackend::new(15, 3);
         let mut terminal = Terminal::new(backend).unwrap();
 
-        let block1 = Block::default()
-            .title(Title::from(Span::styled("Title", Style::default())).alignment(alignment))
-            .borders(borders);
+        let block1 = Block::new()
+            .borders(borders)
+            .title(Title::from(Span::styled("Title", Style::default())).alignment(alignment));
 
-        let block2 = Block::default()
-            .title("Title")
+        let block2 = Block::new()
+            .borders(borders)
             .title_alignment(alignment)
-            .borders(borders);
+            .title("Title");
 
         let area = Rect::new(1, 0, 13, 3);
 
@@ -389,7 +389,7 @@ fn widgets_block_title_alignment_bottom() {
         let title = Title::from(Span::styled("Title", Style::default()))
             .alignment(alignment)
             .position(Position::Bottom);
-        let block = Block::default().title(title).borders(borders);
+        let block = Block::new().borders(borders).title(title);
         let area = Rect::new(1, 0, 13, 3);
         terminal
             .draw(|frame| frame.render_widget(block, area))
@@ -572,10 +572,7 @@ fn widgets_block_multiple_titles() {
         let backend = TestBackend::new(15, 3);
         let mut terminal = Terminal::new(backend).unwrap();
 
-        let block = Block::default()
-            .title(title_a)
-            .title(title_b)
-            .borders(borders);
+        let block = Block::new().borders(borders).title(title_a).title(title_b);
 
         let area = Rect::new(1, 0, 13, 3);
 

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -15,9 +15,8 @@ use ratatui::{
 fn widgets_block_renders() {
     let backend = TestBackend::new(10, 10);
     let mut terminal = Terminal::new(backend).unwrap();
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default().fg(Color::LightBlue)))
-        .borders(Borders::ALL);
+    let block =
+        Block::bordered().title(Span::styled("Title", Style::default().fg(Color::LightBlue)));
     terminal
         .draw(|frame| frame.render_widget(block, Rect::new(0, 0, 8, 8)))
         .unwrap();

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -5,7 +5,7 @@ use ratatui::{
     style::{Color, Style},
     symbols,
     text::{self, Span},
-    widgets::{Axis, Block, Borders, Chart, Dataset, GraphType::Line},
+    widgets::{Axis, Block, Chart, Dataset, GraphType::Line},
     Terminal,
 };
 use rstest::rstest;
@@ -46,7 +46,7 @@ fn widgets_chart_can_render_on_small_areas(#[case] width: u16, #[case] height: u
                 .style(Style::default().fg(Color::Magenta))
                 .data(&[(0.0, 0.0)])];
             let chart = Chart::new(datasets)
-                .block(Block::default().title("Plot").borders(Borders::ALL))
+                .block(Block::bordered().title("Plot"))
                 .x_axis(
                     Axis::default()
                         .bounds([0.0, 0.0])
@@ -265,7 +265,7 @@ fn widgets_chart_can_have_axis_with_zero_length_bounds() {
                 .style(Style::default().fg(Color::Magenta))
                 .data(&[(0.0, 0.0)])];
             let chart = Chart::new(datasets)
-                .block(Block::default().title("Plot").borders(Borders::ALL))
+                .block(Block::bordered().title("Plot"))
                 .x_axis(
                     Axis::default()
                         .bounds([0.0, 0.0])
@@ -305,7 +305,7 @@ fn widgets_chart_handles_overflows() {
                     (1_588_298_496.0, 1.0),
                 ])];
             let chart = Chart::new(datasets)
-                .block(Block::default().title("Plot").borders(Borders::ALL))
+                .block(Block::bordered().title("Plot"))
                 .x_axis(
                     Axis::default()
                         .bounds([1_588_298_471.0, 1_588_992_600.0])
@@ -338,11 +338,7 @@ fn widgets_chart_can_have_empty_datasets() {
         .draw(|f| {
             let datasets = vec![Dataset::default().data(&[]).graph_type(Line)];
             let chart = Chart::new(datasets)
-                .block(
-                    Block::default()
-                        .title("Empty Dataset With Line")
-                        .borders(Borders::ALL),
-                )
+                .block(Block::bordered().title("Empty Dataset With Line"))
                 .x_axis(
                     Axis::default()
                         .bounds([0.0, 0.0])
@@ -411,7 +407,7 @@ fn widgets_chart_can_have_a_legend() {
             ];
             let chart = Chart::new(datasets)
                 .style(Style::default().bg(Color::White))
-                .block(Block::default().title("Chart Test").borders(Borders::ALL))
+                .block(Block::bordered().title("Chart Test"))
                 .x_axis(
                     Axis::default()
                         .bounds([0.0, 100.0])

--- a/tests/widgets_gauge.rs
+++ b/tests/widgets_gauge.rs
@@ -5,7 +5,7 @@ use ratatui::{
     style::{Color, Modifier, Style, Stylize},
     symbols,
     text::Span,
-    widgets::{Block, Borders, Gauge, LineGauge},
+    widgets::{Block, Gauge, LineGauge},
     Terminal,
 };
 
@@ -22,13 +22,13 @@ fn widgets_gauge_renders() {
                 .split(f.size());
 
             let gauge = Gauge::default()
-                .block(Block::default().title("Percentage").borders(Borders::ALL))
+                .block(Block::bordered().title("Percentage"))
                 .gauge_style(Style::default().bg(Color::Blue).fg(Color::Red))
                 .use_unicode(true)
                 .percent(43);
             f.render_widget(gauge, chunks[0]);
             let gauge = Gauge::default()
-                .block(Block::default().title("Ratio").borders(Borders::ALL))
+                .block(Block::bordered().title("Ratio"))
                 .gauge_style(Style::default().bg(Color::Blue).fg(Color::Red))
                 .use_unicode(true)
                 .ratio(0.511_313_934_313_1);
@@ -71,12 +71,12 @@ fn widgets_gauge_renders_no_unicode() {
                 .split(f.size());
 
             let gauge = Gauge::default()
-                .block(Block::default().title("Percentage").borders(Borders::ALL))
+                .block(Block::bordered().title("Percentage"))
                 .percent(43)
                 .use_unicode(false);
             f.render_widget(gauge, chunks[0]);
             let gauge = Gauge::default()
-                .block(Block::default().title("Ratio").borders(Borders::ALL))
+                .block(Block::bordered().title("Ratio"))
                 .ratio(0.211_313_934_313_1)
                 .use_unicode(false);
             f.render_widget(gauge, chunks[1]);
@@ -106,9 +106,7 @@ fn widgets_gauge_applies_styles() {
         .draw(|f| {
             let gauge = Gauge::default()
                 .block(
-                    Block::default()
-                        .title(Span::styled("Test", Style::default().fg(Color::Red)))
-                        .borders(Borders::ALL),
+                    Block::bordered().title(Span::styled("Test", Style::default().fg(Color::Red))),
                 )
                 .gauge_style(Style::default().fg(Color::Blue).bg(Color::Red))
                 .percent(43)
@@ -196,7 +194,7 @@ fn widgets_line_gauge_renders() {
                 },
             );
             let gauge = LineGauge::default()
-                .block(Block::default().title("Gauge 2").borders(Borders::ALL))
+                .block(Block::bordered().title("Gauge 2"))
                 .gauge_style(Style::default().fg(Color::Green))
                 .line_set(symbols::line::THICK)
                 .ratio(0.211_313_934_313_1);

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -127,7 +127,7 @@ fn widgets_list_should_truncate_items() {
         terminal
             .draw(|f| {
                 let list = List::new(case.items.clone())
-                    .block(Block::default().borders(Borders::RIGHT))
+                    .block(Block::new().borders(Borders::RIGHT))
                     .highlight_symbol(">> ");
                 f.render_stateful_widget(list, Rect::new(0, 0, 8, 2), &mut state);
             })

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -288,7 +288,7 @@ fn widgets_list_enable_always_highlight_spacing() {
                     ListItem::new(vec![Line::from("Item 2"), Line::from("Item 2b")]),
                     ListItem::new(vec![Line::from("Item 3"), Line::from("Item 3c")]),
                 ])
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::bordered())
                 .highlight_symbol(">> ")
                 .highlight_spacing(space);
                 f.render_stateful_widget(table, size, state);

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -3,7 +3,7 @@ use ratatui::{
     buffer::Buffer,
     layout::Alignment,
     text::{Line, Span, Text},
-    widgets::{Block, Borders, Padding, Paragraph, Wrap},
+    widgets::{Block, Padding, Paragraph, Wrap},
     Terminal,
 };
 
@@ -30,7 +30,7 @@ fn widgets_paragraph_renders_double_width_graphemes() {
 
     let text = vec![Line::from(s)];
     let paragraph = Paragraph::new(text)
-        .block(Block::default().borders(Borders::ALL))
+        .block(Block::bordered())
         .wrap(Wrap { trim: true });
 
     test_case(
@@ -61,7 +61,7 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
             let size = f.size();
             let text = vec![Line::from(s)];
             let paragraph = Paragraph::new(text)
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::bordered())
                 .wrap(Wrap { trim: true });
             f.render_widget(paragraph, size);
         })
@@ -84,7 +84,7 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
 fn widgets_paragraph_can_wrap_with_a_trailing_nbsp() {
     let nbsp = "\u{00a0}";
     let line = Line::from(vec![Span::raw("NBSP"), Span::raw(nbsp)]);
-    let paragraph = Paragraph::new(line).block(Block::default().borders(Borders::ALL));
+    let paragraph = Paragraph::new(line).block(Block::bordered());
 
     test_case(
         paragraph,
@@ -100,7 +100,7 @@ fn widgets_paragraph_can_wrap_with_a_trailing_nbsp() {
 fn widgets_paragraph_can_scroll_horizontally() {
     let text =
         Text::from("段落现在可以水平滚动了！\nParagraph can scroll horizontally!\nLittle line");
-    let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::ALL));
+    let paragraph = Paragraph::new(text).block(Block::bordered());
 
     test_case(
         paragraph.clone().alignment(Alignment::Left).scroll((0, 7)),
@@ -144,7 +144,7 @@ const SAMPLE_STRING: &str = "The library is based on the principle of immediate 
 fn widgets_paragraph_can_wrap_its_content() {
     let text = vec![Line::from(SAMPLE_STRING)];
     let paragraph = Paragraph::new(text)
-        .block(Block::default().borders(Borders::ALL))
+        .block(Block::bordered())
         .wrap(Wrap { trim: true });
 
     test_case(
@@ -196,14 +196,14 @@ fn widgets_paragraph_can_wrap_its_content() {
 
 #[test]
 fn widgets_paragraph_works_with_padding() {
-    let text = vec![Line::from(SAMPLE_STRING)];
-    let paragraph = Paragraph::new(text)
-        .block(Block::default().borders(Borders::ALL).padding(Padding {
-            left: 2,
-            right: 2,
-            top: 1,
-            bottom: 1,
-        }))
+    let block = Block::bordered().padding(Padding {
+        left: 2,
+        right: 2,
+        top: 1,
+        bottom: 1,
+    });
+    let paragraph = Paragraph::new(vec![Line::from(SAMPLE_STRING)])
+        .block(block.clone())
         .wrap(Wrap { trim: true });
 
     test_case(
@@ -224,7 +224,7 @@ fn widgets_paragraph_works_with_padding() {
         ]),
     );
     test_case(
-        paragraph.clone().alignment(Alignment::Right),
+        paragraph.alignment(Alignment::Right),
         Buffer::with_lines(vec![
             "┌────────────────────┐",
             "│                    │",
@@ -241,16 +241,12 @@ fn widgets_paragraph_works_with_padding() {
         ]),
     );
 
-    let mut text = vec![Line::from("This is always centered.").alignment(Alignment::Center)];
-    text.push(Line::from(SAMPLE_STRING));
-    let paragraph = Paragraph::new(text)
-        .block(Block::default().borders(Borders::ALL).padding(Padding {
-            left: 2,
-            right: 2,
-            top: 1,
-            bottom: 1,
-        }))
-        .wrap(Wrap { trim: true });
+    let paragraph = Paragraph::new(vec![
+        Line::from("This is always centered.").alignment(Alignment::Center),
+        Line::from(SAMPLE_STRING),
+    ])
+    .block(block)
+    .wrap(Wrap { trim: true });
 
     test_case(
         paragraph.alignment(Alignment::Right),
@@ -283,7 +279,7 @@ fn widgets_paragraph_can_align_spans() {
         Line::from(default_s),
     ];
     let paragraph = Paragraph::new(text)
-        .block(Block::default().borders(Borders::ALL))
+        .block(Block::bordered())
         .wrap(Wrap { trim: true });
 
     test_case(
@@ -333,7 +329,7 @@ fn widgets_paragraph_can_align_spans() {
 
     let mut text = left_lines.clone();
     text.append(&mut lines);
-    let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::ALL));
+    let paragraph = Paragraph::new(text).block(Block::bordered());
 
     test_case(
         paragraph.clone().alignment(Alignment::Right),

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -796,7 +796,7 @@ fn widgets_table_can_have_elements_styled_individually() {
                 ],
             )
             .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
+            .block(Block::new().borders(Borders::LEFT | Borders::RIGHT))
             .highlight_symbol(">> ")
             .highlight_style(Style::default().add_modifier(Modifier::BOLD))
             .column_spacing(1);
@@ -861,7 +861,7 @@ fn widgets_table_should_render_even_if_empty() {
                 ],
             )
             .header(Row::new(vec!["Head1", "Head2", "Head3"]))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
+            .block(Block::new().borders(Borders::LEFT | Borders::RIGHT))
             .column_spacing(1);
             f.render_widget(table, size);
         })

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -33,7 +33,7 @@ fn widgets_table_column_spacing_can_be_changed() {
                     ],
                 )
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::bordered())
                 .column_spacing(column_spacing);
                 f.render_widget(table, size);
             })
@@ -129,7 +129,7 @@ fn widgets_table_columns_widths_can_use_fixed_length_constraints() {
                     widths,
                 )
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::default().borders(Borders::ALL));
+                .block(Block::bordered());
                 f.render_widget(table, size);
             })
             .unwrap();
@@ -221,7 +221,7 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
                     widths,
                 )
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::bordered())
                 .column_spacing(0);
                 f.render_widget(table, size);
             })
@@ -331,7 +331,7 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
                     widths,
                 )
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::default().borders(Borders::ALL));
+                .block(Block::bordered());
                 f.render_widget(table, size);
             })
             .unwrap();
@@ -444,7 +444,7 @@ fn widgets_table_columns_widths_can_use_ratio_constraints() {
                     widths,
                 )
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::bordered())
                 .column_spacing(0);
                 f.render_widget(table, size);
             })
@@ -555,7 +555,7 @@ fn widgets_table_can_have_rows_with_multi_lines() {
                     ],
                 )
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::bordered())
                 .highlight_symbol(">> ")
                 .column_spacing(1);
                 f.render_stateful_widget(table, size, state);
@@ -652,7 +652,7 @@ fn widgets_table_enable_always_highlight_spacing() {
                     ],
                 )
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-                .block(Block::default().borders(Borders::ALL))
+                .block(Block::bordered())
                 .highlight_symbol(">> ")
                 .highlight_spacing(space)
                 .column_spacing(1);
@@ -902,7 +902,7 @@ fn widgets_table_columns_dont_panic() {
         ],
     )
     .header(Row::new(vec!["h1", "h2", "h3", "h4"]))
-    .block(Block::default().borders(Borders::ALL))
+    .block(Block::bordered())
     .highlight_symbol(">> ")
     .column_spacing(1);
 
@@ -940,7 +940,7 @@ fn widgets_table_should_clamp_offset_if_rows_are_removed() {
                 ],
             )
             .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-            .block(Block::default().borders(Borders::ALL))
+            .block(Block::bordered())
             .column_spacing(1);
             f.render_stateful_widget(table, size, &mut state);
         })
@@ -971,7 +971,7 @@ fn widgets_table_should_clamp_offset_if_rows_are_removed() {
                 ],
             )
             .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
-            .block(Block::default().borders(Borders::ALL))
+            .block(Block::bordered())
             .column_spacing(1);
             f.render_stateful_widget(table, size, &mut state);
         })


### PR DESCRIPTION
`Block::bordered()` is shorter than `Block::new().borders(Borders::ALL)`, requires one less import (`Borders`) and in case `Block::default()` was used before can even be `const`.

This mostly changes examples, documentation, and tests.
As I used a lot of regular expressions I could have overlooked something when checking all the changes myself. Another set of eyes might find something I missed.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
