### PR TITLE
fix: avoid unicode-width breaking change in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ termwiz = { version = "0.22.0", optional = true }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-truncate = "1"
-unicode-width = "=0.1.12"                                                   # incompatible changes in 0.1.13 https://github.com/unicode-rs/unicode-width/issues/55
+unicode-width = "0.1.13"
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -609,16 +609,18 @@ mod tests {
 
     #[test]
     fn set_string_zero_width() {
+        assert_eq!("\u{200B}".width(), 0);
+
         let area = Rect::new(0, 0, 1, 1);
         let mut buffer = Buffer::empty(area);
 
         // Leading grapheme with zero width
-        let s = "\u{1}a";
+        let s = "\u{200B}a";
         buffer.set_stringn(0, 0, s, 1, Style::default());
         assert_eq!(buffer, Buffer::with_lines(["a"]));
 
         // Trailing grapheme with zero with
-        let s = "a\u{1}";
+        let s = "a\u{200B}";
         buffer.set_stringn(0, 0, s, 1, Style::default());
         assert_eq!(buffer, Buffer::with_lines(["a"]));
     }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -433,7 +433,7 @@ mod test {
 
     #[test]
     fn zero_width_char_at_end_of_line() {
-        let line = "foo\0";
+        let line = "foo\u{200B}";
         for paragraph in [
             Paragraph::new(line),
             Paragraph::new(line).wrap(Wrap { trim: false }),

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -673,11 +673,11 @@ mod test {
     #[test]
     fn line_composer_zero_width_at_end() {
         let width = 3;
-        let line = "foo\0";
+        let line = "foo\u{200B}";
         let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, line, width);
         let (line_truncator, _, _) = run_composer(Composer::LineTruncator, line, width);
-        assert_eq!(word_wrapper, vec!["foo\0"]);
-        assert_eq!(line_truncator, vec!["foo\0"]);
+        assert_eq!(word_wrapper, vec!["foo\u{200B}"]);
+        assert_eq!(line_truncator, vec!["foo\u{200B}"]);
     }
 
     #[test]

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -676,7 +676,7 @@ mod test {
         let line = "foo\u{200B}";
         let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, line, width);
         let (line_truncator, _, _) = run_composer(Composer::LineTruncator, line, width);
-        assert_eq!(word_wrapper, vec!["foo\u{200B}"]);
+        assert_eq!(word_wrapper, vec!["foo"]);
         assert_eq!(line_truncator, vec!["foo\u{200B}"]);
     }
 


### PR DESCRIPTION
unicode-width 0.1.13 changed the width of \u{1} from 0 to 1.
Our tests assumed that \u{1} had a width of 0, so this change replaces
the \u{1} character with \u{200B} (zero width space) in the tests.

Upstream issue (closed as won't fix):
https://github.com/unicode-rs/unicode-width/issues/55
