### PR TITLE
perf(widgets): Avoid extra allocations when rendering List, and `Table` content.

### DIFF
--- a/src/widgets/list/rendering.rs
+++ b/src/widgets/list/rendering.rs
@@ -108,7 +108,7 @@ impl StatefulWidgetRef for List<'_> {
             } else {
                 row_area
             };
-            item.content.clone().render(item_area, buf);
+            item.content.render_ref(item_area, buf);
 
             for j in 0..item.content.height() {
                 // if the item is selected, we need to display the highlight symbol:

--- a/src/widgets/table/cell.rs
+++ b/src/widgets/table/cell.rs
@@ -134,7 +134,7 @@ impl<'a> Cell<'a> {
 impl Cell<'_> {
     pub(crate) fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
-        self.content.clone().render(area, buf);
+        self.content.render_ref(area, buf);
     }
 }
 

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -722,7 +722,7 @@ impl Table<'_> {
                     ..row_area
                 };
                 buf.set_style(selection_area, row.style);
-                highlight_symbol.clone().render(selection_area, buf);
+                highlight_symbol.render_ref(selection_area, buf);
             };
             for ((x, width), cell) in columns_widths.iter().zip(row.cells.iter()) {
                 cell.render(


### PR DESCRIPTION
When rendering `List`, the content is copied which causes the `Text` to be cloned. This causes multiple allocations with the `Vec<Line<'_>>`, `Vec<Span<'_>>` in `Line<'_>`, and the `Cow` in `Span<'_>` if an owned value is being cloned. The same situation also applies to `Table`.

I ran the list benchmark, and on average there's roughly a %1-2 improvement, in timings (while the timings were consistently better I'm not exactly sure by how much since I can only test on my personal system). The change is mainly for memory usage and allocations, but wanted to point out the runtime performance improvement as well.
