### PR TITLE
perf(buffer)!: filled moves the cell to be filled

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -12,6 +12,7 @@ This is a quick summary of the sections below:
 
 - [Unreleased](#unreleased)
   - `Rect::inner` takes `Margin` directly instead of reference
+  - `Buffer::fill` takes `Cell` directly instead of reference
   - `Stylize::bg()` now accepts `Into<Color>`
   - Removed deprecated `List::start_corner`
 - [v0.26.0](#v0260)
@@ -65,6 +66,17 @@ This is a quick summary of the sections below:
      vertical: 0,
      horizontal: 2,
  });
+```
+
+### `Buffer::fill` takes `Cell` directly instead of reference ([#1148])
+
+[#1148]: https://github.com/ratatui-org/ratatui/pull/1148
+
+`Buffer::fill` moves the `Cell` instead of taking a reference.
+
+```diff
+-Buffer::fill(area, &Cell::new("X"));
++Buffer::fill(area, Cell::new("X"));
 ```
 
 ### `Stylize::bg()` now accepts `Into<Color>` ([#1103])

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -12,7 +12,7 @@ This is a quick summary of the sections below:
 
 - [Unreleased](#unreleased)
   - `Rect::inner` takes `Margin` directly instead of reference
-  - `Buffer::fill` takes `Cell` directly instead of reference
+  - `Buffer::filled` takes `Cell` directly instead of reference
   - `Stylize::bg()` now accepts `Into<Color>`
   - Removed deprecated `List::start_corner`
 - [v0.26.0](#v0260)
@@ -68,15 +68,15 @@ This is a quick summary of the sections below:
  });
 ```
 
-### `Buffer::fill` takes `Cell` directly instead of reference ([#1148])
+### `Buffer::filled` takes `Cell` directly instead of reference ([#1148])
 
 [#1148]: https://github.com/ratatui-org/ratatui/pull/1148
 
-`Buffer::fill` moves the `Cell` instead of taking a reference.
+`Buffer::filled` moves the `Cell` instead of taking a reference.
 
 ```diff
--Buffer::fill(area, &Cell::new("X"));
-+Buffer::fill(area, Cell::new("X"));
+-Buffer::filled(area, &Cell::new("X"));
++Buffer::filled(area, Cell::new("X"));
 ```
 
 ### `Stylize::bg()` now accepts `Into<Color>` ([#1103])

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1169,7 +1169,7 @@ mod tests {
         fn render_truncates_away_from_0x0(#[case] alignment: Alignment, #[case] expected: &str) {
             let line = Line::from(vec![Span::raw("a🦀b"), Span::raw("c🦀d")]).alignment(alignment);
             // Fill buffer with stuff to ensure the output is indeed padded
-            let mut buf = Buffer::filled(Rect::new(0, 0, 10, 1), &Cell::new("X"));
+            let mut buf = Buffer::filled(Rect::new(0, 0, 10, 1), Cell::new("X"));
             let area = Rect::new(2, 0, 6, 1);
             line.render_ref(area, &mut buf);
             assert_eq!(buf, Buffer::with_lines([expected]));
@@ -1188,7 +1188,7 @@ mod tests {
             let line = Line::from(vec![Span::raw("a🦀b"), Span::raw("c🦀d")]).right_aligned();
             let area = Rect::new(0, 0, buf_width, 1);
             // Fill buffer with stuff to ensure the output is indeed padded
-            let mut buf = Buffer::filled(area, &Cell::new("X"));
+            let mut buf = Buffer::filled(area, Cell::new("X"));
             line.render_ref(buf.area, &mut buf);
             assert_eq!(buf, Buffer::with_lines([expected]));
         }

--- a/src/widgets/canvas.rs
+++ b/src/widgets/canvas.rs
@@ -817,7 +817,7 @@ mod tests {
     // results in the expected output
     fn test_marker(marker: Marker, expected: &str) {
         let area = Rect::new(0, 0, 5, 5);
-        let mut buf = Buffer::filled(area, &Cell::new("x"));
+        let mut buf = Buffer::filled(area, Cell::new("x"));
         let horizontal_line = Line {
             x1: 0.0,
             y1: 0.0,

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -239,7 +239,7 @@ mod tests {
     // filled with x symbols to make it easier to assert on the result
     fn render(widget: Sparkline, width: u16) -> Buffer {
         let area = Rect::new(0, 0, width, 1);
-        let mut buffer = Buffer::filled(area, &Cell::new("x"));
+        let mut buffer = Buffer::filled(area, Cell::new("x"));
         widget.render(area, &mut buffer);
         buffer
     }


### PR DESCRIPTION
This removes a clone from inside the method allowing the user to do it explicitly when needing.

BREAKING CHANGE: `Buffer::filled` moves the cell instead of taking a reference.

```diff
-Buffer::filled(area, &Cell::new("X"));
+Buffer::filled(area, Cell::new("X"));
```

---

https://github.com/ratatui-org/ratatui/pull/1143#issuecomment-2131247181