### PR TITLE
fix: unicode truncation bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,10 @@ name = "block"
 harness = false
 
 [[bench]]
+name = "line"
+harness = false
+
+[[bench]]
 name = "list"
 harness = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ document-features = { version = "0.2.7", optional = true }
 lru = "0.12.0"
 stability = "0.2.0"
 compact_str = "0.7.1"
+unicode-truncate = "1"
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,25 +25,24 @@ rust-version = "1.74.0"
 [badges]
 
 [dependencies]
-crossterm = { version = "0.27", optional = true }
-termion = { version = "3.0", optional = true }
-termwiz = { version = "0.22.0", optional = true }
-
-serde = { version = "1", optional = true, features = ["derive"] }
 bitflags = "2.3"
 cassowary = "0.3"
+compact_str = "0.7.1"
+crossterm = { version = "0.27", optional = true }
+document-features = { version = "0.2.7", optional = true }
 indoc = "2.0"
 itertools = "0.12"
+lru = "0.12.0"
 paste = "1.0.2"
+serde = { version = "1", optional = true, features = ["derive"] }
+stability = "0.2.0"
 strum = { version = "0.26", features = ["derive"] }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }
+termion = { version = "3.0", optional = true }
+termwiz = { version = "0.22.0", optional = true }
 unicode-segmentation = "1.10"
-unicode-width = "0.1"
-document-features = { version = "0.2.7", optional = true }
-lru = "0.12.0"
-stability = "0.2.0"
-compact_str = "0.7.1"
 unicode-truncate = "1"
