### PR TITLE
feat(state): allow conversion between `ListState` and `TableState`

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -3,7 +3,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     prelude::*,
-    widgets::{Block, HighlightSpacing},
+    widgets::{table::TableState, Block, HighlightSpacing},
 };
 
 /// State of the [`List`] widget
@@ -46,8 +46,8 @@ use crate::{
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListState {
-    offset: usize,
-    selected: Option<usize>,
+    pub(crate) offset: usize,
+    pub(crate) selected: Option<usize>,
 }
 
 impl ListState {
@@ -154,6 +154,15 @@ impl ListState {
         self.selected = index;
         if index.is_none() {
             self.offset = 0;
+        }
+    }
+}
+
+impl From<TableState> for ListState {
+    fn from(table_state: TableState) -> Self {
+        Self {
+            offset: table_state.offset,
+            selected: table_state.selected,
         }
     }
 }
@@ -1033,6 +1042,14 @@ mod tests {
         state.select(None);
         assert_eq!(state.selected, None);
         assert_eq!(state.offset, 0);
+    }
+
+    #[test]
+    fn test_list_state_into_table_state() {
+        let list_state = ListState::default().with_selected(Some(1)).with_offset(1);
+        let table_state: TableState = list_state.into();
+        assert_eq!(table_state.selected(), Some(1));
+        assert_eq!(table_state.offset(), 1);
     }
 
     #[test]

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -1,3 +1,5 @@
+use crate::widgets::ListState;
+
 /// State of a [`Table`] widget
 ///
 /// This state can be used to scroll through the rows and select one of them. When the table is
@@ -177,6 +179,15 @@ impl TableState {
     }
 }
 
+impl From<ListState> for TableState {
+    fn from(list_state: ListState) -> Self {
+        Self {
+            offset: list_state.offset,
+            selected: list_state.selected,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,5 +249,13 @@ mod tests {
         let mut state = TableState::new().with_selected(Some(1));
         state.select(None);
         assert_eq!(state.selected, None);
+    }
+
+    #[test]
+    fn into_list_state() {
+        let table_state = TableState::new().with_selected(Some(1)).with_offset(1);
+        let list_state: ListState = table_state.into();
+        assert_eq!(list_state.selected(), Some(1));
+        assert_eq!(list_state.offset(), 1);
     }
 }


### PR DESCRIPTION
In my TUI apps I often use `Table` instead of `List` since a `Table` with a single column is effectively a `List`. This also gives me the flexibility of adding columns at any time without changing `List` to `Table`. That's why I mostly have a helper struct called [`SelectableList`](https://github.com/orhun/systeroid/blob/main/systeroid-tui/src/widgets.rs).

However, you see, I need to use `TableState` for storing the state. I would like to extend this to support `ListState` but it needs manual conversion and I thought it would be better to do that in Ratatui itself.

So,

This PR adds a `From` implementation for `ListState` and `TableState` for using them interchangeably. For example:

```rust
let list_state = ListState::default();
let table_state: TableState = list_state.into();
```