### PR TITLE
feat(buffer): track_caller for index_of

### DIFF
--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -97,12 +97,14 @@ impl Buffer {
     }
 
     /// Returns a reference to Cell at the given coordinates
+    #[track_caller]
     pub fn get(&self, x: u16, y: u16) -> &Cell {
         let i = self.index_of(x, y);
         &self.content[i]
     }
 
     /// Returns a mutable reference to Cell at the given coordinates
+    #[track_caller]
     pub fn get_mut(&mut self, x: u16, y: u16) -> &mut Cell {
         let i = self.index_of(x, y);
         &mut self.content[i]
@@ -134,6 +136,7 @@ impl Buffer {
     /// // starts at (200, 100).
     /// buffer.index_of(0, 0); // Panics
     /// ```
+    #[track_caller]
     pub fn index_of(&self, x: u16, y: u16) -> usize {
         debug_assert!(
             x >= self.area.left()


### PR DESCRIPTION
The caller put in the wrong x/y -> the caller is the cause.

In the future get and get_mut should return Option but thats a bigger change.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
