### PR TITLE
feat: use inner Display implementation

### DIFF
--- a/src/buffer/cell.rs
+++ b/src/buffer/cell.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use compact_str::CompactString;
 
 use crate::prelude::*;

--- a/src/text/masked.rs
+++ b/src/text/masked.rs
@@ -45,16 +45,16 @@ impl<'a> Masked<'a> {
 
 impl fmt::Debug for Masked<'_> {
     /// Debug representation of a masked string is the underlying string
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // note that calling display instead of Debug here is intentional
-        fmt::Display::fmt(&self.inner, formatter)
+        fmt::Display::fmt(&self.inner, f)
     }
 }
 
 impl fmt::Display for Masked<'_> {
     /// Display representation of a masked string is the masked string
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.value(), formatter)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.value(), f)
     }
 }
 

--- a/src/text/masked.rs
+++ b/src/text/masked.rs
@@ -46,14 +46,15 @@ impl<'a> Masked<'a> {
 impl fmt::Debug for Masked<'_> {
     /// Debug representation of a masked string is the underlying string
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.pad(&self.inner)
+        // note that calling display instead of Debug here is intentional
+        fmt::Display::fmt(&self.inner, formatter)
     }
 }
 
 impl fmt::Display for Masked<'_> {
     /// Display representation of a masked string is the masked string
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.pad(&self.value())
+        fmt::Display::fmt(&self.value(), formatter)
     }
 }
 

--- a/src/text/masked.rs
+++ b/src/text/masked.rs
@@ -45,15 +45,15 @@ impl<'a> Masked<'a> {
 
 impl fmt::Debug for Masked<'_> {
     /// Debug representation of a masked string is the underlying string
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.inner)
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, formatter)
     }
 }
 
 impl fmt::Display for Masked<'_> {
     /// Display representation of a masked string is the masked string
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.value())
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.value(), formatter)
     }
 }
 

--- a/src/text/masked.rs
+++ b/src/text/masked.rs
@@ -46,14 +46,14 @@ impl<'a> Masked<'a> {
 impl fmt::Debug for Masked<'_> {
     /// Debug representation of a masked string is the underlying string
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, formatter)
+        formatter.pad(&self.inner)
     }
 }
 
 impl fmt::Display for Masked<'_> {
     /// Display representation of a masked string is the masked string
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.value(), formatter)
+        formatter.pad(&self.value())
     }
 }
 
@@ -109,12 +109,14 @@ mod tests {
     fn debug() {
         let masked = Masked::new("12345", 'x');
         assert_eq!(format!("{masked:?}"), "12345");
+        assert_eq!(format!("{masked:.3?}"), "123", "Debug truncates");
     }
 
     #[test]
     fn display() {
         let masked = Masked::new("12345", 'x');
         assert_eq!(format!("{masked}"), "xxxxx");
+        assert_eq!(format!("{masked:.3}"), "xxx", "Display truncates");
     }
 
     #[test]

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -396,8 +396,8 @@ impl WidgetRef for Span<'_> {
 }
 
 impl fmt::Display for Span<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", &self.content)
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.content, formatter)
     }
 }
 

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -397,7 +397,7 @@ impl WidgetRef for Span<'_> {
 
 impl fmt::Display for Span<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.pad(&self.content)
+        fmt::Debug::fmt(self, formatter)
     }
 }
 

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -396,8 +396,8 @@ impl WidgetRef for Span<'_> {
 }
 
 impl fmt::Display for Span<'_> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.content, formatter)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.content, f)
     }
 }
 

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -397,7 +397,7 @@ impl WidgetRef for Span<'_> {
 
 impl fmt::Display for Span<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, formatter)
+        fmt::Display::fmt(&self.content, formatter)
     }
 }
 

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -397,7 +397,7 @@ impl WidgetRef for Span<'_> {
 
 impl fmt::Display for Span<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.content, formatter)
+        formatter.pad(&self.content)
     }
 }
 
@@ -529,15 +529,15 @@ mod tests {
     #[test]
     fn display_span() {
         let span = Span::raw("test content");
-
         assert_eq!(format!("{span}"), "test content");
+        assert_eq!(format!("{span:.4}"), "test");
     }
 
     #[test]
     fn display_styled_span() {
         let stylized_span = Span::styled("stylized test content", Style::new().green());
-
         assert_eq!(format!("{stylized_span}"), "stylized test content");
+        assert_eq!(format!("{stylized_span:.8}"), "stylized");
     }
 
     #[test]


### PR DESCRIPTION
This allows for `format!("{:>42})` formatting.
See https://doc.rust-lang.org/std/fmt/struct.Formatter.html#method.pad

---

I am not very attached to this. It feels more correct to reuse the inner Display implementation but we can also drop this. Main reason for this PR was to move it out of #1007