### PR TITLE
docs(examples): fix hyperlink example tape

### DIFF
--- a/examples/vhs/hyperlink.tape
+++ b/examples/vhs/hyperlink.tape
@@ -2,12 +2,12 @@
 # To run this script, install vhs and run `vhs ./examples/hello_world.tape`
 Output "target/hyperlink.gif"
 Set Theme "Aardvark Blue"
-Set Width 600
-Set Height 150
+Set Width 1200
+Set Height 200
 Hide
 Type "cargo run --example=hyperlink --features=crossterm,unstable-widget-ref"
 Enter
-Sleep 2s
+Sleep 3s
 Show
 Sleep 1s
 Hide


### PR DESCRIPTION
Fix for the current tape for the hyperlink example producing an empty image. Width was adjusted to be consistent with other tapes.