### PR TITLE
fix(buffer): fix Debug panic and fix formatting of overridden parts

### DIFF
--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -419,12 +419,13 @@ impl fmt::Debug for Buffer {
                     }
                 }
             }
+            f.write_str("\",")?;
             if !overwritten.is_empty() {
                 f.write_fmt(format_args!(
-                    "// hidden by multi-width symbols: {overwritten:?}"
+                    " // hidden by multi-width symbols: {overwritten:?}"
                 ))?;
             }
-            f.write_str("\",\n")?;
+            f.write_str("\n")?;
         }
         f.write_str("    ],\n    styles: [\n")?;
         for s in styles {
@@ -468,6 +469,24 @@ mod tests {
         let expected = "Buffer {
     area: Rect { x: 0, y: 0, width: 0, height: 0 }
 }";
+        assert_eq!(result, expected);
+    }
+
+    #[cfg(feature = "underline-color")]
+    #[test]
+    fn debug_grapheme_override() {
+        let buffer = Buffer::with_lines(["a🦀b"]);
+        let result = format!("{buffer:?}");
+        println!("{result}");
+        let expected = r#"Buffer {
+    area: Rect { x: 0, y: 0, width: 4, height: 1 },
+    content: [
+        "a🦀b", // hidden by multi-width symbols: [(2, " ")]
+    ],
+    styles: [
+        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+    ]
+}"#;
         assert_eq!(result, expected);
     }
 

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -381,14 +381,13 @@ impl fmt::Debug for Buffer {
     /// * `styles`: displayed as a list of: `{ x: 1, y: 2, fg: Color::Red, bg: Color::Blue,
     ///   modifier: Modifier::BOLD }` only showing a value when there is a change in style.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("Buffer {{\n    area: {:?}", &self.area))?;
+
         if self.area.is_empty() {
-            return f.write_fmt(format_args!("Buffer {{\n    area: {:?}\n}}", self.area));
+            return f.write_str("\n}");
         }
 
-        f.write_fmt(format_args!(
-            "Buffer {{\n    area: {:?},\n    content: [\n",
-            &self.area
-        ))?;
+        f.write_str(",\n    content: [\n")?;
         let mut last_style = None;
         let mut styles = vec![];
         for (y, line) in self.content.chunks(self.area.width as usize).enumerate() {

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -466,9 +466,7 @@ mod tests {
         let buffer = Buffer::empty(Rect::ZERO);
         let result = format!("{buffer:?}");
         println!("{result}");
-        let expected = "Buffer {
-    area: Rect { x: 0, y: 0, width: 0, height: 0 }
-}";
+        let expected = "Buffer {\n    area: Rect { x: 0, y: 0, width: 0, height: 0 }\n}";
         assert_eq!(result, expected);
     }
 
@@ -478,15 +476,18 @@ mod tests {
         let buffer = Buffer::with_lines(["a🦀b"]);
         let result = format!("{buffer:?}");
         println!("{result}");
-        let expected = r#"Buffer {
-    area: Rect { x: 0, y: 0, width: 4, height: 1 },
-    content: [
-        "a🦀b", // hidden by multi-width symbols: [(2, " ")]
-    ],
-    styles: [
-        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
-    ]
-}"#;
+        let expected = indoc::indoc!(
+            r#"
+            Buffer {
+                area: Rect { x: 0, y: 0, width: 4, height: 1 },
+                content: [
+                    "a🦀b", // hidden by multi-width symbols: [(2, " ")]
+                ],
+                styles: [
+                    x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+                ]
+            }"#
+        );
         assert_eq!(result, expected);
     }
 
@@ -506,29 +507,35 @@ mod tests {
         let result = format!("{buffer:?}");
         println!("{result}");
         #[cfg(feature = "underline-color")]
-        let expected = r#"Buffer {
-    area: Rect { x: 0, y: 0, width: 12, height: 2 },
-    content: [
-        "Hello World!",
-        "G'day World!",
-    ],
-    styles: [
-        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
-        x: 0, y: 1, fg: Green, bg: Yellow, underline: Reset, modifier: BOLD,
-    ]
-}"#;
+        let expected = indoc::indoc!(
+            r#"
+            Buffer {
+                area: Rect { x: 0, y: 0, width: 12, height: 2 },
+                content: [
+                    "Hello World!",
+                    "G'day World!",
+                ],
+                styles: [
+                    x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+                    x: 0, y: 1, fg: Green, bg: Yellow, underline: Reset, modifier: BOLD,
+                ]
+            }"#
+        );
         #[cfg(not(feature = "underline-color"))]
-        let expected = r#"Buffer {
-    area: Rect { x: 0, y: 0, width: 12, height: 2 },
-    content: [
-        "Hello World!",
-        "G'day World!",
-    ],
-    styles: [
-        x: 0, y: 0, fg: Reset, bg: Reset, modifier: NONE,
-        x: 0, y: 1, fg: Green, bg: Yellow, modifier: BOLD,
-    ]
-}"#;
+        let expected = indoc::indoc!(
+            r#"
+            Buffer {
+                area: Rect { x: 0, y: 0, width: 12, height: 2 },
+                content: [
+                    "Hello World!",
+                    "G'day World!",
+                ],
+                styles: [
+                    x: 0, y: 0, fg: Reset, bg: Reset, modifier: NONE,
+                    x: 0, y: 1, fg: Green, bg: Yellow, modifier: BOLD,
+                ]
+            }"#
+        );
 
         assert_eq!(result, expected);
     }


### PR DESCRIPTION
Fix panic in `Debug for Buffer` when `width == 0`.
Also corrects the output when symbols are overridden.

---

Let's do some final testing for #1007… test runner aborts on panic in panic handler. Nice. :ghost: 