### PR TITLE
docs(github): update code owners about past maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,6 @@
 
 # Maintainers
 * @orhun @joshka @kdheepak @Valentin271 @EdJoPaTo
+
+# Past maintainers
+# @mindoodoo @sayanarijit


### PR DESCRIPTION
As per suggestion in https://github.com/ratatui-org/ratatui/pull/1067#issuecomment-2079766990

It's good for historical purposes!