### PR TITLE
perf(crossterm): Speed up combined fg and bg color changes by up to 20%

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -10,8 +10,8 @@ use crossterm::{
     cursor::{Hide, MoveTo, Show},
     execute, queue,
     style::{
-        Attribute as CAttribute, Attributes as CAttributes, Color as CColor, ContentStyle, Print,
-        SetAttribute, SetBackgroundColor, SetForegroundColor,
+        Attribute as CAttribute, Attributes as CAttributes, Color as CColor, Colors, ContentStyle,
+        Print, SetAttribute, SetBackgroundColor, SetColors, SetForegroundColor,
     },
     terminal::{self, Clear},
 };
@@ -145,14 +145,12 @@ where
                 diff.queue(&mut self.writer)?;
                 modifier = cell.modifier;
             }
-            if cell.fg != fg {
-                let color = CColor::from(cell.fg);
-                queue!(self.writer, SetForegroundColor(color))?;
+            if cell.fg != fg || cell.bg != bg {
+                queue!(
+                    self.writer,
+                    SetColors(Colors::new(cell.fg.into(), cell.bg.into()))
+                )?;
                 fg = cell.fg;
-            }
-            if cell.bg != bg {
-                let color = CColor::from(cell.bg);
-                queue!(self.writer, SetBackgroundColor(color))?;
                 bg = cell.bg;
             }
             #[cfg(feature = "underline-color")]


### PR DESCRIPTION
Use Crossterm SetColors instead of SetForegroundColor and
SetBackgroundColor.

In https://github.com/crossterm-rs/crossterm/pull/879 I changed the
SetColors command to write both colors at once with a single write
instead of multiple writes that more bytes. This led to a 15-25% fps
increase when testing the colors_rgb example on iTerm2 on an M2 Macbook
Pro.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
