### PR TITLE
feat: add cursor_position to Buffer

### DIFF
--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -48,6 +48,8 @@ pub struct Buffer {
     /// The content of the buffer. The length of this Vec should always be equal to area.width *
     /// area.height
     pub content: Vec<Cell>,
+    /// The cursor shown for this buffer.
+    pub cursor_position: Option<(u16, u16)>,
 }
 
 impl Buffer {
@@ -62,7 +64,11 @@ impl Buffer {
     pub fn filled(area: Rect, cell: Cell) -> Self {
         let size = area.area() as usize;
         let content = vec![cell; size];
-        Self { area, content }
+        Self {
+            area,
+            content,
+            cursor_position: None,
+        }
     }
 
     /// Returns a Buffer containing the given lines
@@ -180,6 +186,19 @@ impl Buffer {
             self.area.x + (i as u16) % self.area.width,
             self.area.y + (i as u16) / self.area.width,
         )
+    }
+
+    /// After drawing the frame to which this buffer belongs, the cursor is made visible
+    /// and put at the specified (x,y) coordinates. If this method is not called, the
+    /// cursor will be hidden.
+    ///
+    /// Unless the cursor is set at the Frame directly, which takes precedence.
+    ///
+    /// Note that this will interfere with calls to `Terminal::hide_cursor()`,
+    /// `Terminal::show_cursor()`, and `Terminal::set_cursor()`. Pick one of the APIs and stick
+    /// with it.
+    pub fn set_cursor(&mut self, x: u16, y: u16) {
+        self.cursor_position = Some((x, y));
     }
 
     /// Print a string, starting at the position (x, y)

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -158,6 +158,7 @@ where
     /// Get a Frame object which provides a consistent view into the terminal state for rendering.
     pub fn get_frame(&mut self) -> Frame {
         let count = self.frame_count;
+        self.current_buffer_mut().cursor_position = None;
         Frame {
             cursor_position: None,
             viewport_area: self.viewport_area,
@@ -266,11 +267,12 @@ where
         self.autoresize()?;
 
         let mut frame = self.get_frame();
+
         f(&mut frame);
         // We can't change the cursor position right away because we have to flush the frame to
         // stdout first. But we also can't keep the frame around, since it holds a &mut to
         // Buffer. Thus, we're taking the important data out of the Frame and dropping it.
-        let cursor_position = frame.cursor_position;
+        let cursor_position = frame.cursor_position.or(frame.buffer.cursor_position);
 
         // Draw to stdout
         self.flush()?;


### PR DESCRIPTION
Maybe one way to go with #1044 is to recognize that there is already 
a context struct passed into render, and it's named Buffer. 

I gave this a try and added cursor_pos, and it doesn't fit too badly. 

--

The current state is quite a chore, when writing an application with more then 3 
text-input fields. You have to collect all the possible cursor-positions, check 
against the current focus and set the cursor. and all this in the application code.








