### PR TITLE
feat: allow `Line`s to be wrapped individually wrapped

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -47,7 +47,7 @@
 mod grapheme;
 pub use grapheme::StyledGrapheme;
 
-mod line;
+pub(crate) mod line;
 pub use line::Line;
 
 mod masked;

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -32,7 +32,7 @@ mod clear;
 mod gauge;
 mod list;
 mod paragraph;
-mod reflow;
+pub(crate) mod reflow;
 mod scrollbar;
 mod sparkline;
 mod table;

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -2,17 +2,9 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     prelude::*,
-    text::StyledGrapheme,
+    text::{line::get_line_offset, StyledGrapheme},
     widgets::{reflow::*, Block},
 };
-
-const fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) -> u16 {
-    match alignment {
-        Alignment::Center => (text_area_width / 2).saturating_sub(line_width / 2),
-        Alignment::Right => text_area_width.saturating_sub(line_width),
-        Alignment::Left => 0,
-    }
-}
 
 /// A widget to display some text.
 ///

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -26,7 +26,7 @@ pub struct WrappedLine<'lend, 'text> {
 
 /// A state machine that wraps lines on word boundaries.
 #[derive(Debug, Default, Clone)]
-pub struct WordWrapper<'a, O, I>
+pub(crate) struct WordWrapper<'a, O, I>
 where
     // Outer iterator providing the individual lines
     O: Iterator<Item = (I, Alignment)>,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
I am implementing #201 because I need this feature.

This PR is still a WIP as I haven't added tests. Early feedback is always welcome!

How the individual line wrapping should interact with the paragraph's wrapping is a big headache. For now this PR only handles wrapping for lines without considering the interaction with paragraphs, which means that when rendering paragraph, `Line's' wrap is ignored.

It seems I also need to update `Text` to make it work in the `List`.