### PR TITLE
perf(table): avoid extra allocations when rendering `Table`

### DIFF
--- a/src/widgets/table/cell.rs
+++ b/src/widgets/table/cell.rs
@@ -134,7 +134,7 @@ impl<'a> Cell<'a> {
 impl Cell<'_> {
     pub(crate) fn render(&self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
-        self.content.clone().render(area, buf);
+        self.content.render_ref(area, buf);
     }
 }
 

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -722,7 +722,7 @@ impl Table<'_> {
                     ..row_area
                 };
                 buf.set_style(selection_area, row.style);
-                highlight_symbol.clone().render(selection_area, buf);
+                highlight_symbol.render_ref(selection_area, buf);
             };
             for ((x, width), cell) in columns_widths.iter().zip(row.cells.iter()) {
                 cell.render(


### PR DESCRIPTION
When rendering a `Table` the `Text` stored inside of a `Cell` gets cloned before rendering. This removes the clone and uses `WidgetRef` instead, saving us from allocating a `Vec<Line<'_>>` inside `Text`. Also avoids an allocation when rendering the highlight symbol if it contains an owned value. 