### PR TITLE
build: add underline-color to all features flag in makefile

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,11 +7,12 @@ skip_core_tasks = true
 # all features except the backend ones
 ALL_FEATURES = "all-widgets,macros,serde"
 
+[env.ALL_FEATURES_FLAG]
 # Windows does not support building termion, so this avoids the build failure by providing two
 # sets of flags, one for Windows and one for other platforms.
-# Windows: --features=all-widgets,macros,serde,crossterm,termwiz,underline-color
-# Other: --features=all-widgets,macros,serde,crossterm,termion,termwiz,underline-color
-ALL_FEATURES_FLAG = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "--features=all-widgets,macros,serde,crossterm,termion,termwiz,unstable", mapping = { "windows" = "--features=all-widgets,macros,serde,crossterm,termwiz,unstable" } }
+source = "${CARGO_MAKE_RUST_TARGET_OS}"
+default_value = "--features=all-widgets,macros,serde,crossterm,termion,termwiz,underline-color,unstable"
+mapping = { "windows" = "--features=all-widgets,macros,serde,crossterm,termwiz,underline-color,unstable" }
 
 [tasks.default]
 alias = "ci"

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -574,15 +574,20 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "underline-color"))]
     fn from_cell_attribute_for_style() {
         use crate::style::Stylize;
 
+        #[cfg(feature = "underline-color")]
+        const STYLE: Style = Style::new()
+            .underline_color(Color::Reset)
+            .fg(Color::Reset)
+            .bg(Color::Reset);
+        #[cfg(not(feature = "underline-color"))]
+        const STYLE: Style = Style::new().fg(Color::Reset).bg(Color::Reset);
+
         // default
-        assert_eq!(
-            Style::from(CellAttributes::default()),
-            Style::new().fg(Color::Reset).bg(Color::Reset)
-        );
+        assert_eq!(Style::from(CellAttributes::default()), STYLE);
+
         // foreground color
         assert_eq!(
             Style::from(
@@ -590,7 +595,7 @@ mod tests {
                     .set_foreground(ColorAttribute::PaletteIndex(31))
                     .to_owned()
             ),
-            Style::new().fg(Color::Indexed(31)).bg(Color::Reset)
+            STYLE.fg(Color::Indexed(31))
         );
         // background color
         assert_eq!(
@@ -599,7 +604,7 @@ mod tests {
                     .set_background(ColorAttribute::PaletteIndex(31))
                     .to_owned()
             ),
-            Style::new().fg(Color::Reset).bg(Color::Indexed(31))
+            STYLE.bg(Color::Indexed(31))
         );
         // underlined
         assert_eq!(
@@ -608,12 +613,12 @@ mod tests {
                     .set_underline(Underline::Single)
                     .to_owned()
             ),
-            Style::new().fg(Color::Reset).bg(Color::Reset).underlined()
+            STYLE.underlined()
         );
         // blink
         assert_eq!(
             Style::from(CellAttributes::default().set_blink(Blink::Slow).to_owned()),
-            Style::new().fg(Color::Reset).bg(Color::Reset).slow_blink()
+            STYLE.slow_blink()
         );
         // intensity
         assert_eq!(
@@ -622,44 +627,38 @@ mod tests {
                     .set_intensity(Intensity::Bold)
                     .to_owned()
             ),
-            Style::new().fg(Color::Reset).bg(Color::Reset).bold()
+            STYLE.bold()
         );
         // italic
         assert_eq!(
             Style::from(CellAttributes::default().set_italic(true).to_owned()),
-            Style::new().fg(Color::Reset).bg(Color::Reset).italic()
+            STYLE.italic()
         );
         // reversed
         assert_eq!(
             Style::from(CellAttributes::default().set_reverse(true).to_owned()),
-            Style::new().fg(Color::Reset).bg(Color::Reset).reversed()
+            STYLE.reversed()
         );
         // strikethrough
         assert_eq!(
             Style::from(CellAttributes::default().set_strikethrough(true).to_owned()),
-            Style::new().fg(Color::Reset).bg(Color::Reset).crossed_out()
+            STYLE.crossed_out()
         );
         // hidden
         assert_eq!(
             Style::from(CellAttributes::default().set_invisible(true).to_owned()),
-            Style::new().fg(Color::Reset).bg(Color::Reset).hidden()
+            STYLE.hidden()
         );
-    }
 
-    #[test]
-    #[cfg(feature = "underline-color")]
-    fn from_cell_attributes_with_underline_color() {
         // underline color
+        #[cfg(feature = "underline-color")]
         assert_eq!(
             Style::from(
                 CellAttributes::default()
                     .set_underline_color(AnsiColor::Red)
                     .to_owned()
             ),
-            Style::new()
-                .fg(Color::Reset)
-                .bg(Color::Reset)
-                .underline_color(Color::Indexed(9))
+            STYLE.underline_color(Color::Indexed(9))
         );
     }
 }

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -407,7 +407,6 @@ fn u16_max(i: usize) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::style::Stylize;
 
     mod into_color {
         use Color as C;
@@ -577,6 +576,8 @@ mod tests {
     #[test]
     #[cfg(not(feature = "underline-color"))]
     fn from_cell_attribute_for_style() {
+        use crate::style::Stylize;
+
         // default
         assert_eq!(
             Style::from(CellAttributes::default()),


### PR DESCRIPTION
Ensures that we upload coverage details for the underline-color tests (at the expense of possible removing some coverage where the feature is not enabled). Given `underline-color` is a default feature this is sensible.

Also fixes up a small build warning that pops up when not building with the underline-color feature 