### PR TITLE
refactor: expand glob imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ rest_pat_in_fully_bound_structs = "warn"
 string_lit_chars_any = "warn"
 string_slice = "warn"
 string_to_string = "warn"
+unnecessary_self_imports = "warn"
 use_self = "warn"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"
 must_use_candidate = "allow"
-wildcard_imports = "allow"
 
 # nursery or restricted
 as_underscore = "warn"
@@ -98,6 +97,7 @@ string_slice = "warn"
 string_to_string = "warn"
 unnecessary_self_imports = "warn"
 use_self = "warn"
+wildcard_imports = "deny"
 
 [features]
 #! The crate provides a set of optional features that can be enabled in your `cargo.toml` file.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,6 @@ string_slice = "warn"
 string_to_string = "warn"
 unnecessary_self_imports = "warn"
 use_self = "warn"
-wildcard_imports = "deny"
 
 [features]
 #! The crate provides a set of optional features that can be enabled in your `cargo.toml` file.

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -25,7 +25,11 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    terminal::{Frame, Terminal},
+    text::{Line, Span},
     widgets::{Bar, BarChart, BarGroup, Block, Paragraph},
 };
 

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -27,7 +27,11 @@ use crossterm::{
 };
 use itertools::Itertools;
 use ratatui::{
-    prelude::*,
+    backend::CrosstermBackend,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Style, Stylize},
+    terminal::Frame,
+    text::Line,
     widgets::{
         block::{Position, Title},
         Block, BorderType, Borders, Padding, Paragraph, Wrap,

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::wildcard_imports)]
-
 use std::{error::Error, io};
 
 use crossterm::{
@@ -26,8 +24,8 @@ use ratatui::{
     backend::CrosstermBackend,
     layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
-    terminal::{Frame, Terminal},
     widgets::calendar::{CalendarEventStore, DateStyler, Monthly},
+    Frame, Terminal,
 };
 use time::{Date, Month, OffsetDateTime};
 
@@ -58,8 +56,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn draw(f: &mut Frame) {
-    let app_area = f.size();
+fn draw(frame: &mut Frame) {
+    let app_area = frame.size();
 
     let calarea = Rect {
         x: app_area.x + 1,
@@ -86,7 +84,7 @@ fn draw(f: &mut Frame) {
     });
     for col in cols {
         let cal = cals::get_cal(start.month(), start.year(), &list);
-        f.render_widget(cal, col);
+        frame.render_widget(cal, col);
         start = start.replace_month(start.month().next()).unwrap();
     }
 }

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -22,7 +22,13 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{prelude::*, widgets::calendar::*};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    terminal::{Frame, Terminal},
+    widgets::calendar::{CalendarEventStore, DateStyler, Monthly},
+};
 use time::{Date, Month, OffsetDateTime};
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -170,6 +170,7 @@ fn make_dates(current_year: i32) -> CalendarEventStore {
 }
 
 mod cals {
+    #[allow(clippy::wildcard_imports)]
     use super::*;
 
     pub fn get_cal<'a, DS: DateStyler>(m: Month, y: i32, es: DS) -> Monthly<'a, DS> {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::wildcard_imports)]
-
 use std::{
     io::{self, stdout, Stdout},
     time::{Duration, Instant},

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -26,8 +26,15 @@ use crossterm::{
     ExecutableCommand,
 };
 use ratatui::{
-    prelude::*,
-    widgets::{canvas::*, *},
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Stylize},
+    symbols::Marker,
+    terminal::{Frame, Terminal},
+    widgets::{
+        canvas::{Canvas, Circle, Map, MapResolution, Rectangle},
+        Block, Widget,
+    },
 };
 
 fn main() -> io::Result<()> {

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -25,7 +25,12 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Color, Modifier, Style, Stylize},
+    symbols::{self, Marker},
+    terminal::{Frame, Terminal},
+    text::Span,
     widgets::{block::Title, Axis, Block, Chart, Dataset, GraphType, LegendPosition},
 };
 

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -30,7 +30,11 @@ use crossterm::{
 };
 use itertools::Itertools;
 use ratatui::{
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Color, Style, Stylize},
+    terminal::{Frame, Terminal},
+    text::Line,
     widgets::{Block, Borders, Paragraph},
 };
 

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -39,7 +39,15 @@ use crossterm::{
     ExecutableCommand,
 };
 use palette::{convert::FromColorUnclamped, Okhsv, Srgb};
