### PR TITLE
fix: pin unicode-width crate to 0.1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ termwiz = { version = "0.22.0", optional = true }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-truncate = "1"
-unicode-width = "0.1"
+unicode-width = "=0.1.12"                                                   # incompatible changes in 0.1.13 https://github.com/unicode-rs/unicode-width/issues/55
 
 [dev-dependencies]
 anyhow = "1.0.71"


### PR DESCRIPTION
semver breaking change in 0.1.13 <https://github.com/unicode-rs/unicode-width/issues/55>

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
