### PR TITLE
chore: Revert "Make Stylize's `.bg(color)` generic"

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -10,8 +10,6 @@ GitHub with a [breaking change] label.
 
 This is a quick summary of the sections below:
 
-- [v0.26.1](#v0261)
-  - `Stylize::bg()` now accepts `Into<Color>`
 - [v0.26.0](#v0260)
   - `Flex::Start` is the new default flex mode for `Layout`
   - `patch_style` & `reset_style` now consume and return `Self`
@@ -49,14 +47,6 @@ This is a quick summary of the sections below:
   - MSRV is now 1.63.0
   - `List` no longer ignores empty strings
 
-## [v0.26.1](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.1)
-
-### `Stylize::bg()` now accepts `Into<Color>` ([#1099])
-
-[#1099]: https://github.com/ratatui-org/ratatui/pull/1099
-
-Previously, `Stylize::bg()` accepted `Color` but now accepts `Into<Color>`. This allows more flexible types from calling scopes, though it can break some type inference in the calling scope.
-
 ## [v0.26.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.0)
 
 ### `Flex::Start` is the new default flex mode for `Layout` ([#881])
@@ -84,7 +74,7 @@ existing layouts with `Flex::Start`. However, to get old behavior, use `Flex::Le
 
 [#774]: https://github.com/ratatui-org/ratatui/pull/774
 
-Previously, `Table::new()` accepted `IntoIterator<Item=Row<'a>>`. The argument change to
+Previously, `Table::new()` accepted `IntoIterator<Item=Row<'a>>`.  The argument change to
 `IntoIterator<Item: Into<Row<'a>>>`, This allows more flexible types from calling scopes, though it
 can some break type inference in the calling scope for empty containers.
 
@@ -101,7 +91,7 @@ This can be resolved either by providing an explicit type (e.g. `Vec::<Row>::new
 
 [#776]: https://github.com/ratatui-org/ratatui/pull/776
 
-Previously, `Tabs::new()` accepted `Vec<T>` where `T: Into<Line<'a>>`. This allows more flexible
+Previously, `Tabs::new()` accepted `Vec<T>` where `T: Into<Line<'a>>`.  This allows more flexible
 types from calling scopes, though it can break some type inference in the calling scope.
 
 This typically occurs when collecting an iterator prior to calling `Tabs::new`, and can be resolved

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -137,9 +137,9 @@ macro_rules! modifier {
 /// ```
 pub trait Stylize<'a, T>: Sized {
     #[must_use = "`bg` returns the modified style without modifying the original"]
-    fn bg<C: Into<Color>>(self, color: C) -> T;
+    fn bg(self, color: Color) -> T;
     #[must_use = "`fg` returns the modified style without modifying the original"]
-    fn fg<C: Into<Color>>(self, color: C) -> T;
+    fn fg<S: Into<Color>>(self, color: S) -> T;
     #[must_use = "`reset` returns the modified style without modifying the original"]
     fn reset(self) -> T;
     #[must_use = "`add_modifier` returns the modified style without modifying the original"]
@@ -179,12 +179,12 @@ impl<'a, T, U> Stylize<'a, T> for U
 where
     U: Styled<Item = T>,
 {
-    fn bg<C: Into<Color>>(self, color: C) -> T {
-        let style = self.style().bg(color.into());
+    fn bg(self, color: Color) -> T {
+        let style = self.style().bg(color);
         self.set_style(style)
     }
 
-    fn fg<C: Into<Color>>(self, color: C) -> T {
+    fn fg<S: Into<Color>>(self, color: S) -> T {
         let style = self.style().fg(color.into());
         self.set_style(style)
     }


### PR DESCRIPTION
This reverts commit ec763af8512df731799c8f30c38c37252068a4c4 from #1099