### PR TITLE
build: add clippy::cargo lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,9 @@ serde_json = "1.0.109"
 
 [lints.rust]
 unsafe_code = "forbid"
+
 [lints.clippy]
+cargo = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+# https://rust-lang.github.io/rust-clippy/master/index.html#/multiple_crate_versions
+# ratatui -> bitflags v2.3
+# termwiz -> wezterm-blob-leases -> mac_address -> nix -> bitflags v1.3.2
+allowed-duplicate-crates = ["bitflags"]


### PR DESCRIPTION
Followup to https://github.com/ratatui-org/ratatui/pull/1035 and
https://github.com/ratatui-org/ratatui/discussions/1034

It's reasonable to enable this and deal with breakage by fixing any
specific issues that arise.