-use ratatui::prelude::*;
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    style::Color,
+    terminal::Terminal,
+    text::Text,
+    widgets::Widget,
+};
 
 #[derive(Debug, Default)]
 struct App {
@@ -142,7 +150,7 @@ impl App {
 impl Widget for &mut App {
     fn render(self, area: Rect, buf: &mut Buffer) {
         #[allow(clippy::enum_glob_use)]
-        use Constraint::*;
+        use Constraint::{Length, Min};
         let [top, colors] = Layout::vertical([Length(1), Min(0)]).areas(area);
         let [title, fps] = Layout::horizontal([Min(0), Length(8)]).areas(top);
         Text::from("colors_rgb example. Press q to quit")

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -149,7 +149,6 @@ impl App {
 /// to update the colors to render.
 impl Widget for &mut App {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        #[allow(clippy::enum_glob_use)]
         use Constraint::{Length, Min};
         let [top, colors] = Layout::vertical([Length(1), Min(0)]).areas(area);
         let [title, fps] = Layout::horizontal([Min(0), Length(8)]).areas(top);

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::enum_glob_use, clippy::wildcard_imports)]
-
 use std::io::{self, stdout};
 
 use color_eyre::{config::HookBuilder, Result};

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -25,11 +25,20 @@ use crossterm::{
 };
 use itertools::Itertools;
 use ratatui::{
-    layout::{Constraint::*, Flex},
-    prelude::*,
-    style::palette::tailwind::*,
-    symbols::line,
-    widgets::{Block, Paragraph, Wrap},
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{
+        Constraint::{self, Fill, Length, Max, Min, Percentage, Ratio},
+        Flex, Layout, Rect,
+    },
+    style::{
+        palette::tailwind::{BLUE, SKY, SLATE, STONE},
+        Color, Style, Stylize,
+    },
+    symbols::{self, line},
+    terminal::Terminal,
+    text::{Line, Span, Text},
+    widgets::{Block, Paragraph, Widget, Wrap},
 };
 use strum::{Display, EnumIter, FromRepr};
 
@@ -123,7 +132,7 @@ impl App {
     }
 
     fn handle_events(&mut self) -> Result<()> {
-        use KeyCode::*;
+        use KeyCode::{Char, Down, Esc, Left, Right, Up};
         match event::read()? {
             Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                 Char('q') | Esc => self.exit(),

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -130,24 +130,23 @@ impl App {
     }
 
     fn handle_events(&mut self) -> Result<()> {
-        use KeyCode::{Char, Down, Esc, Left, Right, Up};
         match event::read()? {
             Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
-                Char('q') | Esc => self.exit(),
-                Char('1') => self.swap_constraint(ConstraintName::Min),
-                Char('2') => self.swap_constraint(ConstraintName::Max),
-                Char('3') => self.swap_constraint(ConstraintName::Length),
-                Char('4') => self.swap_constraint(ConstraintName::Percentage),
-                Char('5') => self.swap_constraint(ConstraintName::Ratio),
-                Char('6') => self.swap_constraint(ConstraintName::Fill),
-                Char('+') => self.increment_spacing(),
-                Char('-') => self.decrement_spacing(),
-                Char('x') => self.delete_block(),
-                Char('a') => self.insert_block(),
-                Char('k') | Up => self.increment_value(),
-                Char('j') | Down => self.decrement_value(),
-                Char('h') | Left => self.prev_block(),
-                Char('l') | Right => self.next_block(),
+                KeyCode::Char('q') | KeyCode::Esc => self.exit(),
+                KeyCode::Char('1') => self.swap_constraint(ConstraintName::Min),
+                KeyCode::Char('2') => self.swap_constraint(ConstraintName::Max),
+                KeyCode::Char('3') => self.swap_constraint(ConstraintName::Length),
+                KeyCode::Char('4') => self.swap_constraint(ConstraintName::Percentage),
+                KeyCode::Char('5') => self.swap_constraint(ConstraintName::Ratio),
+                KeyCode::Char('6') => self.swap_constraint(ConstraintName::Fill),
+                KeyCode::Char('+') => self.increment_spacing(),
+                KeyCode::Char('-') => self.decrement_spacing(),
+                KeyCode::Char('x') => self.delete_block(),
+                KeyCode::Char('a') => self.insert_block(),
+                KeyCode::Char('k') | KeyCode::Up => self.increment_value(),
+                KeyCode::Char('j') | KeyCode::Down => self.decrement_value(),
+                KeyCode::Char('h') | KeyCode::Left => self.prev_block(),
+                KeyCode::Char('l') | KeyCode::Right => self.next_block(),
                 _ => {}
             },
             _ => {}

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -23,7 +23,22 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use ratatui::{layout::Constraint::*, prelude::*, style::palette::tailwind, widgets::*};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{
+        Constraint::{self, Fill, Length, Max, Min, Percentage, Ratio},
+        Layout, Rect,
+    },
+    style::{palette::tailwind, Color, Modifier, Style, Stylize},
+    symbols,
+    terminal::Terminal,
+    text::Line,
+    widgets::{
+        Block, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget,
+        Tabs, Widget,
+    },
+};
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
 const SPACER_HEIGHT: u16 = 0;
@@ -108,7 +123,7 @@ impl App {
 
     fn handle_events(&mut self) -> Result<()> {
         if let Event::Key(key) = event::read()? {
-            use KeyCode::*;
+            use KeyCode::{Char, Down, End, Esc, Home, Left, Right, Up};
             if key.kind != KeyEventKind::Press {
                 return Ok(());
             }

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::enum_glob_use, clippy::wildcard_imports)]
-
 use std::io::{self, stdout};
 
 use color_eyre::{config::HookBuilder, Result};

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -121,18 +121,17 @@ impl App {
 
     fn handle_events(&mut self) -> Result<()> {
         if let Event::Key(key) = event::read()? {
-            use KeyCode::{Char, Down, End, Esc, Home, Left, Right, Up};
             if key.kind != KeyEventKind::Press {
                 return Ok(());
             }
             match key.code {
-                Char('q') | Esc => self.quit(),
-                Char('l') | Right => self.next(),
-                Char('h') | Left => self.previous(),
-                Char('j') | Down => self.down(),
-                Char('k') | Up => self.up(),
-                Char('g') | Home => self.top(),
-                Char('G') | End => self.bottom(),
+                KeyCode::Char('q') | KeyCode::Esc => self.quit(),
+                KeyCode::Char('l') | KeyCode::Right => self.next(),
+                KeyCode::Char('h') | KeyCode::Left => self.previous(),
+                KeyCode::Char('j') | KeyCode::Down => self.down(),
+                KeyCode::Char('k') | KeyCode::Up => self.up(),
+                KeyCode::Char('g') | KeyCode::Home => self.top(),
+                KeyCode::Char('G') | KeyCode::End => self.bottom(),
                 _ => (),
             }
         }

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -23,7 +23,15 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{prelude::*, widgets::Paragraph};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Style},
+    terminal::{Frame, Terminal},
+    text::Line,
+    widgets::{Paragraph, Widget},
+};
 
 /// A custom widget that renders a button with a label, theme and state.
 #[derive(Debug, Clone)]

--- a/examples/demo/crossterm.rs
+++ b/examples/demo/crossterm.rs
@@ -9,7 +9,10 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    terminal::Terminal,
+};
 
 use crate::{app::App, ui};
 

--- a/examples/demo/termion.rs
+++ b/examples/demo/termion.rs
@@ -1,6 +1,9 @@
 use std::{error::Error, io, sync::mpsc, thread, time::Duration};
 
-use ratatui::prelude::*;
+use ratatui::{
+    backend::{Backend, TermionBackend},
+    terminal::Terminal,
+};
 use termion::{
     event::Key,
     input::{MouseTerminal, TermRead},

--- a/examples/demo/termwiz.rs
+++ b/examples/demo/termwiz.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ratatui::prelude::*;
+use ratatui::{backend::TermwizBackend, terminal::Terminal};
 use termwiz::{
     input::{InputEvent, KeyCode},
     terminal::Terminal as TermwizTerminal,

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -1,7 +1,16 @@
+use ratatui::widgets::canvas;
 #[allow(clippy::wildcard_imports)]
 use ratatui::{
-    prelude::*,
-    widgets::{canvas::*, *},
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    symbols::{self},
+    terminal::Frame,
+    text::{self, Span},
+    widgets::{
+        canvas::{Canvas, Circle, Map, MapResolution, Rectangle},
+        Axis, BarChart, Block, Cell, Chart, Dataset, Gauge, LineGauge, List, ListItem, Paragraph,
+        Row, Sparkline, Table, Tabs, Wrap,
+    },
 };
 
 use crate::app::App;

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -1,13 +1,11 @@
-use ratatui::widgets::canvas;
-#[allow(clippy::wildcard_imports)]
 use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
-    symbols::{self},
+    symbols,
     terminal::Frame,
     text::{self, Span},
     widgets::{
-        canvas::{Canvas, Circle, Map, MapResolution, Rectangle},
+        canvas::{self, Canvas, Circle, Map, MapResolution, Rectangle},
         Axis, BarChart, Block, Cell, Chart, Dataset, Gauge, LineGauge, List, ListItem, Paragraph,
         Row, Sparkline, Table, Tabs, Wrap,
     },

--- a/examples/demo2/app.rs
+++ b/examples/demo2/app.rs
@@ -94,14 +94,13 @@ impl App {
     }
 
     fn handle_key_press(&mut self, key: KeyEvent) {
-        use KeyCode::{Char, Delete, Down, Esc, Left, Right, Up};
         match key.code {
-            Char('q') | Esc => self.mode = Mode::Quit,
-            Char('h') | Left => self.prev_tab(),
-            Char('l') | Right => self.next_tab(),
-            Char('k') | Up => self.prev(),
-            Char('j') | Down => self.next(),
-            Char('d') | Delete => self.destroy(),
+            KeyCode::Char('q') | KeyCode::Esc => self.mode = Mode::Quit,
+            KeyCode::Char('h') | KeyCode::Left => self.prev_tab(),
+            KeyCode::Char('l') | KeyCode::Right => self.next_tab(),
+            KeyCode::Char('k') | KeyCode::Up => self.prev(),
+            KeyCode::Char('j') | KeyCode::Down => self.next(),
+            KeyCode::Char('d') | KeyCode::Delete => self.destroy(),
             _ => {}
         };
     }

--- a/examples/demo2/app.rs
+++ b/examples/demo2/app.rs
@@ -3,10 +3,22 @@ use std::time::Duration;
 use color_eyre::{eyre::Context, Result};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
 use itertools::Itertools;
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    backend::Backend,
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    style::Color,
+    terminal::Terminal,
+    text::{Line, Span},
+    widgets::{Block, Tabs, Widget},
+};
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
-use crate::{destroy, tabs::*, term, THEME};
+use crate::{
+    destroy,
+    tabs::{AboutTab, EmailTab, RecipeTab, TracerouteTab, WeatherTab},
+    term, THEME,
+};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct App {
@@ -82,7 +94,7 @@ impl App {
     }
 
     fn handle_key_press(&mut self, key: KeyEvent) {
-        use KeyCode::*;
+        use KeyCode::{Char, Delete, Down, Esc, Left, Right, Up};
         match key.code {
             Char('q') | Esc => self.mode = Mode::Quit,
             Char('h') | Left => self.prev_tab(),

--- a/examples/demo2/big_text.rs
+++ b/examples/demo2/big_text.rs
@@ -300,8 +300,9 @@ fn render_glyph(glyph: [u8; 8], area: Rect, buf: &mut Buffer, pixel_size: PixelS
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ratatui::style::Stylize;
+
+    use super::*;
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/examples/demo2/big_text.rs
+++ b/examples/demo2/big_text.rs
@@ -20,7 +20,16 @@
 //!
 //! ```rust
 //! use anyhow::Result;
-//! use ratatui::prelude::*;
+//! use ratatui::{
+//!     backend::{self, Backend, CrosstermBackend},
+//!     buffer::{self, Buffer},
+//!     layout::{self, Alignment, Constraint, Direction, Layout, Margin, Rect},
+//!     style::{self, Color, Modifier, Style, Styled, Stylize},
+//!     symbols::{self, Marker},
+//!     terminal::{CompletedFrame, Frame, Terminal, TerminalOptions, Viewport},
+//!     text::{self, Line, Masked, Span, Text},
+//!     widgets::{block::BlockExt, StatefulWidget, Widget},
+//! };
 //! use tui_big_text::{BigTextBuilder, PixelSize};
 //!
 //! fn render(frame: &mut Frame) -> Result<()> {
@@ -50,7 +59,13 @@ use std::cmp::min;
 
 use derive_builder::Builder;
 use font8x8::UnicodeFonts;
-use ratatui::{prelude::*, text::StyledGrapheme};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+    text::{Line, StyledGrapheme},
+    widgets::Widget,
+};
 
 #[allow(unused)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Default)]
@@ -79,7 +94,16 @@ pub enum PixelSize {
 /// # Examples
 ///
 /// ```rust
-/// use ratatui::prelude::*;
+/// use ratatui::{
+///     backend::{self, Backend, CrosstermBackend},
+///     buffer::{self, Buffer},
+///     layout::{self, Alignment, Constraint, Direction, Layout, Margin, Rect},
+///     style::{self, Color, Modifier, Style, Styled, Stylize},
+///     symbols::{self, Marker},
+///     terminal::{CompletedFrame, Frame, Terminal, TerminalOptions, Viewport},
+///     text::{self, Line, Masked, Span, Text},
+///     widgets::{block::BlockExt, StatefulWidget, Widget},
+/// };
 /// use tui_big_text::{BigTextBuilder, PixelSize};
 ///
 /// BigText::builder()

--- a/examples/demo2/big_text.rs
+++ b/examples/demo2/big_text.rs
@@ -301,6 +301,7 @@ fn render_glyph(glyph: [u8; 8], area: Rect, buf: &mut Buffer, pixel_size: PixelS
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::style::Stylize;
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/examples/demo2/colors.rs
+++ b/examples/demo2/colors.rs
@@ -1,5 +1,5 @@
 use palette::{IntoColor, Okhsv, Srgb};
-use ratatui::prelude::*;
+use ratatui::{buffer::Buffer, layout::Rect, style::Color, widgets::Widget};
 
 /// A widget that renders a color swatch of RGB colors.
 ///

--- a/examples/demo2/destroy.rs
+++ b/examples/demo2/destroy.rs
@@ -1,6 +1,12 @@
 use rand::Rng;
 use rand_chacha::rand_core::SeedableRng;
-use ratatui::{layout::Flex, prelude::*};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Flex, Layout, Rect},
+    style::{Color, Style},
+    terminal::Frame,
+    widgets::Widget,
+};
 use unicode_width::UnicodeWidthStr;
 
 use crate::big_text::{BigTextBuilder, PixelSize};

--- a/examples/demo2/main.rs
+++ b/examples/demo2/main.rs
@@ -30,16 +30,16 @@ mod tabs;
 mod term;
 mod theme;
 
-pub use app::*;
+pub use app::App;
 use color_eyre::Result;
-pub use colors::*;
-pub use term::*;
-pub use theme::*;
+pub use colors::{color_from_oklab, RgbSwatch};
+pub use term::{init, restore};
+pub use theme::THEME;
 
 fn main() -> Result<()> {
     errors::init_hooks()?;
     let terminal = &mut term::init()?;
-    App::default().run(terminal)?;
+    app::run(terminal)?;
     term::restore()?;
     Ok(())
 }

--- a/examples/demo2/main.rs
+++ b/examples/demo2/main.rs
@@ -30,7 +30,7 @@ mod theme;
 
 use color_eyre::Result;
 
-pub use crate::{
+pub use self::{
     colors::{color_from_oklab, RgbSwatch},
     theme::THEME,
 };

--- a/examples/demo2/main.rs
+++ b/examples/demo2/main.rs
@@ -28,11 +28,12 @@ mod tabs;
 mod term;
 mod theme;
 
-pub use app::App;
 use color_eyre::Result;
-pub use colors::{color_from_oklab, RgbSwatch};
-pub use term::{init, restore};
-pub use theme::THEME;
+
+pub use crate::{
+    colors::{color_from_oklab, RgbSwatch},
+    theme::THEME,
+};
 
 fn main() -> Result<()> {
     errors::init_hooks()?;

--- a/examples/demo2/main.rs
+++ b/examples/demo2/main.rs
@@ -14,11 +14,9 @@
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
 #![allow(
-    clippy::enum_glob_use,
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::wildcard_imports
+    clippy::must_use_candidate
 )]
 
 mod app;

--- a/examples/demo2/tabs/about.rs
+++ b/examples/demo2/tabs/about.rs
@@ -1,5 +1,9 @@
 use itertools::Itertools;
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Margin, Rect},
+    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget, Wrap},
+};
 
 use crate::{RgbSwatch, THEME};
 

--- a/examples/demo2/tabs/email.rs
+++ b/examples/demo2/tabs/email.rs
@@ -1,5 +1,14 @@
 use itertools::Itertools;
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Layout, Margin, Rect},
+    style::{Styled, Stylize},
+    text::Line,
+    widgets::{
+        Block, BorderType, Borders, Clear, List, ListItem, ListState, Padding, Paragraph,
+        Scrollbar, ScrollbarState, StatefulWidget, Tabs, Widget,
+    },
+};
 use unicode_width::UnicodeWidthStr;
 
 use crate::{RgbSwatch, THEME};

--- a/examples/demo2/tabs/recipe.rs
+++ b/examples/demo2/tabs/recipe.rs
@@ -1,5 +1,14 @@
 use itertools::Itertools;
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Margin, Rect},
+    style::{Style, Stylize},
+    text::Line,
+    widgets::{
+        Block, Clear, Padding, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState,
+        StatefulWidget, Table, TableState, Widget, Wrap,
+    },
+};
 
 use crate::{RgbSwatch, THEME};
 

--- a/examples/demo2/tabs/traceroute.rs
+++ b/examples/demo2/tabs/traceroute.rs
@@ -1,7 +1,14 @@
 use itertools::Itertools;
 use ratatui::{
-    prelude::*,
-    widgets::{canvas::*, *},
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Margin, Rect},
+    style::{Styled, Stylize},
+    symbols::Marker,
+    widgets::{
+        canvas::{self, Canvas, Map, MapResolution, Points},
+        Block, BorderType, Clear, Padding, Row, Scrollbar, ScrollbarOrientation, ScrollbarState,
+        Sparkline, StatefulWidget, Table, TableState, Widget,
+    },
 };
 
 use crate::{RgbSwatch, THEME};
@@ -104,7 +111,7 @@ fn render_map(selected_row: usize, area: Rect, buf: &mut Buffer) {
     let theme = THEME.traceroute.map;
     let path: Option<(&Hop, &Hop)> = HOPS.iter().tuple_windows().nth(selected_row);
     let map = Map {
-        resolution: canvas::MapResolution::High,
+        resolution: MapResolution::High,
         color: theme.color,
     };
     Canvas::default()

--- a/examples/demo2/tabs/weather.rs
+++ b/examples/demo2/tabs/weather.rs
@@ -1,8 +1,14 @@
 use itertools::Itertools;
 use palette::Okhsv;
 use ratatui::{
-    prelude::*,
-    widgets::{calendar::CalendarEventStore, *},
+    buffer::Buffer,
+    layout::{Constraint, Direction, Layout, Margin, Rect},
+    style::{Color, Style, Stylize},
+    symbols::{self},
+    widgets::{
+        calendar::{CalendarEventStore, Monthly},
+        Bar, BarChart, BarGroup, Block, Clear, LineGauge, Padding, Widget,
+    },
 };
 use time::OffsetDateTime;
 
@@ -59,7 +65,7 @@ impl Widget for WeatherTab {
 
 fn render_calendar(area: Rect, buf: &mut Buffer) {
     let date = OffsetDateTime::now_utc().date();
-    calendar::Monthly::new(date, CalendarEventStore::today(Style::new().red().bold()))
+    Monthly::new(date, CalendarEventStore::today(Style::new().red().bold()))
         .block(Block::new().padding(Padding::new(0, 0, 2, 0)))
         .show_month_header(Style::new().bold())
         .show_weekdays_header(Style::new().italic())

--- a/examples/demo2/tabs/weather.rs
+++ b/examples/demo2/tabs/weather.rs
@@ -4,7 +4,7 @@ use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Style, Stylize},
-    symbols::{self},
+    symbols,
     widgets::{
         calendar::{CalendarEventStore, Monthly},
         Bar, BarChart, BarGroup, Block, Clear, LineGauge, Padding, Widget,

--- a/examples/demo2/term.rs
+++ b/examples/demo2/term.rs
@@ -9,7 +9,11 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use ratatui::prelude::*;
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::Rect,
+    terminal::{Terminal, TerminalOptions, Viewport},
+};
 
 pub fn init() -> Result<Terminal<impl Backend>> {
     // this size is to match the size of the terminal when running the demo

--- a/examples/demo2/theme.rs
+++ b/examples/demo2/theme.rs
@@ -1,4 +1,4 @@
-use ratatui::prelude::*;
+use ratatui::style::{Color, Modifier, Style};
 
 pub struct Theme {
     pub root: Style,

--- a/examples/docsrs.rs
+++ b/examples/docsrs.rs
@@ -20,7 +20,11 @@ use crossterm::{
     ExecutableCommand,
 };
 use ratatui::{
-    prelude::*,
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style, Stylize},
+    terminal::{Frame, Terminal},
+    text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph},
 };
 

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -24,11 +24,21 @@ use crossterm::{
     ExecutableCommand,
 };
 use ratatui::{
-    layout::{Constraint::*, Flex},
-    prelude::*,
-    style::palette::tailwind,
-    symbols::line,
-    widgets::{block::Title, *},
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{
+        Alignment, Constraint,
+        Constraint::{Fill, Length, Max, Min, Percentage, Ratio},
+        Flex, Layout, Rect,
+    },
+    style::{palette::tailwind, Color, Modifier, Style, Stylize},
+    symbols::{self, line},
+    terminal::Terminal,
+    text::{Line, Text},
+    widgets::{
+        block::Title, Block, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+        StatefulWidget, Tabs, Widget,
+    },
 };
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
@@ -177,7 +187,7 @@ impl App {
     }
 
     fn handle_events(&mut self) -> Result<()> {
-        use KeyCode::*;
+        use KeyCode::{Char, Down, End, Esc, Home, Left, Right, Up};
         match event::read()? {
             Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                 Char('q') | Esc => self.quit(),
@@ -364,7 +374,7 @@ impl SelectedTab {
 
     /// Convert a `SelectedTab` into a `Line` to display it by the `Tabs` widget.
     fn to_tab_title(value: Self) -> Line<'static> {
-        use tailwind::*;
+        use tailwind::{INDIGO, ORANGE, SKY};
         let text = value.to_string();
         let color = match value {
             Self::Legacy => ORANGE.c400,
@@ -509,7 +519,7 @@ impl Example {
 }
 
 const fn color_for_constraint(constraint: Constraint) -> Color {
-    use tailwind::*;
+    use tailwind::{BLUE, SLATE};
     match constraint {
         Constraint::Min(_) => BLUE.c900,
         Constraint::Max(_) => BLUE.c800,

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::enum_glob_use, clippy::wildcard_imports)]
-
 use std::io::{self, stdout};
 
 use color_eyre::{config::HookBuilder, Result};

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -185,18 +185,17 @@ impl App {
     }
 
     fn handle_events(&mut self) -> Result<()> {
-        use KeyCode::{Char, Down, End, Esc, Home, Left, Right, Up};
         match event::read()? {
             Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
-                Char('q') | Esc => self.quit(),
-                Char('l') | Right => self.next(),
-                Char('h') | Left => self.previous(),
-                Char('j') | Down => self.down(),
-                Char('k') | Up => self.up(),
-                Char('g') | Home => self.top(),
-                Char('G') | End => self.bottom(),
-                Char('+') => self.increment_spacing(),
-                Char('-') => self.decrement_spacing(),
+                KeyCode::Char('q') | KeyCode::Esc => self.quit(),
+                KeyCode::Char('l') | KeyCode::Right => self.next(),
+                KeyCode::Char('h') | KeyCode::Left => self.previous(),
+                KeyCode::Char('j') | KeyCode::Down => self.down(),
+                KeyCode::Char('k') | KeyCode::Up => self.up(),
+                KeyCode::Char('g') | KeyCode::Home => self.top(),
+                KeyCode::Char('G') | KeyCode::End => self.bottom(),
+                KeyCode::Char('+') => self.increment_spacing(),
+                KeyCode::Char('-') => self.decrement_spacing(),
                 _ => (),
             },
             _ => {}

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -24,9 +24,13 @@ use crossterm::{
     ExecutableCommand,
 };
 use ratatui::{
-    prelude::*,
-    style::palette::tailwind,
-    widgets::{block::Title, Block, Borders, Gauge, Padding, Paragraph},
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{palette::tailwind, Color, Style, Stylize},
+    terminal::Terminal,
+    text::Span,
+    widgets::{block::Title, Block, Borders, Gauge, Padding, Paragraph, Widget},
 };
 
 const GAUGE1_COLOR: Color = tailwind::RED.c800;
@@ -99,7 +103,7 @@ impl App {
         if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
-                    use KeyCode::*;
+                    use KeyCode::{Char, Enter, Esc};
                     match key.code {
                         Char(' ') | Enter => self.start(),
                         Char('q') | Esc => self.quit(),
@@ -123,7 +127,7 @@ impl App {
 impl Widget for &App {
     #[allow(clippy::similar_names)]
     fn render(self, area: Rect, buf: &mut Buffer) {
-        use Constraint::*;
+        use Constraint::{Length, Min, Ratio};
         let layout = Layout::vertical([Length(2), Min(0), Length(1)]);
         let [header_area, gauge_area, footer_area] = layout.areas(area);
 

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -101,10 +101,9 @@ impl App {
         if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
-                    use KeyCode::{Char, Enter, Esc};
                     match key.code {
-                        Char(' ') | Enter => self.start(),
-                        Char('q') | Esc => self.quit(),
+                        KeyCode::Char(' ') | KeyCode::Enter => self.start(),
+                        KeyCode::Char('q') | KeyCode::Esc => self.quit(),
                         _ => {}
                     }
                 }

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::enum_glob_use)]
-
 use std::{io::stdout, time::Duration};
 
 use color_eyre::{config::HookBuilder, Result};

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -24,7 +24,11 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{prelude::*, widgets::Paragraph};
+use ratatui::{
+    backend::CrosstermBackend,
+    terminal::{Frame, Terminal},
+    widgets::Paragraph,
+};
 
 /// This is a bare minimum example. There are many approaches to running an application loop, so
 /// this is not meant to be prescriptive. It is only meant to demonstrate the basic setup and

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -25,7 +25,16 @@ use std::{
 };
 
 use rand::distributions::{Distribution, Uniform};
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    symbols,
+    terminal::{Frame, Terminal, Viewport},
+    text::{Line, Span},
+    widgets::{block, Block, Gauge, LineGauge, List, ListItem, Paragraph, Widget},
+    TerminalOptions,
+};
 
 const NUM_DOWNLOADS: usize = 10;
 

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::wildcard_imports)]
-
 use std::{
     collections::{BTreeMap, VecDeque},
     error::Error,

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -24,8 +24,15 @@ use crossterm::{
 };
 use itertools::Itertools;
 use ratatui::{
-    layout::Constraint::*,
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    layout::{
+        Constraint,
+        Constraint::{Length, Max, Min, Percentage, Ratio},
+        Layout, Rect,
+    },
+    style::{Color, Style, Stylize},
+    terminal::{Frame, Terminal},
+    text::Line,
     widgets::{Block, Paragraph},
 };
 

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::enum_glob_use)]
-
 use std::{error::Error, io};
 
 use crossterm::{

--- a/examples/line_gauge.rs
+++ b/examples/line_gauge.rs
@@ -22,9 +22,12 @@ use crossterm::{
     ExecutableCommand,
 };
 use ratatui::{
-    prelude::*,
-    style::palette::tailwind,
-    widgets::{block::Title, *},
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{palette::tailwind, Color, Style, Stylize},
+    terminal::Terminal,
+    widgets::{block::Title, Block, Borders, LineGauge, Padding, Paragraph, Widget},
 };
 
 const CUSTOM_LABEL_COLOR: Color = tailwind::SLATE.c200;

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -23,7 +23,18 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use ratatui::{prelude::*, style::palette::tailwind, widgets::*};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{palette::tailwind, Color, Modifier, Style, Stylize},
+    terminal::Terminal,
+    text::Line,
+    widgets::{
+        Block, Borders, HighlightSpacing, List, ListItem, ListState, Padding, Paragraph,
+        StatefulWidget, Widget, Wrap,
+    },
+};
 
 const TODO_HEADER_BG: Color = tailwind::BLUE.c950;
 const NORMAL_ROW_COLOR: Color = tailwind::SLATE.c950;
@@ -152,7 +163,7 @@ impl App {
 
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
-                    use KeyCode::*;
+                    use KeyCode::{Char, Down, Enter, Esc, Left, Right, Up};
                     match key.code {
                         Char('q') | Esc => return Ok(()),
                         Char('h') | Left => self.items.unselect(),

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -161,15 +161,16 @@ impl App {
 
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
-                    use KeyCode::{Char, Down, Enter, Esc, Left, Right, Up};
                     match key.code {
-                        Char('q') | Esc => return Ok(()),
-                        Char('h') | Left => self.items.unselect(),
-                        Char('j') | Down => self.items.next(),
-                        Char('k') | Up => self.items.previous(),
-                        Char('l') | Right | Enter => self.change_status(),
-                        Char('g') => self.go_top(),
-                        Char('G') => self.go_bottom(),
+                        KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                        KeyCode::Char('h') | KeyCode::Left => self.items.unselect(),
+                        KeyCode::Char('j') | KeyCode::Down => self.items.next(),
+                        KeyCode::Char('k') | KeyCode::Up => self.items.previous(),
+                        KeyCode::Char('l') | KeyCode::Right | KeyCode::Enter => {
+                            self.change_status();
+                        }
+                        KeyCode::Char('g') => self.go_top(),
+                        KeyCode::Char('G') => self.go_bottom(),
                         _ => {}
                     }
                 }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::enum_glob_use, clippy::wildcard_imports)]
-
 use std::{error::Error, io, io::stdout};
 
 use color_eyre::config::HookBuilder;

--- a/examples/modifiers.rs
+++ b/examples/modifiers.rs
@@ -31,7 +31,14 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use itertools::Itertools;
-use ratatui::{prelude::*, widgets::Paragraph};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style, Stylize},
+    terminal::{Frame, Terminal},
+    text::Line,
+    widgets::Paragraph,
+};
 
 type Result<T> = result::Result<T, Box<dyn Error>>;
 

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -36,7 +36,9 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    terminal::{Frame, Terminal},
+    text::Line,
     widgets::{Block, Paragraph},
 };
 

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -25,7 +25,11 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style, Stylize},
+    terminal::{Frame, Terminal},
+    text::{Line, Masked, Span},
     widgets::{Block, Paragraph, Wrap},
 };
 

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -24,7 +24,10 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Layout, Rect},
+    style::Stylize,
+    terminal::{Frame, Terminal},
     widgets::{Block, Clear, Paragraph, Wrap},
 };
 

--- a/examples/ratatui-logo.rs
+++ b/examples/ratatui-logo.rs
@@ -22,7 +22,12 @@ use std::{
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use indoc::indoc;
 use itertools::izip;
-use ratatui::{prelude::*, widgets::Paragraph};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    terminal::{Terminal, Viewport},
+    widgets::Paragraph,
+    TerminalOptions,
+};
 
 /// A fun example of using half block characters to draw a logo
 #[allow(clippy::many_single_char_names)]

--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -27,7 +27,15 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{prelude::*, symbols::scrollbar, widgets::*};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Alignment, Constraint, Layout, Margin},
+    style::{Color, Style, Stylize},
+    symbols::scrollbar,
+    terminal::{Frame, Terminal},
+    text::{Line, Masked, Span},
+    widgets::{Block, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+};
 
 #[derive(Default)]
 struct App {

--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -14,7 +14,6 @@
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
 #![warn(clippy::pedantic)]
-#![allow(clippy::wildcard_imports)]
 
 use std::{
     error::Error,

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -29,7 +29,10 @@ use rand::{
     rngs::ThreadRng,
 };
 use ratatui::{
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Layout},
+    style::{Color, Style},
+    terminal::{Frame, Terminal},
     widgets::{Block, Borders, Sparkline},
 };
 

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::enum_glob_use, clippy::wildcard_imports)]
-
 use std::{error::Error, io};
 
 use crossterm::{

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -220,13 +220,12 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
 
         if let Event::Key(key) = event::read()? {
             if key.kind == KeyEventKind::Press {
-                use KeyCode::{Char, Down, Esc, Left, Right, Up};
                 match key.code {
-                    Char('q') | Esc => return Ok(()),
-                    Char('j') | Down => app.next(),
-                    Char('k') | Up => app.previous(),
-                    Char('l') | Right => app.next_color(),
-                    Char('h') | Left => app.previous_color(),
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                    KeyCode::Char('j') | KeyCode::Down => app.next(),
+                    KeyCode::Char('k') | KeyCode::Up => app.previous(),
+                    KeyCode::Char('l') | KeyCode::Right => app.next_color(),
+                    KeyCode::Char('h') | KeyCode::Left => app.previous_color(),
                     _ => {}
                 }
             }

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -23,7 +23,17 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use itertools::Itertools;
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Layout, Margin, Rect},
+    style::{self, Color, Modifier, Style, Stylize},
+    terminal::{Frame, Terminal},
+    text::{Line, Text},
+    widgets::{
+        Block, BorderType, Cell, HighlightSpacing, Paragraph, Row, Scrollbar, ScrollbarOrientation,
+        ScrollbarState, Table, TableState,
+    },
+};
 use style::palette::tailwind;
 use unicode_width::UnicodeWidthStr;
 
