### PR TITLE
fix(line): panic in truncated due to byte index not being a char boundary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ strum = { version = "0.26", features = ["derive"] }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-width = "0.1"
+unicode-truncate = "1.0.0"
 document-features = { version = "0.2.7", optional = true }
 lru = "0.12.0"
 stability = "0.2.0"

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -453,7 +453,7 @@ impl<'a> Line<'a> {
         self.spans.iter_mut()
     }
 
-    /// Returns a line that's truncated corresponding to it's alignment and result width
+    /// Returns a line that's truncated corresponding to its alignment and result width
     #[must_use = "method returns the modified value"]
     fn truncated(&'a self, result_width: u16) -> Self {
         let mut truncated_line = Line::default();

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -925,6 +925,39 @@ mod tests {
         );
     }
 
+   #[test]
+    fn truncate_utf8_even_right() {
+        let line = Line::from("██████░░░░".to_string());
+        assert_eq!(
+            line.right_aligned().truncated(4).to_string(),
+            String::from("░░░░")
+        );
+    }
+    #[test]
+    fn truncate_utf8_odd_right() {
+        let line = Line::from("██████░░░░".to_string());
+        assert_eq!(
+            line.right_aligned().truncated(5).to_string(),
+            String::from("█░░░░")
+        );
+    }
+    #[test]
+    fn truncate_utf8_even_left() {
+        let line = Line::from("░░░░██████".to_string());
+        assert_eq!(
+            line.left_aligned().truncated(4).to_string(),
+            String::from("░░░░")
+        );
+    }
+    #[test]
+    fn truncate_utf8_odd_left() {
+        let line = Line::from("░░░░██████".to_string());
+        assert_eq!(
+            line.left_aligned().truncated(5).to_string(),
+            String::from("░░░░█")
+        );
+    }
+    
     #[test]
     fn truncation_ignores_useless_spans() {
         let line = Line::default().spans(vec!["foo", "bar"]);

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -474,12 +474,11 @@ impl<'a> Line<'a> {
             let new_span_width = span_width - offset;
             if x + new_span_width > result_width {
                 let span_end = (result_width - x + offset) as usize;
-                new_span.content = Cow::from(&span.content[offset as usize..span_end]);
+                new_span.content = Cow::from( span.content.as_ref().chars().skip(offset.into()).take(span_end - (offset as usize)).collect::<String>());
                 truncated_line.spans.push(new_span);
                 break;
             }
-
-            new_span.content = Cow::from(&span.content[offset as usize..]);
+            new_span.content = Cow::from( span.content.as_ref().chars().skip(offset.into()).collect::<String>());
             truncated_line.spans.push(new_span);
             x += new_span_width;
             offset = 0;

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -946,7 +946,7 @@ mod tests {
             String::from("░░░░")
         );
     }
-    
+
     #[test]
     fn truncate_utf8_odd_right() {
         let line = Line::from("██████░░░░".to_string());
@@ -955,7 +955,7 @@ mod tests {
             String::from("█░░░░")
         );
     }
-    
+
     #[test]
     fn truncate_utf8_even_left() {
         let line = Line::from("░░░░██████".to_string());
@@ -964,7 +964,7 @@ mod tests {
             String::from("░░░░")
         );
     }
-    
+
     #[test]
     fn truncate_utf8_odd_left() {
         let line = Line::from("░░░░██████".to_string());
@@ -973,7 +973,7 @@ mod tests {
             String::from("░░░░█")
         );
     }
-    
+
     #[test]
     fn truncation_ignores_useless_spans() {
         let line = Line::default().spans(vec!["foo", "bar"]);

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -897,6 +897,7 @@ mod tests {
 
         assert_eq!(format!("{line_from_styled_span}"), "Hello, world!");
     }
+
     #[test]
     fn render_truncates_left() {
         let mut buf = Buffer::empty(Rect::new(0, 0, 5, 1));

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -938,7 +938,7 @@ mod tests {
         );
     }
 
-   #[test]
+    #[test]
     fn truncate_utf8_even_right() {
         let line = Line::from("██████░░░░".to_string());
         assert_eq!(
@@ -946,6 +946,7 @@ mod tests {
             String::from("░░░░")
         );
     }
+    
     #[test]
     fn truncate_utf8_odd_right() {
         let line = Line::from("██████░░░░".to_string());
@@ -954,6 +955,7 @@ mod tests {
             String::from("█░░░░")
         );
     }
+    
     #[test]
     fn truncate_utf8_even_left() {
         let line = Line::from("░░░░██████".to_string());
@@ -962,6 +964,7 @@ mod tests {
             String::from("░░░░")
         );
     }
+    
     #[test]
     fn truncate_utf8_odd_left() {
         let line = Line::from("░░░░██████".to_string());

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -477,8 +477,8 @@ impl<'a> Line<'a> {
                 new_span.content = Cow::from(
                     span.content
                         .chars()
-                        .skip(offset.into())
-                        .take(span_end - (offset as usize))
+                        .skip(usize::from(offset))
+                        .take(span_end - usize::from(offset))
                         .collect::<String>(),
                 );
                 truncated_line.spans.push(new_span);

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 use std::borrow::Cow;
+use unicode_truncate::UnicodeTruncateStr;
 
 use super::StyledGrapheme;
 use crate::prelude::*;
@@ -474,22 +475,15 @@ impl<'a> Line<'a> {
             let new_span_width = span_width - offset;
             if x + new_span_width > result_width {
                 let span_end = (result_width - x + offset) as usize;
-                new_span.content = Cow::from(
-                    span.content
-                        .chars()
-                        .skip(usize::from(offset))
-                        .take(span_end - usize::from(offset))
-                        .collect::<String>(),
+                let (str_cut_start, _len) = span.content.unicode_truncate_start(usize::from(new_span_width));
+                let (str_cut_final, _len) = str_cut_start.unicode_truncate(span_end - usize::from(offset));
+                new_span.content = Cow::from(str_cut_final
                 );
                 truncated_line.spans.push(new_span);
                 break;
             }
-            new_span.content = Cow::from(
-                span.content
-                    .chars()
-                    .skip(usize::from(offset))
-                    .collect::<String>(),
-            );
+            let (new_content, _len) = span.content.unicode_truncate_start(usize::from(new_span_width));
+            new_span.content = Cow::from(new_content);
             truncated_line.spans.push(new_span);
             x += new_span_width;
             offset = 0;

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -486,7 +486,6 @@ impl<'a> Line<'a> {
             }
             new_span.content = Cow::from(
                 span.content
-                    .as_ref()
                     .chars()
                     .skip(usize::from(offset))
                     .collect::<String>(),

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -476,7 +476,6 @@ impl<'a> Line<'a> {
                 let span_end = (result_width - x + offset) as usize;
                 new_span.content = Cow::from(
                     span.content
-                        .as_ref()
                         .chars()
                         .skip(offset.into())
                         .take(span_end - (offset as usize))

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -474,11 +474,24 @@ impl<'a> Line<'a> {
             let new_span_width = span_width - offset;
             if x + new_span_width > result_width {
                 let span_end = (result_width - x + offset) as usize;
-                new_span.content = Cow::from( span.content.as_ref().chars().skip(offset.into()).take(span_end - (offset as usize)).collect::<String>());
+                new_span.content = Cow::from(
+                    span.content
+                        .as_ref()
+                        .chars()
+                        .skip(offset.into())
+                        .take(span_end - (offset as usize))
+                        .collect::<String>(),
+                );
                 truncated_line.spans.push(new_span);
                 break;
             }
-            new_span.content = Cow::from( span.content.as_ref().chars().skip(offset.into()).collect::<String>());
+            new_span.content = Cow::from(
+                span.content
+                    .as_ref()
+                    .chars()
+                    .skip(offset.into())
+                    .collect::<String>(),
+            );
             truncated_line.spans.push(new_span);
             x += new_span_width;
             offset = 0;

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -488,7 +488,7 @@ impl<'a> Line<'a> {
                 span.content
                     .as_ref()
                     .chars()
-                    .skip(offset.into())
+                    .skip(usize::from(offset))
                     .collect::<String>(),
             );
             truncated_line.spans.push(new_span);

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -937,6 +937,10 @@ mod tests {
     }
 
     #[test]
+    // https://github.com/ratatui-org/ratatui/issues/1032 truncating string slice is not safe in
+    // Rust UTF-8 encoded strings, here we cut a gauge composed of characters that encode as 2 byte
+    // we cut it from the right with an even number. We expect four characters. Byte operation would
+    // yield only two.
     fn truncate_utf8_even_right() {
         let line = Line::from("██████░░░░".to_string());
         assert_eq!(
@@ -946,6 +950,9 @@ mod tests {
     }
 
     #[test]
+    // https://github.com/ratatui-org/ratatui/issues/1032 truncating string slice is not safe in
+    // Rust UTF-8 encoded strings, here we cut a gauge composed of characters that encode as 2 byte
+    // we cut it from the right with an odd number, this would hit an illegal UTF-8 position to cut
     fn truncate_utf8_odd_right() {
         let line = Line::from("██████░░░░".to_string());
         assert_eq!(
@@ -955,6 +962,10 @@ mod tests {
     }
 
     #[test]
+    // https://github.com/ratatui-org/ratatui/issues/1032 truncating string slice is not safe in
+    // Rust UTF-8 encoded strings, here we cut a gauge composed of characters that encode as 2 byte
+    // we cut it from the left with an even number. We expect four characters. Byte operation would
+    // yield only two.
     fn truncate_utf8_even_left() {
         let line = Line::from("░░░░██████".to_string());
         assert_eq!(
@@ -964,6 +975,9 @@ mod tests {
     }
 
     #[test]
+    // https://github.com/ratatui-org/ratatui/issues/1032 truncating string slice is not safe in
+    // Rust UTF-8 encoded strings, here we cut a gauge composed of characters that encode as 2 byte
+    // we cut it from the left with an odd number, this would hit an illegal UTF-8 position to cut
     fn truncate_utf8_odd_left() {
         let line = Line::from("░░░░██████".to_string());
         assert_eq!(

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 use std::borrow::Cow;
+
 use unicode_truncate::UnicodeTruncateStr;
 
 use super::StyledGrapheme;
@@ -475,14 +476,18 @@ impl<'a> Line<'a> {
             let new_span_width = span_width - offset;
             if x + new_span_width > result_width {
                 let span_end = (result_width - x + offset) as usize;
-                let (str_cut_start, _len) = span.content.unicode_truncate_start(usize::from(new_span_width));
-                let (str_cut_final, _len) = str_cut_start.unicode_truncate(span_end - usize::from(offset));
-                new_span.content = Cow::from(str_cut_final
-                );
+                let (str_cut_start, _len) = span
+                    .content
+                    .unicode_truncate_start(usize::from(new_span_width));
+                let (str_cut_final, _len) =
+                    str_cut_start.unicode_truncate(span_end - usize::from(offset));
+                new_span.content = Cow::from(str_cut_final);
                 truncated_line.spans.push(new_span);
                 break;
             }
-            let (new_content, _len) = span.content.unicode_truncate_start(usize::from(new_span_width));
+            let (new_content, _len) = span
+                .content
+                .unicode_truncate_start(usize::from(new_span_width));
             new_span.content = Cow::from(new_content);
             truncated_line.spans.push(new_span);
             x += new_span_width;


### PR DESCRIPTION
Hi,

I think this will fix https://github.com/ratatui-org/ratatui/issues/1032

One needs to iterate chars() instead of slicing into the &str content itself. Obvious Rust thing with relation to UTF-8.

Added some truncation tests truncating UTF-8 strings left- and right-centered, even and odd numbers.

If there is a more performant way for things to do, please adjust accordingly.

Regards,
Thomas