### PR TITLE
docs: Constraints::from_fills docs correction

### DIFF
--- a/src/layout/constraint.rs
+++ b/src/layout/constraint.rs
@@ -310,7 +310,7 @@ impl Constraint {
     /// ```rust
     /// # use ratatui::prelude::*;
     /// # let area = Rect::default();
-    /// let constraints = Constraint::from_mins([1, 2, 3]);
+    /// let constraints = Constraint::from_fills([1, 2, 3]);
     /// let layout = Layout::default().constraints(constraints).split(area);
     /// ```
     pub fn from_fills<T>(proportional_factors: T) -> Vec<Self>


### PR DESCRIPTION
Quick fix for the documentation of the `from_fills` method. 
Should be uncontroversial
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