@@ -212,7 +222,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
 
         if let Event::Key(key) = event::read()? {
             if key.kind == KeyEventKind::Press {
-                use KeyCode::*;
+                use KeyCode::{Char, Down, Esc, Left, Right, Up};
                 match key.code {
                     Char('q') | Esc => return Ok(()),
                     Char('j') | Down => app.next(),

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -23,7 +23,16 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use ratatui::{prelude::*, style::palette::tailwind, widgets::*};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    style::{palette::tailwind, Color, Stylize},
+    symbols,
+    terminal::Terminal,
+    text::Line,
+    widgets::{Block, Padding, Paragraph, Tabs, Widget},
+};
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
 #[derive(Default)]
@@ -77,7 +86,7 @@ impl App {
     fn handle_events(&mut self) -> std::io::Result<()> {
         if let Event::Key(key) = event::read()? {
             if key.kind == KeyEventKind::Press {
-                use KeyCode::*;
+                use KeyCode::{Char, Esc, Left, Right};
                 match key.code {
                     Char('l') | Right => self.next_tab(),
                     Char('h') | Left => self.previous_tab(),
@@ -120,7 +129,7 @@ impl SelectedTab {
 
 impl Widget for &App {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        use Constraint::*;
+        use Constraint::{Length, Min};
         let vertical = Layout::vertical([Length(1), Min(0), Length(1)]);
         let [header_area, inner_area, footer_area] = vertical.areas(area);
 

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -84,11 +84,10 @@ impl App {
     fn handle_events(&mut self) -> std::io::Result<()> {
         if let Event::Key(key) = event::read()? {
             if key.kind == KeyEventKind::Press {
-                use KeyCode::{Char, Esc, Left, Right};
                 match key.code {
-                    Char('l') | Right => self.next_tab(),
-                    Char('h') | Left => self.previous_tab(),
-                    Char('q') | Esc => self.quit(),
+                    KeyCode::Char('l') | KeyCode::Right => self.next_tab(),
+                    KeyCode::Char('h') | KeyCode::Left => self.previous_tab(),
+                    KeyCode::Char('q') | KeyCode::Esc => self.quit(),
                     _ => {}
                 }
             }

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -13,8 +13,6 @@
 //! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
-#![allow(clippy::wildcard_imports, clippy::enum_glob_use)]
-
 use std::io::stdout;
 
 use color_eyre::{config::HookBuilder, Result};

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -35,7 +35,11 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
-    prelude::*,
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style, Stylize},
+    terminal::{Frame, Terminal},
+    text::{Line, Span, Text},
     widgets::{Block, List, ListItem, Paragraph},
 };
 

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -3,7 +3,10 @@ use unicode_width::UnicodeWidthStr;
 use crate::{
     prelude::*,
     text::StyledGrapheme,
-    widgets::{reflow::*, Block},
+    widgets::{
+        reflow::{LineComposer, LineTruncator, WordWrapper, WrappedLine},
+        Block,
+    },
 };
 
 const fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) -> u16 {

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -3,8 +3,7 @@
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
-    clippy::module_name_repetitions,
-    clippy::wildcard_imports
+    clippy::module_name_repetitions
 )]
 
 use std::iter;
@@ -12,7 +11,10 @@ use std::iter;
 use strum::{Display, EnumString};
 use unicode_width::UnicodeWidthStr;
 
-use crate::{prelude::*, symbols::scrollbar::*};
+use crate::{
+    prelude::*,
+    symbols::scrollbar::{Set, DOUBLE_HORIZONTAL, DOUBLE_VERTICAL},
+};
 
 /// A widget to display a scrollbar
 ///

--- a/src/widgets/table/row.rs
+++ b/src/widgets/table/row.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::Cell;
 use crate::prelude::*;
 
 /// A single row of data to be displayed in a [`Table`] widget.

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -1,5 +1,7 @@
 use itertools::Itertools;
 
+#[allow(unused_imports)] // `Cell` is used in the doc comment but not the code
+use super::Cell;
 use super::{HighlightSpacing, Row, TableState};
 use crate::{layout::Flex, prelude::*, widgets::Block};
 
@@ -176,7 +178,11 @@ use crate::{layout::Flex, prelude::*, widgets::Block};
 ///     Row::new(vec!["Row21", "Row22", "Row23"]),
 ///     Row::new(vec!["Row31", "Row32", "Row33"]),
 /// ];
-/// let widths = [Constraint::Length(5), Constraint::Length(5), Constraint::Length(10)];
+/// let widths = [
+///     Constraint::Length(5),
+///     Constraint::Length(5),
+///     Constraint::Length(10),
+/// ];
 /// let table = Table::new(rows, widths)
 ///     .block(Block::new().title("Table"))
 ///     .highlight_style(Style::new().add_modifier(Modifier::REVERSED))
@@ -184,6 +190,7 @@ use crate::{layout::Flex, prelude::*, widgets::Block};
 ///
 /// frame.render_stateful_widget(table, area, &mut table_state);
 /// # }
+/// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Table<'a> {
     /// Data to display in each row

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 
-use super::*;
+use super::{HighlightSpacing, Row, TableState};
 use crate::{layout::Flex, prelude::*, widgets::Block};
 
 /// A widget to display data in formatted columns.
@@ -842,7 +842,7 @@ mod tests {
     use std::vec;
 
     use super::*;
-    use crate::{layout::Constraint::*, style::Style, text::Line};
+    use crate::{layout::Constraint::*, style::Style, text::Line, widgets::Cell};
 
     #[test]
     fn new() {


### PR DESCRIPTION
Consensus is that explicit imports make it easier to understand the
example code. This commit removes the prelude import from all examples
and replaces it with the necessary imports, and expands other glob
imports (widget::*, Constraint::*, KeyCode::*, etc.) everywhere else.
Prelude glob imports not in examples are not covered by this PR.

See https://github.com/ratatui-org/ratatui/issues/1150 for more details.
