### PR TITLE
build(bench): improve benchmark consistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,11 @@ all-features = true
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+# Improve benchmark consistency
+[profile.bench]
+codegen-units = 1
+lto = true
+
 [[bench]]
 name = "barchart"
 harness = false


### PR DESCRIPTION
Codegen units are optimized on their own. Per default bench / release have 16 codegen units. What ends up in a codeget unit is rather random and can influence a benchmark result as a code change can move stuff into a different codegen unit → prevent / allow LLVM optimizations unrelated to the actual change.

More details: https://doc.rust-lang.org/cargo/reference/profiles.html