### PR TITLE
docs(github): update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # Maintainers
-* @orhun @mindoodoo @sayanarijit @joshka @kdheepak @Valentin271 @EdJoPaTo
+* @orhun @joshka @kdheepak @Valentin271 @EdJoPaTo


### PR DESCRIPTION
Removes the team members that are not able to review PRs recently (with their approval ofc)