### PR TITLE
chore(ci): change label from `breaking change` to `Type: Breaking Change`

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -71,7 +71,7 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: ['breaking change']
+            labels: ['Type: Breaking Change']
           })
 
   do-not-merge:


### PR DESCRIPTION
This PR changes the label that is auto attached to a PR with a breaking change per the conventional commits specification.