### PR TITLE
style: use std::fmt instead of importing Debug and Display

### DIFF
--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -2,7 +2,7 @@
 //! It is used in the integration tests to verify the correctness of the library.
 
 use std::{
-    fmt::{Display, Write},
+    fmt::{self, Write},
     io,
 };
 
@@ -105,10 +105,10 @@ impl TestBackend {
     }
 }
 
-impl Display for TestBackend {
+impl fmt::Display for TestBackend {
     /// Formats the `TestBackend` for display by calling the `buffer_view` function
     /// on its internal buffer.
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", buffer_view(&self.buffer))
     }
 }

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -370,7 +372,7 @@ impl Buffer {
     }
 }
 
-impl std::fmt::Debug for Buffer {
+impl fmt::Debug for Buffer {
     /// Writes a debug representation of the buffer to the given formatter.
     ///
     /// The format is like a pretty printed struct, with the following fields:
@@ -378,7 +380,7 @@ impl std::fmt::Debug for Buffer {
     /// * `content`: displayed as a list of strings representing the content of the buffer
     /// * `styles`: displayed as a list of: `{ x: 1, y: 2, fg: Color::Red, bg: Color::Blue,
     ///   modifier: Modifier::BOLD }` only showing a value when there is a change in style.
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!(
             "Buffer {{\n    area: {:?},\n    content: [\n",
             &self.area

--- a/src/layout/constraint.rs
+++ b/src/layout/constraint.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display};
+use std::fmt;
 
 use itertools::Itertools;
 use strum::EnumIs;
@@ -362,7 +362,7 @@ impl Default for Constraint {
     }
 }
 
-impl Display for Constraint {
+impl fmt::Display for Constraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Percentage(p) => write!(f, "Percentage({p})"),

--- a/src/layout/margin.rs
+++ b/src/layout/margin.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display};
+use std::fmt;
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct Margin {
@@ -15,7 +15,7 @@ impl Margin {
     }
 }
 
-impl Display for Margin {
+impl fmt::Display for Margin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}x{}", self.horizontal, self.vertical)
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -68,7 +68,7 @@
 //! [`prelude`]: crate::prelude
 //! [`Span`]: crate::text::Span
 
-use std::fmt::{self, Debug};
+use std::fmt;
 
 use bitflags::bitflags;
 
@@ -119,7 +119,7 @@ impl fmt::Debug for Modifier {
         if self.is_empty() {
             return write!(f, "NONE");
         }
-        fmt::Debug::fmt(&self.0, f)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::unreadable_literal)]
 
-use std::{
-    fmt::{self, Debug, Display},
-    str::FromStr,
-};
+use std::{fmt, str::FromStr};
 
 /// ANSI Color
 ///
@@ -142,7 +139,7 @@ impl Color {
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for Color {
-    /// This utilises the [`Display`] implementation for serialization.
+    /// This utilises the [`fmt::Display`] implementation for serialization.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -243,8 +240,8 @@ impl<'de> serde::Deserialize<'de> for Color {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ParseColorError;
 
-impl std::fmt::Display for ParseColorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ParseColorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Failed to parse Colors")
     }
 }
@@ -336,7 +333,7 @@ impl FromStr for Color {
     }
 }
 
-impl Display for Color {
+impl fmt::Display for Color {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Reset => write!(f, "Reset"),

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt};
 
 use super::StyledGrapheme;
 use crate::prelude::*;
@@ -615,8 +615,8 @@ impl WidgetRef for Line<'_> {
     }
 }
 
-impl std::fmt::Display for Line<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Line<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for span in &self.spans {
             write!(f, "{span}")?;
         }

--- a/src/text/masked.rs
+++ b/src/text/masked.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow,
-    fmt::{self, Debug, Display},
-};
+use std::{borrow::Cow, fmt};
 
 use super::Text;
 
@@ -46,17 +43,17 @@ impl<'a> Masked<'a> {
     }
 }
 
-impl Debug for Masked<'_> {
+impl fmt::Debug for Masked<'_> {
     /// Debug representation of a masked string is the underlying string
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.inner, f)
+        f.write_str(&self.inner)
     }
 }
 
-impl Display for Masked<'_> {
+impl fmt::Display for Masked<'_> {
     /// Display representation of a masked string is the masked string
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.value(), f)
+        f.write_str(&self.value())
     }
 }
 

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Debug};
+use std::{borrow::Cow, fmt};
 
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
@@ -395,8 +395,8 @@ impl WidgetRef for Span<'_> {
     }
 }
 
-impl std::fmt::Display for Span<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Span<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", &self.content)
     }
 }

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt};
 
 use itertools::{Itertools, Position};
 
@@ -580,8 +580,8 @@ where
     }
 }
 
-impl std::fmt::Display for Text<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Text<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (position, line) in self.iter().with_position() {
             if position == Position::Last {
                 write!(f, "{line}")?;

--- a/src/widgets/borders.rs
+++ b/src/widgets/borders.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug};
+use std::fmt;
 
 use bitflags::bitflags;
 
@@ -24,7 +24,7 @@ bitflags! {
 /// Implement the `Debug` trait for the `Borders` bitflags. This is a manual implementation to
 /// display the flags in a more readable way. The default implementation would display the
 /// flags as 'Border(0x0)' for `Borders::NONE` for example.
-impl Debug for Borders {
+impl fmt::Debug for Borders {
     /// Display the Borders bitflags as a list of names. For example, `Borders::NONE` will be
     /// displayed as `NONE` and `Borders::ALL` will be displayed as `ALL`. If multiple flags are
     /// set, they will be displayed separated by a pipe character.

--- a/src/widgets/canvas.rs
+++ b/src/widgets/canvas.rs
@@ -19,7 +19,7 @@ mod points;
 mod rectangle;
 mod world;
 
-use std::{fmt::Debug, iter::zip};
+use std::{fmt, iter::zip};
 
 use itertools::Itertools;
 
@@ -70,7 +70,7 @@ struct Layer {
 /// resolution of the grid might exceed the number of rows and columns. For example, a grid of
 /// Braille patterns will have a resolution of 2x4 dots per cell. This means that a grid of 10x10
 /// cells will have a resolution of 20x40 dots.
-trait Grid: Debug {
+trait Grid: fmt::Debug {
     /// Get the resolution of the grid in number of dots.
     ///
     /// This doesn't have to be the same as the number of rows and columns of the grid. For example,


### PR DESCRIPTION
Based on a [discussion](https://github.com/ratatui-org/ratatui/pull/1083#discussion_r1588466060) with @EdJoPaTo on a PR.

This is a small universal style change to avoid making this change a part of other PRs.