### PR TITLE
fix(TestBackend): prevent area mismatch

### DIFF
--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -34,9 +34,7 @@ use crate::{
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TestBackend {
-    width: u16,
     buffer: Buffer,
-    height: u16,
     cursor: bool,
     pos: (u16, u16),
 }
@@ -74,8 +72,6 @@ impl TestBackend {
     /// Creates a new `TestBackend` with the specified width and height.
     pub fn new(width: u16, height: u16) -> Self {
         Self {
-            width,
-            height,
             buffer: Buffer::empty(Rect::new(0, 0, width, height)),
             cursor: false,
             pos: (0, 0),
@@ -90,8 +86,6 @@ impl TestBackend {
     /// Resizes the `TestBackend` to the specified width and height.
     pub fn resize(&mut self, width: u16, height: u16) {
         self.buffer.resize(Rect::new(0, 0, width, height));
-        self.width = width;
-        self.height = height;
     }
 
     /// Asserts that the `TestBackend`'s buffer is equal to the expected buffer.
@@ -182,12 +176,12 @@ impl Backend for TestBackend {
             }
             ClearType::CurrentLine => {
                 let line_start_index = self.buffer.index_of(0, self.pos.1);
-                let line_end_index = self.buffer.index_of(self.width - 1, self.pos.1);
+                let line_end_index = self.buffer.index_of(self.buffer.area.width - 1, self.pos.1);
                 &mut self.buffer.content[line_start_index..=line_end_index]
             }
             ClearType::UntilNewLine => {
                 let index = self.buffer.index_of(self.pos.0, self.pos.1);
-                let line_end_index = self.buffer.index_of(self.width - 1, self.pos.1);
+                let line_end_index = self.buffer.index_of(self.buffer.area.width - 1, self.pos.1);
                 &mut self.buffer.content[index..=line_end_index]
             }
         };
@@ -211,24 +205,23 @@ impl Backend for TestBackend {
     /// be added after the current position and the cursor will be moved to the last row.
     fn append_lines(&mut self, n: u16) -> io::Result<()> {
         let (cur_x, cur_y) = self.get_cursor()?;
+        let Rect { width, height, .. } = self.buffer.area;
 
         // the next column ensuring that we don't go past the last column
-        let new_cursor_x = cur_x.saturating_add(1).min(self.width.saturating_sub(1));
+        let new_cursor_x = cur_x.saturating_add(1).min(width.saturating_sub(1));
 
-        let max_y = self.height.saturating_sub(1);
+        let max_y = height.saturating_sub(1);
         let lines_after_cursor = max_y.saturating_sub(cur_y);
         if n > lines_after_cursor {
             let rotate_by = n.saturating_sub(lines_after_cursor).min(max_y);
 
-            if rotate_by == self.height - 1 {
+            if rotate_by == height - 1 {
                 self.clear()?;
             }
 
             self.set_cursor(0, rotate_by)?;
             self.clear_region(ClearType::BeforeCursor)?;
-            self.buffer
-                .content
-                .rotate_left((self.width * rotate_by).into());
+            self.buffer.content.rotate_left((width * rotate_by).into());
         }
 
         let new_cursor_y = cur_y.saturating_add(n).min(max_y);
@@ -238,7 +231,7 @@ impl Backend for TestBackend {
     }
 
     fn size(&self) -> io::Result<Rect> {
-        Ok(Rect::new(0, 0, self.width, self.height))
+        Ok(self.buffer.area)
     }
 
     fn window_size(&mut self) -> io::Result<WindowSize> {
@@ -248,7 +241,7 @@ impl Backend for TestBackend {
             height: 480,
         };
         Ok(WindowSize {
-            columns_rows: (self.width, self.height).into(),
+            columns_rows: self.buffer.area.as_size(),
             pixels: WINDOW_PIXEL_SIZE,
         })
     }
@@ -267,8 +260,6 @@ mod tests {
         assert_eq!(
             TestBackend::new(10, 2),
             TestBackend {
-                width: 10,
-                height: 2,
                 buffer: Buffer::with_lines(["          "; 2]),
                 cursor: false,
                 pos: (0, 0),


### PR DESCRIPTION
`TestBackend::new(400, 400)` resulted in a Rect with width/height 255,255 and a locally stored width/height of 400,400 which is wrong.

`TestBackend::new` could have been fixed, but this prevents this kind of error completely as its stored only at a single location now.

Hint for `serde` feature users: The `TestBackend` representation changes. It should be able to read older data, but data generated after this change can't be read by older versions.