### PR TITLE
perf(list): avoid extra allocations when rendering `List`

### DIFF
--- a/src/widgets/list/rendering.rs
+++ b/src/widgets/list/rendering.rs
@@ -108,7 +108,7 @@ impl StatefulWidgetRef for List<'_> {
             } else {
                 row_area
             };
-            item.content.clone().render(item_area, buf);
+            item.content.render_ref(item_area, buf);
 
             for j in 0..item.content.height() {
                 // if the item is selected, we need to display the highlight symbol:


### PR DESCRIPTION
When rendering a `List`, each `ListItem` would be cloned. Removing the clone, and replacing `Widget::render` with `WidgetRef::render_ref` saves us allocations caused by the clone of the `Text<'_>` stored inside of `ListItem`. 

Based on the results of running the "list" benchmark locally; Performance is improved by %1-3 for all `render` benchmarks for `List`. 