### PR TITLE
fix(color): change parse error message to single color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ wildcard_imports = "allow"
 
 # nursery or restricted
 as_underscore = "warn"
+assertions_on_result_states = "warn"
 deref_by_slicing = "warn"
 else_if_without_else = "warn"
 empty_line_after_doc_comments = "warn"

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -187,7 +187,7 @@ impl<'de> serde::Deserialize<'de> for Color {
     /// assert!(err.is_data());
     /// assert_eq!(
     ///     err.to_string(),
-    ///     "Failed to parse Colors at line 1 column 20"
+    ///     "Failed to parse Color at line 1 column 20"
     /// );
     ///
     /// // Deserializing from the previous serialization implementation
@@ -225,7 +225,7 @@ impl<'de> serde::Deserialize<'de> for Color {
         }
 
         let multi_type = ColorFormat::deserialize(deserializer)
-            .map_err(|err| serde::de::Error::custom(format!("Failed to parse Colors: {err}")))?;
+            .map_err(|err| serde::de::Error::custom(format!("Failed to parse Color: {err}")))?;
         match multi_type {
             ColorFormat::V2(s) => FromStr::from_str(&s).map_err(serde::de::Error::custom),
             ColorFormat::V1(color_wrapper) => match color_wrapper {
@@ -242,7 +242,7 @@ pub struct ParseColorError;
 
 impl fmt::Display for ParseColorError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Failed to parse Colors")
+        f.pad("Failed to parse Color")
     }
 }
 
@@ -654,14 +654,20 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn deserialize_error() {
+    #[should_panic = "Failed to parse Color"]
+    fn deserialize_unknown_string_errors() {
         let color: Result<_, serde::de::value::Error> =
             Color::deserialize("invalid".into_deserializer());
-        assert!(color.is_err());
+        color.unwrap();
+    }
 
+    #[cfg(feature = "serde")]
+    #[test]
+    #[should_panic = "Failed to parse Color"]
+    fn deserialize_wrong_hex_errors() {
         let color: Result<_, serde::de::value::Error> =
             Color::deserialize("#00000000".into_deserializer());
-        assert!(color.is_err());
+        color.unwrap();
     }
 
     #[cfg(feature = "serde")]

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -185,10 +185,7 @@ impl<'de> serde::Deserialize<'de> for Color {
     ///
     /// let err = serde_json::from_str::<Theme>(r#"{"color": "invalid"}"#).unwrap_err();
     /// assert!(err.is_data());
-    /// assert_eq!(
-    ///     err.to_string(),
-    ///     "Failed to parse Color at line 1 column 20"
-    /// );
+    /// assert_eq!(err.to_string(), "Failed to parse Color at line 1 column 20");
     ///
     /// // Deserializing from the previous serialization implementation
     /// let theme: Theme = serde_json::from_str(r#"{"color": {"Rgb":[255,0,255]}}"#)?;


### PR DESCRIPTION
Found while enabling <https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_result_states>

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
