### PR TITLE
refactor(cell): reset instead of applying default

### DIFF
--- a/examples/demo2/destroy.rs
+++ b/examples/demo2/destroy.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 use rand_chacha::rand_core::SeedableRng;
-use ratatui::{buffer::Cell, layout::Flex, prelude::*};
+use ratatui::{layout::Flex, prelude::*};
 use unicode_width::UnicodeWidthStr;
 
 use crate::big_text::{BigTextBuilder, PixelSize};
@@ -59,7 +59,7 @@ fn drip(frame_count: usize, area: Rect, buf: &mut Buffer) {
             if rng.gen_ratio(1, 10) {
                 *dest = src;
             } else {
-                *dest = Cell::default();
+                dest.reset();
             }
         } else {
             // move the pixel down one row

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -170,26 +170,29 @@ impl Backend for TestBackend {
     }
 
     fn clear_region(&mut self, clear_type: super::ClearType) -> io::Result<()> {
-        match clear_type {
-            ClearType::All => self.clear()?,
+        let region = match clear_type {
+            ClearType::All => return self.clear(),
             ClearType::AfterCursor => {
                 let index = self.buffer.index_of(self.pos.0, self.pos.1) + 1;
-                self.buffer.content[index..].fill(Cell::default());
+                &mut self.buffer.content[index..]
             }
             ClearType::BeforeCursor => {
                 let index = self.buffer.index_of(self.pos.0, self.pos.1);
-                self.buffer.content[..index].fill(Cell::default());
+                &mut self.buffer.content[..index]
             }
             ClearType::CurrentLine => {
                 let line_start_index = self.buffer.index_of(0, self.pos.1);
                 let line_end_index = self.buffer.index_of(self.width - 1, self.pos.1);
-                self.buffer.content[line_start_index..=line_end_index].fill(Cell::default());
+                &mut self.buffer.content[line_start_index..=line_end_index]
             }
             ClearType::UntilNewLine => {
                 let index = self.buffer.index_of(self.pos.0, self.pos.1);
                 let line_end_index = self.buffer.index_of(self.width - 1, self.pos.1);
-                self.buffer.content[index..=line_end_index].fill(Cell::default());
+                &mut self.buffer.content[index..=line_end_index]
             }
+        };
+        for cell in region {
+            cell.reset();
         }
         Ok(())
     }

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -285,8 +285,8 @@ impl Buffer {
 
     /// Reset all cells in the buffer
     pub fn reset(&mut self) {
-        for c in &mut self.content {
-            c.reset();
+        for cell in &mut self.content {
+            cell.reset();
         }
     }
 
@@ -303,7 +303,7 @@ impl Buffer {
             let k = ((y - area.y) * area.width + x - area.x) as usize;
             if i != k {
                 self.content[k] = self.content[i].clone();
-                self.content[i] = Cell::default();
+                self.content[i].reset();
             }
         }
 


### PR DESCRIPTION
Using reset is clearer to me what actually happens. On the other case a struct is created to override the old one completely which basically does the same in a less clear way.