### PR TITLE
docs: add note about scrollbar state content length

### DIFF
--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -29,6 +29,11 @@ use crate::{prelude::*, symbols::scrollbar::*};
 /// └─────────── begin
 /// ```
 ///
+/// ## Important
+/// When rendering `Scrollbar`, you must specify the `content_length`
+/// field in the [`ScrollbarState`], or else the `Scrollbar` will not render. See
+/// the documentation for [`ScrollbarState`] for more information.
+///
 /// # Examples
 ///
 /// ```rust

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -29,10 +29,10 @@ use crate::{prelude::*, symbols::scrollbar::*};
 /// └─────────── begin
 /// ```
 ///
-/// ## Important
-/// When rendering `Scrollbar`, you must specify the `content_length`
-/// field in the [`ScrollbarState`], or else the `Scrollbar` will not render. See
-/// the documentation for [`ScrollbarState`] for more information.
+/// # Important
+///
+/// You must specify the [`ScrollbarState::content_length`] before rendering the `Scrollbar`, or
+/// else the `Scrollbar` will render blank.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Updates the `Scrollbar` docs [as discussed](https://discord.com/channels/1070692720437383208/1072907135664529508/1235032608283557918) on the Discord.

Please let me know if I did anything wrong, and also happy to iterate on the docs change itself. Just added something small and quick for now.