### PR TITLE
feat(rect): intersect_opt

### DIFF
--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -338,10 +338,11 @@ impl App {
         }
 
         if scrollbar_needed {
-            let area = area.intersection(buf.area);
-            let mut state = ScrollbarState::new(max_scroll_offset() as usize)
-                .position(self.scroll_offset as usize);
-            Scrollbar::new(ScrollbarOrientation::VerticalRight).render(area, buf, &mut state);
+            if let Some(area) = area.intersection_opt(buf.area) {
+                let mut state = ScrollbarState::new(max_scroll_offset() as usize)
+                    .position(self.scroll_offset as usize);
+                Scrollbar::new(ScrollbarOrientation::VerticalRight).render(area, buf, &mut state);
+            }
         }
         scrollbar_needed
     }

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -273,7 +273,9 @@ impl Buffer {
     /// your own type that implements [`Into<Style>`]).
     pub fn set_style<S: Into<Style>>(&mut self, area: Rect, style: S) {
         let style = style.into();
-        let area = self.area.intersection(area);
+        let Some(area) = self.area.intersection_opt(area) else {
+            return;
+        };
         for y in area.top()..area.bottom() {
             for x in area.left()..area.right() {
                 self.get_mut(x, y).set_style(style);

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -584,7 +584,9 @@ impl Widget for Line<'_> {
 
 impl WidgetRef for Line<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
-        let area = area.intersection(buf.area);
+        let Some(area) = area.intersection_opt(buf.area) else {
+            return;
+        };
         buf.set_style(area, self.style);
         let width = self.width() as u16;
         let mut x = area.left();

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -601,7 +601,9 @@ impl Widget for Text<'_> {
 
 impl WidgetRef for Text<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
-        let area = area.intersection(buf.area);
+        let Some(area) = area.intersection_opt(buf.area) else {
+            return;
+        };
         buf.set_style(area, self.style);
         for (line, row) in self.iter().zip(area.rows()) {
             let line_width = line.width() as u16;

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -596,10 +596,9 @@ impl Widget for Block<'_> {
 
 impl WidgetRef for Block<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
-        let area = area.intersection(buf.area);
-        if area.is_empty() {
+        let Some(area) = area.intersection_opt(buf.area) else {
             return;
-        }
+        };
         buf.set_style(area, self.style);
         self.render_borders(area, buf);
         self.render_titles(area, buf);
@@ -824,7 +823,7 @@ impl Block<'_> {
             x: area.left() + left_border,
             y: match position {
                 Position::Top => area.top(),
-                Position::Bottom => area.bottom() - 1,
+                Position::Bottom => area.bottom().saturating_sub(1),
             },
             width: area
                 .width


### PR DESCRIPTION
While trying to figure out #1001 I tried to understand why `max_x` is calculated so overcomplicated.

https://github.com/ratatui-org/ratatui/blob/bef5bcf750375a78b11ae06f217091b2463e842f/src/text/span.rs#L366-L373

`max_x` should be `intersected.right()`. No other logic required. `assert_eq!()` noticed differences which surprised me. Then I found out: intersect returns an empty area but the offset stays. This means in these cases `right()` is the offset at some wonky position without an area.
The simple solution to this is to not render anything when `intersected.is_empty()`. In some places of the `intersect()` usage this was done, in some it was not. This means it's a bug introduced by mistake (#997 in this case). Just fixing this would introduce this bug again at some point in the future.

The better way is to return whether there is an actual intersection. When there is no intersection its unlikely someone wants to use this `Rect`. So return `None` instead.
The user of `intersect()` then has to actively think about what to do with this case. In case of rendering to an area: abort the render early. No space to render into anyway. So this might also be a performance gain.

While having this implemented wrong I had a bunch of failing tests which sparked #1046 and the `saturating_sub` in `Block`.

The name of the new method is inspired by `chrono` which moves to `_opt` methods as the existing ones can panic. (Maybe `Buffer::index_of` should also introduce `Buffer::index_of_opt`, same for `Buffer::get(_mut)`)