### PR TITLE
feat: Make Stylize's `.bg(color)` generic

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -10,6 +10,8 @@ GitHub with a [breaking change] label.
 
 This is a quick summary of the sections below:
 
+- [v0.26.1](#v0261)
+  - `Stylize::bg()` now accepts `Into<Color>`
 - [v0.26.0](#v0260)
   - `Flex::Start` is the new default flex mode for `Layout`
   - `patch_style` & `reset_style` now consume and return `Self`
@@ -47,6 +49,14 @@ This is a quick summary of the sections below:
   - MSRV is now 1.63.0
   - `List` no longer ignores empty strings
 
+## [v0.26.1](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.1)
+
+### `Stylize::bg()` now accepts `Into<Color>` ([#1099])
+
+[#1099]: https://github.com/ratatui-org/ratatui/pull/1099
+
+Previously, `Stylize::bg()` accepted `Color` but now accepts `Into<Color>`. This allows more flexible types from calling scopes, though it can break some type inference in the calling scope.
+
 ## [v0.26.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.0)
 
 ### `Flex::Start` is the new default flex mode for `Layout` ([#881])
@@ -74,7 +84,7 @@ existing layouts with `Flex::Start`. However, to get old behavior, use `Flex::Le
 
 [#774]: https://github.com/ratatui-org/ratatui/pull/774
 
-Previously, `Table::new()` accepted `IntoIterator<Item=Row<'a>>`.  The argument change to
+Previously, `Table::new()` accepted `IntoIterator<Item=Row<'a>>`. The argument change to
 `IntoIterator<Item: Into<Row<'a>>>`, This allows more flexible types from calling scopes, though it
 can some break type inference in the calling scope for empty containers.
 
@@ -91,7 +101,7 @@ This can be resolved either by providing an explicit type (e.g. `Vec::<Row>::new
 
 [#776]: https://github.com/ratatui-org/ratatui/pull/776
 
-Previously, `Tabs::new()` accepted `Vec<T>` where `T: Into<Line<'a>>`.  This allows more flexible
+Previously, `Tabs::new()` accepted `Vec<T>` where `T: Into<Line<'a>>`. This allows more flexible
 types from calling scopes, though it can break some type inference in the calling scope.
 
 This typically occurs when collecting an iterator prior to calling `Tabs::new`, and can be resolved

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -362,6 +362,11 @@ mod tests {
         let cyan_fg = Style::default().fg(Color::Cyan);
 
         assert_eq!("hello".cyan(), Span::styled("hello", cyan_fg));
+
+        assert_eq!(
+            "hello".fg(crossterm::style::Color::DarkCyan),
+            Span::styled("hello", cyan_fg)
+        );
     }
 
     #[test]
@@ -369,6 +374,11 @@ mod tests {
         let cyan_bg = Style::default().bg(Color::Cyan);
 
         assert_eq!("hello".on_cyan(), Span::styled("hello", cyan_bg));
+
+        assert_eq!(
+            "hello".bg(crossterm::style::Color::DarkCyan),
+            Span::styled("hello", cyan_bg)
+        );
     }
 
     #[test]

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -362,11 +362,6 @@ mod tests {
         let cyan_fg = Style::default().fg(Color::Cyan);
 
         assert_eq!("hello".cyan(), Span::styled("hello", cyan_fg));
-
-        assert_eq!(
-            "hello".fg(crossterm::style::Color::DarkCyan),
-            Span::styled("hello", cyan_fg)
-        );
     }
 
     #[test]
@@ -374,11 +369,6 @@ mod tests {
         let cyan_bg = Style::default().bg(Color::Cyan);
 
         assert_eq!("hello".on_cyan(), Span::styled("hello", cyan_bg));
-
-        assert_eq!(
-            "hello".bg(crossterm::style::Color::DarkCyan),
-            Span::styled("hello", cyan_bg)
-        );
     }
 
     #[test]

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -137,9 +137,9 @@ macro_rules! modifier {
 /// ```
 pub trait Stylize<'a, T>: Sized {
     #[must_use = "`bg` returns the modified style without modifying the original"]
-    fn bg<S: Into<Color>>(self, color: S) -> T;
+    fn bg<C: Into<Color>>(self, color: C) -> T;
     #[must_use = "`fg` returns the modified style without modifying the original"]
-    fn fg<S: Into<Color>>(self, color: S) -> T;
+    fn fg<C: Into<Color>>(self, color: C) -> T;
     #[must_use = "`reset` returns the modified style without modifying the original"]
     fn reset(self) -> T;
     #[must_use = "`add_modifier` returns the modified style without modifying the original"]
@@ -179,12 +179,12 @@ impl<'a, T, U> Stylize<'a, T> for U
 where
     U: Styled<Item = T>,
 {
-    fn bg<S: Into<Color>>(self, color: S) -> T {
+    fn bg<C: Into<Color>>(self, color: C) -> T {
         let style = self.style().bg(color.into());
         self.set_style(style)
     }
 
-    fn fg<S: Into<Color>>(self, color: S) -> T {
+    fn fg<C: Into<Color>>(self, color: C) -> T {
         let style = self.style().fg(color.into());
         self.set_style(style)
     }

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -137,7 +137,7 @@ macro_rules! modifier {
 /// ```
 pub trait Stylize<'a, T>: Sized {
     #[must_use = "`bg` returns the modified style without modifying the original"]
-    fn bg(self, color: Color) -> T;
+    fn bg<S: Into<Color>>(self, color: S) -> T;
     #[must_use = "`fg` returns the modified style without modifying the original"]
     fn fg<S: Into<Color>>(self, color: S) -> T;
     #[must_use = "`reset` returns the modified style without modifying the original"]
@@ -179,8 +179,8 @@ impl<'a, T, U> Stylize<'a, T> for U
 where
     U: Styled<Item = T>,
 {
-    fn bg(self, color: Color) -> T {
-        let style = self.style().bg(color);
+    fn bg<S: Into<Color>>(self, color: S) -> T {
+        let style = self.style().bg(color.into());
         self.set_style(style)
     }
 


### PR DESCRIPTION
This PR makes `.bg(color)` generic accepting anything that can be converted into `Color`; similar to the `.fg(color)` method on the same trait