### PR TITLE
docs(examples): fix typos in tape files

### DIFF
--- a/examples/vhs/constraint-explorer.tape
+++ b/examples/vhs/constraint-explorer.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/constraints.tape`
+# To run this script, install vhs and run `vhs ./examples/constraint-explorer.tape`
 Output "target/constraint-explorer.gif"
 Set Theme "Aardvark Blue"
 Set FontSize 18

--- a/examples/vhs/demo2-destroy.tape
+++ b/examples/vhs/demo2-destroy.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/demo.tape`
+# To run this script, install vhs and run `vhs ./examples/demo2-destroy.tape`
 # NOTE: Requires VHS 0.6.1 or later for Screenshot support
 Output "target/demo2-destroy.gif"
 Set Theme "Aardvark Blue"

--- a/examples/vhs/demo2-social.tape
+++ b/examples/vhs/demo2-social.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/demo.tape`
+# To run this script, install vhs and run `vhs ./examples/demo2-social.tape`
 
 Output "target/demo2-social.gif"
 Set Theme "Aardvark Blue"

--- a/examples/vhs/demo2.tape
+++ b/examples/vhs/demo2.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/demo.tape`
+# To run this script, install vhs and run `vhs ./examples/demo2.tape`
 # NOTE: Requires VHS 0.6.1 or later for Screenshot support
 Output "target/demo2.gif"
 Set Theme "Aardvark Blue"

--- a/examples/vhs/docsrs.tape
+++ b/examples/vhs/docsrs.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/demo.tape`
+# To run this script, install vhs and run `vhs ./examples/docsrs.tape`
 # NOTE: Requires VHS 0.6.1 or later for Screenshot support
 Output "target/docsrs.gif"
 Set Theme "Aardvark Blue"

--- a/examples/vhs/flex.tape
+++ b/examples/vhs/flex.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/layout.tape`
+# To run this script, install vhs and run `vhs ./examples/flex.tape`
 Output "target/flex.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200

--- a/examples/vhs/hyperlink.tape
+++ b/examples/vhs/hyperlink.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/hello_world.tape`
+# To run this script, install vhs and run `vhs ./examples/hyperlink.tape`
 Output "target/hyperlink.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200

--- a/examples/vhs/minimal.tape
+++ b/examples/vhs/minimal.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/hello_world.tape`
+# To run this script, install vhs and run `vhs ./examples/minimal.tape`
 Output "target/minimal.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200

--- a/examples/vhs/ratatui-logo.tape
+++ b/examples/vhs/ratatui-logo.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/popup.tape`
+# To run this script, install vhs and run `vhs ./examples/ratatui-logo.tape`
 Output "target/ratatui-logo.gif"
 Set Theme "Aardvark Blue"
 Set Width 550

--- a/examples/vhs/tracing.tape
+++ b/examples/vhs/tracing.tape
@@ -1,5 +1,5 @@
 # This is a vhs script. See https://github.com/charmbracelet/vhs for more info.
-# To run this script, install vhs and run `vhs ./examples/barchart.tape`
+# To run this script, install vhs and run `vhs ./examples/tracing.tape`
 Output "target/tracing.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200


### PR DESCRIPTION
Fixes filename typos in example tape files to be consistent.