### PR TITLE
refactor: dont manually impl Default for defaults

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -222,7 +222,7 @@ impl fmt::Debug for Modifier {
 ///     buffer.get(0, 0).style(),
 /// );
 /// ```
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Style {
     pub fg: Option<Color>,
@@ -231,12 +231,6 @@ pub struct Style {
     pub underline_color: Option<Color>,
     pub add_modifier: Modifier,
     pub sub_modifier: Modifier,
-}
-
-impl Default for Style {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl Styled for Style {

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -33,7 +33,7 @@ use crate::{prelude::*, widgets::Block};
 ///
 /// - [`LineGauge`] for a thin progress bar
 #[allow(clippy::struct_field_names)] // gauge_style needs to be differentiated to style
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Gauge<'a> {
     block: Option<Block<'a>>,
     ratio: f64,
@@ -41,19 +41,6 @@ pub struct Gauge<'a> {
     use_unicode: bool,
     style: Style,
     gauge_style: Style,
-}
-
-impl<'a> Default for Gauge<'a> {
-    fn default() -> Self {
-        Self {
-            block: None,
-            ratio: 0.0,
-            label: None,
-            use_unicode: false,
-            style: Style::default(),
-            gauge_style: Style::default(),
-        }
-    }
 }
 
 impl<'a> Gauge<'a> {

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -132,7 +132,7 @@ pub enum ScrollbarOrientation {
 ///
 /// If you don't have multi-line content, you can leave the `viewport_content_length` set to the
 /// default and it'll use the track size as a `viewport_content_length`.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollbarState {
     /// The total length of the scrollable content.
@@ -388,12 +388,6 @@ impl<'a> Scrollbar<'a> {
         self.begin_style = style;
         self.end_style = style;
         self
-    }
-}
-
-impl Default for ScrollbarState {
-    fn default() -> Self {
-        Self::new(0)
     }
 }
 

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -30,7 +30,7 @@ use crate::{prelude::*, widgets::Block};
 ///     .direction(RenderDirection::RightToLeft)
 ///     .style(Style::default().red().on_white());
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Sparkline<'a> {
     /// A block to wrap the widget in
     block: Option<Block<'a>>,
@@ -57,19 +57,6 @@ pub enum RenderDirection {
     LeftToRight,
     /// The first value is on the right, going to the left
     RightToLeft,
-}
-
-impl<'a> Default for Sparkline<'a> {
-    fn default() -> Self {
-        Self {
-            block: None,
-            style: Style::default(),
-            data: &[],
-            max: None,
-            bar_set: symbols::bar::NINE_LEVELS,
-            direction: RenderDirection::LeftToRight,
-        }
-    }
 }
 
 impl<'a> Sparkline<'a> {


### PR DESCRIPTION
Replace `impl Default` by `#[derive(Default)]` when its implementation equals.

---

Funny finding, the default Canvas doesn't use the default Marker:

https://github.com/ratatui-org/ratatui/blob/4f7791079edd16b54dc8cdfc95bb72b282a09576/src/widgets/canvas.rs#L621

https://github.com/ratatui-org/ratatui/blob/4f7791079edd16b54dc8cdfc95bb72b282a09576/src/symbols.rs#L489-L492