### PR TITLE
fix: only apply style to first line when rendering a `Line`

### DIFF
--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -591,6 +591,7 @@ impl WidgetRef for Line<'_> {
         if area.is_empty() {
             return;
         }
+        let area = Rect { height: 1, ..area };
         let line_width = self.width();
         if line_width == 0 {
             return;
@@ -1118,6 +1119,17 @@ mod tests {
             hello_world().render(Rect::new(0, 0, 15, 1), &mut buf);
             let mut expected = Buffer::with_lines(["Hello world!        "]);
             expected.set_style(Rect::new(0, 0, 15, 1), ITALIC);
+            expected.set_style(Rect::new(0, 0, 6, 1), BLUE);
+            expected.set_style(Rect::new(6, 0, 6, 1), GREEN);
+            assert_eq!(buf, expected);
+        }
+
+        #[test]
+        fn render_only_styles_first_line() {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 20, 2));
+            hello_world().render(buf.area, &mut buf);
+            let mut expected = Buffer::with_lines(["Hello world!        ", "                    "]);
+            expected.set_style(Rect::new(0, 0, 20, 1), ITALIC);
             expected.set_style(Rect::new(0, 0, 6, 1), BLUE);
             expected.set_style(Rect::new(6, 0, 6, 1), GREEN);
             assert_eq!(buf, expected);


### PR DESCRIPTION
A `Line` widget should only apply its style to the first line when
rendering and not the entire area. This is because the `Line` widget
should only render a single line of text. This commit fixes the issue by
clamping the area to a single line before rendering the text.