+unicode-width = "0.1"
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/benches/line.rs
+++ b/benches/line.rs
@@ -1,31 +1,38 @@
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use ratatui::{buffer::Buffer, layout::Rect, style::Stylize, text::Line, widgets::Widget};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::Stylize,
+    text::Line,
+    widgets::Widget,
+};
 
 fn line_render(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("line_render");
-    group.sample_size(1000);
+    for alignment in [Alignment::Left, Alignment::Center, Alignment::Right] {
+        let mut group = criterion.benchmark_group(format!("line_render/{alignment}"));
+        group.sample_size(1000);
 
-    let line = &Line::from(vec![
-        "This".red(),
-        " ".green(),
-        "is".italic(),
-        " ".blue(),
-        "SPARTA!!".bold(),
-    ])
-    .right_aligned();
+        let line = &Line::from(vec![
+            "This".red(),
+            " ".green(),
+            "is".italic(),
+            " ".blue(),
+            "SPARTA!!".bold(),
+        ])
+        .alignment(alignment);
 
-    for width in [0, 3, 4, 6, 7, 10, 42] {
-        let area = Rect::new(0, 0, width, 1);
+        for width in [0, 3, 4, 6, 7, 10, 42] {
+            let area = Rect::new(0, 0, width, 1);
 
-        group.bench_function(width.to_string(), |bencher| {
-            let mut buffer = Buffer::empty(area);
-            bencher.iter(|| black_box(line).render(area, &mut buffer));
-        });
+            group.bench_function(width.to_string(), |bencher| {
+                let mut buffer = Buffer::empty(area);
+                bencher.iter(|| black_box(line).render(area, &mut buffer));
+            });
+        }
+        group.finish();
     }
-
-    group.finish();
 }
 
 criterion_group!(benches, line_render);

--- a/benches/line.rs
+++ b/benches/line.rs
@@ -1,0 +1,32 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use ratatui::{buffer::Buffer, layout::Rect, style::Stylize, text::Line, widgets::Widget};
+
+fn line_render(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("line_render");
+    group.sample_size(1000);
+
+    let line = &Line::from(vec![
+        "This".red(),
+        " ".green(),
+        "is".italic(),
+        " ".blue(),
+        "SPARTA!!".bold(),
+    ])
+    .right_aligned();
+
+    for width in [0, 3, 4, 6, 7, 10, 42] {
+        let area = Rect::new(0, 0, width, 1);
+
+        group.bench_function(width.to_string(), |bencher| {
+            let mut buffer = Buffer::empty(area);
+            bencher.iter(|| black_box(line).render(area, &mut buffer));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, line_render);
+criterion_main!(benches);

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -313,6 +313,18 @@ impl Rect {
             height: self.height,
         }
     }
+
+    /// indents the x value of the `Rect` by a given `offset`
+    ///
+    /// This is pub(crate) for now as we need to stabilize the naming / design of this API.
+    #[must_use]
+    pub(crate) const fn indent_x(self, offset: u16) -> Self {
+        Self {
+            x: self.x.saturating_add(offset),
+            width: self.width.saturating_sub(offset),
+            ..self
+        }
+    }
 }
 
 impl From<(Position, Size)> for Rect {

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -604,8 +604,8 @@ fn render_spans(
             width: area.width.saturating_sub(buf_x_offset),
             ..area
         };
-        let is_span_partially_visible = span_offset > 0;
-        if is_span_partially_visible {
+        let span_is_only_partially_visible = span_offset > 0;
+        if span_is_only_partially_visible {
             // render the partially visible span starting at the offset -> right side
             let (_left, right) = span.split_at_width(span_offset as usize);
             right.render_ref(area, buf);

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -602,18 +602,19 @@ fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_offse
         if span_offset > 0 {
             // the first span is only partially visible, so truncate the start and render it
             // starting at span offset
-            let render_width = span_width - span_offset;
-            let (content, display_width) =
-                span.content.unicode_truncate_start(render_width as usize);
-            let display_width = display_width as u16;
+            let available_width = span_width - span_offset;
+            let (content, actual_width) = span
+                .content
+                .unicode_truncate_start(available_width as usize);
+            let actual_width = actual_width as u16;
 
             // if the truncation has truncated an initial grapheme, then we need to start rendering
             // from a position that takes that into account by indenting the start of the area
-            area = area.indent_x(render_width - display_width);
+            area = area.indent_x(available_width - actual_width);
             let right = Span::styled(content, span.style);
             right.render_ref(area, buf);
 
-            area = area.indent_x(display_width);
+            area = area.indent_x(actual_width);
             span_offset = 0; // ensure that the next span is rendered in full
         } else {
             // render the whole span

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1,9 +1,10 @@
 #![deny(missing_docs)]
 use std::borrow::Cow;
 
+use unicode_truncate::UnicodeTruncateStr;
+
 use super::StyledGrapheme;
 use crate::prelude::*;
-use unicode_truncate::UnicodeTruncateStr;
 
 /// A line of text, consisting of one or more [`Span`]s.
 ///
@@ -940,7 +941,6 @@ mod tests {
         use unicode_width::UnicodeWidthStr;
 
         use self::buffer::Cell;
-
         use super::*;
         use crate::assert_buffer_eq;
         const BLUE: Style = Style::new().fg(Color::Blue);

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -607,7 +607,8 @@ fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_skip_
         if span_skip_width > 0 {
             // the first visible span is only partially visible, so truncate the start and render it
             // starting at span_skip_width, all subsequent visible spans are rendered in full (as
-            // available space permits)
+            // available space permits). We only need to truncate the start of the first visible span
+            // because the rest of the line will be truncated automatically by the area width
             let available_width = span_width - span_skip_width;
             let (content, actual_width) = span
                 .content

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -555,6 +555,9 @@ impl Widget for Line<'_> {
 impl WidgetRef for Line<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let area = area.intersection(buf.area);
+        if area.is_empty() {
+            return;
+        }
         buf.set_style(area, self.style);
 
         // Left aligned is the default. Use a performance optimized minimal solution.
@@ -565,6 +568,10 @@ impl WidgetRef for Line<'_> {
 
         let area_width = usize::from(area.width);
         let line_width = self.width();
+        if line_width == 0 {
+            return;
+        }
+
         let can_render_complete_line = line_width <= area_width;
 
         #[allow(clippy::cast_possible_truncation)] // explained in comment

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -596,9 +596,6 @@ fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_offse
             span_offset -= span_width;
             continue;
         }
-        if area.is_empty() {
-            break;
-        }
         if span_offset > 0 {
             // the first visible span is only partially visible, so truncate the start and render it
             // starting at span offset, all subsequent visible spans are rendered in full (as
@@ -612,6 +609,9 @@ fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_offse
             // if the truncation has truncated an initial grapheme, then we need to start rendering
             // from a position that takes that into account by indenting the start of the area
             area = area.indent_x(available_width - actual_width);
+            if area.is_empty() {
+                break;
+            }
             let right = Span::styled(content, span.style);
             right.render_ref(area, buf);
 
@@ -619,6 +619,9 @@ fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_offse
             span_offset = 0; // ensure that the next span is rendered in full
         } else {
             // render the whole span
+            if area.is_empty() {
+                break;
+            }
             span.render_ref(area, buf);
             area = area.indent_x(span_width);
         }

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -607,7 +607,7 @@ fn render_spans(
         let span_is_only_partially_visible = span_offset > 0;
         if span_is_only_partially_visible {
             // render the partially visible span starting at the offset -> right side
-            let (_left, right) = span.split_at_width(span_offset as usize);
+            let right = span.skip_unicode_width(span_offset as usize);
             right.render_ref(area, buf);
             buf_x_offset += right.width() as u16;
             span_offset = 0; // ensure that the next span is rendered in full
@@ -1063,7 +1063,7 @@ mod tests {
         #[case::left_7(Alignment::Left, 7, "1234🦀7")]
         #[case::right_4(Alignment::Right, 4, "7890")]
         /// FIXME should be " 7890" https://github.com/ratatui-org/ratatui/pull/1089#issue-2280234173
-        #[case::right_5(Alignment::Right, 5, "🦀789")] // failing actual: "🦀789"
+        #[case::right_5(Alignment::Right, 5, "🦀789")]
         #[case::right_6(Alignment::Right, 6, "🦀7890")]
         #[case::right_7(Alignment::Right, 7, "4🦀7890")]
         fn render_truncates_emoji(

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1011,7 +1011,24 @@ mod tests {
             assert_buffer_eq!(buf, Buffer::with_lines(["lo wo"]));
         }
 
-        /// documentary test to highlight the crab emoji width / length discrepancy
+        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// found panics with truncating lines that contained multi-byte characters.
+        #[test]
+        fn regression_1032() {
+            let line = Line::from(
+                "🦀 RFC8628 OAuth 2.0 Device Authorization GrantでCLIからGithubのaccess tokenを取得する"
+            );
+            let mut buf = Buffer::empty(Rect::new(0, 0, 83, 1));
+            line.render_ref(buf.area, &mut buf);
+            assert_buffer_eq!(buf, Buffer::with_lines([
+                "🦀 RFC8628 OAuth 2.0 Device Authorization GrantでCLIからGithubのaccess tokenを取得 "
+            ]));
+        }
+
+        /// Documentary test to highlight the crab emoji width / length discrepancy
+        ///
+        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// found panics with truncating lines that contained multi-byte characters.
         #[test]
         fn crab_emoji_width() {
             let line = Line::from("🦀");
@@ -1019,6 +1036,8 @@ mod tests {
             assert_eq!(line.to_string().len(), 4);
         }
 
+        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// found panics with truncating lines that contained multi-byte characters.
         #[rstest]
         #[case::left_4(Alignment::Left, 4, "1234")]
         #[case::left_5(Alignment::Left, 5, "1234 ")]
@@ -1040,6 +1059,9 @@ mod tests {
             assert_buffer_eq!(buf, Buffer::with_lines([expected]));
         }
 
+        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// found panics with truncating lines that contained multi-byte characters.
+        ///
         /// centering is tricky because there's an ambiguity about whether to take one more char
         /// from the left or the right when the line width is odd. This interacts with the width of
         /// the crab emoji, which is 2 characters wide by hitting the left or right side of the

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -600,8 +600,9 @@ fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_offse
             break;
         }
         if span_offset > 0 {
-            // the first span is only partially visible, so truncate the start and render it
-            // starting at span offset
+            // the first visible span is only partially visible, so truncate the start and render it
+            // starting at span offset, all subsequent visible spans are rendered in full (as
+            // available space permits)
             let available_width = span_width - span_offset;
             let (content, actual_width) = span
                 .content

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -606,7 +606,7 @@ fn render_spans(
         };
         let is_span_partially_visible = span_offset > 0;
         if is_span_partially_visible {
-            // only render the right side of the partially visible span
+            // render the partially visible span starting at the offset -> right side
             let (_left, right) = span.split_at_width(span_offset as usize);
             right.render_ref(area, buf);
             buf_x_offset += right.width() as u16;

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -562,7 +562,7 @@ impl WidgetRef for Line<'_> {
                 Some(Alignment::Right) => area.width.saturating_sub(line_width),
                 Some(Alignment::Left) | None => 0,
             };
-            let area = indent(area, offset);
+            let area = area.indent_x(offset);
             render_spans(&self.spans, area, buf, 0);
         } else {
             let offset = match self.alignment {
@@ -609,29 +609,17 @@ fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_offse
 
             // if the truncation has truncated an initial grapheme, then we need to start rendering
             // from a position that takes that into account by indenting the start of the area
-            area = indent(area, render_width - display_width);
+            area = area.indent_x(render_width - display_width);
             let right = Span::styled(content, span.style);
             right.render_ref(area, buf);
 
-            area = indent(area, display_width);
+            area = area.indent_x(display_width);
             span_offset = 0; // ensure that the next span is rendered in full
         } else {
             // render the whole span
             span.render_ref(area, buf);
-            area = indent(area, span_width);
+            area = area.indent_x(span_width);
         }
-    }
-}
-
-/// indents a given `area`'s x value by the given `x_offset`, returning a new `Rect`
-///
-/// TODO: this should probably be move into a pubic method on `Rect` as it's a common operation
-/// that's used in a few places
-const fn indent(area: Rect, x_offset: u16) -> Rect {
-    Rect {
-        x: area.x.saturating_add(x_offset),
-        width: area.width.saturating_sub(x_offset),
-        ..area
     }
 }
 

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![warn(clippy::cast_possible_truncation)]
+#![warn(clippy::pedantic, clippy::nursery, clippy::arithmetic_side_effects)]
 use std::borrow::Cow;
 
 use unicode_truncate::UnicodeTruncateStr;
@@ -599,7 +599,7 @@ impl WidgetRef for Line<'_> {
 /// 2. Indent `area` to account for the width of the rendered span
 /// 3. Update `span_skip_width` to 0 after the first span is rendered in full
 /// 4. Repeat
-#[allow(clippy::cast_possible_truncation)] // Ensured by debug_assert or explained in comment
+#[allow(clippy::cast_possible_truncation, clippy::arithmetic_side_effects)] // Ensured by debug_assert or explained in comment
 fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_skip_width: usize) {
     for span in spans {
         let span_width = span.width();
@@ -616,6 +616,7 @@ fn render_spans(spans: &[Span], mut area: Rect, buf: &mut Buffer, mut span_skip_
             // available space permits). We only need to truncate the start of the first visible
             // span because the rest of the line will be truncated automatically by the
             // area width
+            debug_assert!(span_width > span_skip_width, "span_skip_width seems wrong");
             let available_width = span_width - span_skip_width;
             let (content, actual_width) = span.content.unicode_truncate_start(available_width);
 

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -555,10 +555,14 @@ impl Widget for Line<'_> {
 impl WidgetRef for Line<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let area = area.intersection(buf.area);
-        let line_width = self.width();
-        if area.is_empty() || line_width == 0 {
+        if area.is_empty() {
             return;
         }
+        let line_width = self.width();
+        if line_width == 0 {
+            return;
+        }
+
         buf.set_style(area, self.style);
 
         let area_width = usize::from(area.width);

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt::Debug};
 
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthStr;
 
 use super::StyledGrapheme;
 use crate::prelude::*;
@@ -331,54 +331,6 @@ impl<'a> Span<'a> {
     #[deprecated = "use into_right_aligned_line"]
     pub fn to_right_aligned_line(self) -> Line<'a> {
         self.into_right_aligned_line()
-    }
-
-    /// Splits the span into two at the given width.
-    ///
-    /// The first span will contain the characters that fit within the given width, and the second
-    /// span will contain the remaining characters.
-    #[must_use]
-    pub(crate) fn split_at_width(&'a self, width: usize) -> (Self, Self) {
-        // There's at least two ways to do this. I chose the second option as it iterates over the
-        // string once at the cost of always allocating two strings regardless of the split point.
-        // 1. iterate the chars to find the split point and then split the spans.
-        // 2. iterate the chars and build the spans at the same time.
-        let mut left = String::new();
-        let mut right = String::new();
-        let mut left_width = 0;
-        for c in self.content.chars() {
-            left_width += c.width().unwrap_or(0);
-            if left_width <= width {
-                left.push(c);
-            } else {
-                right.push(c);
-            }
-        }
-        (
-            Span::styled(left, self.style),
-            Span::styled(right, self.style),
-        )
-    }
-
-    /// Skips the content until the given `skip_width` is skipped to start after the `skip_width`
-    /// while honoring unicode width of characters.
-    #[must_use]
-    pub(crate) fn skip_unicode_width(&'a self, skip_width: usize) -> Self {
-        let byte_index = self
-            .content
-            .char_indices()
-            .map(|(byte_index, char)| (byte_index, char.width().unwrap_or(0)))
-            // Dont include zero width characters at the beginning
-            .filter(|(_, char_width)| *char_width > 0)
-            .scan(0, |sum: &mut usize, (byte_index, char_width)| {
-                *sum = sum.checked_add(char_width)?;
-                Some((byte_index, *sum))
-            })
-            .find(|(_, current_width)| *current_width > skip_width)
-            .map_or_else(|| self.content.len(), |(index, _current_width)| index);
-        // unwrap is safe as it comes from char_indicies
-        let content = self.content.get(byte_index..).unwrap();
-        Self::styled(content, self.style)
     }
 
     /// Returns `true` if the span is empty.

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -337,7 +337,7 @@ impl<'a> Span<'a> {
     ///
     /// The first span will contain the characters that fit within the given width, and the second
     /// span will contain the remaining characters.
-    pub fn split_at_width(&'a self, width: usize) -> (Self, Self) {
+    pub(crate) fn split_at_width(&'a self, width: usize) -> (Self, Self) {
         // There's at least two ways to do this. I chose the second option as it iterates over the
         // string once at the cost of always allocating two strings regardless of the split point.
         // 1. iterate the chars to find the split point and then split the spans.
@@ -359,6 +359,7 @@ impl<'a> Span<'a> {
         )
     }
 
+    /// Returns `true` if the span is empty.
     pub fn is_empty(&self) -> bool {
         self.content.is_empty()
     }

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -332,12 +332,6 @@ impl<'a> Span<'a> {
     pub fn to_right_aligned_line(self) -> Line<'a> {
         self.into_right_aligned_line()
     }
-
-    /// Returns `true` if the span is empty.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.content.is_empty()
-    }
 }
 
 impl<'a, T> From<T> for Span<'a>


### PR DESCRIPTION
- Rewrote the line / span rendering code to take into account how multi-byte / wide emoji characters are truncated when rendering into areas that cannot accommodate them in the available space
- Added comprehensive coverage over the edge cases
- Adds a benchmark to ensure perf

Fixes: https://github.com/ratatui-org/ratatui/issues/1032

