### PR TITLE
feat!: add `get/set_cursor_position()` methods to Terminal and Backend

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -11,10 +11,12 @@ GitHub with a [breaking change] label.
 This is a quick summary of the sections below:
 
 - [v0.28.0](#v0280) (unreleased)
+  ⁻ `Backend::size` returns `Size` instead of `Rect`
+  - `Backend` trait migrates to `get/set_cursor_position`
   - Ratatui now requires Crossterm 0.28.0
+  - `Axis::labels` now accepts `Vec<T: Into<Line>>`
   - `Layout::init_cache` no longer returns bool and takes a `NonZeroUsize` instead of `usize`
   - `ratatui::terminal` module is now private
-  - `Axis::labels` now accepts `Vec<T: Into<Line>>`
   - `ToText` no longer has a lifetime
 - [v0.27.0](#v0270)
   - List no clamps the selected index to list
@@ -70,6 +72,17 @@ This is a quick summary of the sections below:
 
 The `Backend::size` method returns a `Size` instead of a `Rect`.
 There is no need for the position here as it was always 0,0.
+
+### `Backend` trait migrates to `get/set_cursor_position` ([#1284])
+
+[#1284]: https://github.com/ratatui-org/ratatui/pull/1284
+
+If you just use the types implementing the `Backend` trait, you will see deprecation hints but
+nothing is a breaking change for you.
+
+If you implement the Backend trait yourself, you need to update the implementation and add the
+`get/set_cursor_position` method. You can remove the `get/set_cursor` methods as they are deprecated
+and a default implementation for them exists.
 
 ### Ratatui now requires Crossterm 0.28.0 ([#1278])
 

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -36,7 +36,7 @@ use ratatui::{
         execute,
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     },
-    layout::{Constraint, Layout},
+    layout::{Constraint, Layout, Position},
     style::{Color, Modifier, Style, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, List, ListItem, Paragraph},
@@ -245,22 +245,19 @@ fn ui(f: &mut Frame, app: &App) {
         .block(Block::bordered().title("Input"));
     f.render_widget(input, input_area);
     match app.input_mode {
-        InputMode::Normal =>
-            // Hide the cursor. `Frame` does this by default, so we don't need to do anything here
-            {}
+        // Hide the cursor. `Frame` does this by default, so we don't need to do anything here
+        InputMode::Normal => {}
 
-        InputMode::Editing => {
-            // Make the cursor visible and ask ratatui to put it at the specified coordinates after
-            // rendering
-            #[allow(clippy::cast_possible_truncation)]
-            f.set_cursor(
-                // Draw the cursor at the current position in the input field.
-                // This position is can be controlled via the left and right arrow key
-                input_area.x + app.character_index as u16 + 1,
-                // Move one line down, from the border to the input line
-                input_area.y + 1,
-            );
-        }
+        // Make the cursor visible and ask ratatui to put it at the specified coordinates after
+        // rendering
+        #[allow(clippy::cast_possible_truncation)]
+        InputMode::Editing => f.set_cursor(Position::new(
+            // Draw the cursor at the current position in the input field.
+            // This position is can be controlled via the left and right arrow key
+            input_area.x + app.character_index as u16 + 1,
+            // Move one line down, from the border to the input line
+            input_area.y + 1,
+        )),
     }
 
     let messages: Vec<ListItem> = app

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -251,7 +251,7 @@ fn ui(f: &mut Frame, app: &App) {
         // Make the cursor visible and ask ratatui to put it at the specified coordinates after
         // rendering
         #[allow(clippy::cast_possible_truncation)]
-        InputMode::Editing => f.set_cursor(Position::new(
+        InputMode::Editing => f.set_cursor_position(Position::new(
             // Draw the cursor at the current position in the input field.
             // This position is can be controlled via the left and right arrow key
             input_area.x + app.character_index as u16 + 1,

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -104,7 +104,10 @@ use std::io;
 
 use strum::{Display, EnumString};
 
-use crate::{buffer::Cell, layout::Size, prelude::Rect};
+use crate::{
+    buffer::Cell,
+    layout::{Position, Rect, Size},
+};
 
 #[cfg(feature = "termion")]
 mod termion;
@@ -210,7 +213,7 @@ pub trait Backend {
     /// See [`set_cursor`] for an example.
     ///
     /// [`set_cursor`]: Backend::set_cursor
-    fn get_cursor(&mut self) -> io::Result<(u16, u16)>;
+    fn get_cursor(&mut self) -> io::Result<Position>;
 
     /// Set the cursor position on the terminal screen to the given x and y coordinates.
     ///
@@ -220,14 +223,15 @@ pub trait Backend {
     ///
     /// ```rust
     /// # use ratatui::backend::{Backend, TestBackend};
+    /// # use ratatui::layout::Position;
     /// # let mut backend = TestBackend::new(80, 25);
-    /// backend.set_cursor(10, 20)?;
-    /// assert_eq!(backend.get_cursor()?, (10, 20));
+    /// backend.set_cursor(Position { x: 10, y: 20 })?;
+    /// assert_eq!(backend.get_cursor()?, Position { x: 10, y: 20 });
     /// # std::io::Result::Ok(())
     /// ```
     ///
     /// [`get_cursor`]: Backend::get_cursor
-    fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()>;
+    fn set_cursor<P: Into<Position>>(&mut self, position: P) -> io::Result<()>;
 
     /// Clears the whole terminal screen
     ///

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -195,25 +195,25 @@ pub trait Backend {
     /// # std::io::Result::Ok(())
     /// ```
     ///
-    /// [`show_cursor`]: Backend::show_cursor
+    /// [`show_cursor`]: Self::show_cursor
     fn hide_cursor(&mut self) -> io::Result<()>;
 
     /// Show the cursor on the terminal screen.
     ///
     /// See [`hide_cursor`] for an example.
     ///
-    /// [`hide_cursor`]: Backend::hide_cursor
+    /// [`hide_cursor`]: Self::hide_cursor
     fn show_cursor(&mut self) -> io::Result<()>;
 
     /// Get the current cursor position on the terminal screen.
     ///
-    /// The returned tuple contains the x and y coordinates of the cursor. The origin
-    /// (0, 0) is at the top left corner of the screen.
+    /// The returned tuple contains the x and y coordinates of the cursor.
+    /// The origin (0, 0) is at the top left corner of the screen.
     ///
-    /// See [`set_cursor`] for an example.
+    /// See [`set_cursor_position`] for an example.
     ///
-    /// [`set_cursor`]: Backend::set_cursor
-    fn get_cursor(&mut self) -> io::Result<Position>;
+    /// [`set_cursor_position`]: Self::set_cursor_position
+    fn get_cursor_position(&mut self) -> io::Result<Position>;
 
     /// Set the cursor position on the terminal screen to the given x and y coordinates.
     ///
@@ -225,13 +225,29 @@ pub trait Backend {
     /// # use ratatui::backend::{Backend, TestBackend};
     /// # use ratatui::layout::Position;
     /// # let mut backend = TestBackend::new(80, 25);
-    /// backend.set_cursor(Position { x: 10, y: 20 })?;
-    /// assert_eq!(backend.get_cursor()?, Position { x: 10, y: 20 });
+    /// backend.set_cursor_position(Position { x: 10, y: 20 })?;
+    /// assert_eq!(backend.get_cursor_position()?, Position { x: 10, y: 20 });
     /// # std::io::Result::Ok(())
     /// ```
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()>;
+
+    /// Get the current cursor position on the terminal screen.
     ///
-    /// [`get_cursor`]: Backend::get_cursor
-    fn set_cursor<P: Into<Position>>(&mut self, position: P) -> io::Result<()>;
+    /// The returned tuple contains the x and y coordinates of the cursor. The origin
+    /// (0, 0) is at the top left corner of the screen.
+    #[deprecated = "the method get_cursor_position indicates more clearly what about the cursor to get"]
+    fn get_cursor(&mut self) -> io::Result<(u16, u16)> {
+        let Position { x, y } = self.get_cursor_position()?;
+        Ok((x, y))
+    }
+
+    /// Set the cursor position on the terminal screen to the given x and y coordinates.
+    ///
+    /// The origin (0, 0) is at the top left corner of the screen.
+    #[deprecated = "the method set_cursor_position indicates more clearly what about the cursor to set"]
+    fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()> {
+        self.set_cursor_position(Position { x, y })
+    }
 
     /// Clears the whole terminal screen
     ///
@@ -265,7 +281,7 @@ pub trait Backend {
     /// This method will return an error if the terminal screen could not be cleared. It will also
     /// return an error if the `clear_type` is not supported by the backend.
     ///
-    /// [`clear`]: Backend::clear
+    /// [`clear`]: Self::clear
     fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
         match clear_type {
             ClearType::All => self.clear(),

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -212,12 +212,14 @@ where
         execute!(self.writer, Show)
     }
 
-    fn get_cursor(&mut self) -> io::Result<(u16, u16)> {
+    fn get_cursor(&mut self) -> io::Result<Position> {
         crossterm::cursor::position()
+            .map(|(x, y)| Position { x, y })
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
     }
 
-    fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()> {
+    fn set_cursor<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+        let Position { x, y } = position.into();
         execute!(self.writer, MoveTo(x, y))
     }
 

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -212,13 +212,13 @@ where
         execute!(self.writer, Show)
     }
 
-    fn get_cursor(&mut self) -> io::Result<Position> {
+    fn get_cursor_position(&mut self) -> io::Result<Position> {
         crossterm::cursor::position()
             .map(|(x, y)| Position { x, y })
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
     }
 
-    fn set_cursor<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
         let Position { x, y } = position.into();
         execute!(self.writer, MoveTo(x, y))
     }

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -157,11 +157,13 @@ where
         self.writer.flush()
     }
 
-    fn get_cursor(&mut self) -> io::Result<(u16, u16)> {
-        termion::cursor::DetectCursorPos::cursor_pos(&mut self.writer).map(|(x, y)| (x - 1, y - 1))
+    fn get_cursor(&mut self) -> io::Result<Position> {
+        termion::cursor::DetectCursorPos::cursor_pos(&mut self.writer)
+            .map(|(x, y)| Position { x: x - 1, y: y - 1 })
     }
 
-    fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()> {
+    fn set_cursor<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+        let Position { x, y } = position.into();
         write!(self.writer, "{}", termion::cursor::Goto(x + 1, y + 1))?;
         self.writer.flush()
     }

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -157,12 +157,12 @@ where
         self.writer.flush()
     }
 
-    fn get_cursor(&mut self) -> io::Result<Position> {
+    fn get_cursor_position(&mut self) -> io::Result<Position> {
         termion::cursor::DetectCursorPos::cursor_pos(&mut self.writer)
             .map(|(x, y)| Position { x: x - 1, y: y - 1 })
     }
 
-    fn set_cursor<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
         let Position { x, y } = position.into();
         write!(self.writer, "{}", termion::cursor::Goto(x + 1, y + 1))?;
         self.writer.flush()

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -192,12 +192,15 @@ impl Backend for TermwizBackend {
         Ok(())
     }
 
-    fn get_cursor(&mut self) -> io::Result<crate::layout::Position> {
+    fn get_cursor_position(&mut self) -> io::Result<crate::layout::Position> {
         let (x, y) = self.buffered_terminal.cursor_position();
         Ok((x as u16, y as u16).into())
     }
 
-    fn set_cursor<P: Into<crate::layout::Position>>(&mut self, position: P) -> io::Result<()> {
+    fn set_cursor_position<P: Into<crate::layout::Position>>(
+        &mut self,
+        position: P,
+    ) -> io::Result<()> {
         let crate::layout::Position { x, y } = position.into();
         self.buffered_terminal.add_change(Change::CursorPosition {
             x: Position::Absolute(x as usize),

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -192,12 +192,13 @@ impl Backend for TermwizBackend {
         Ok(())
     }
 
-    fn get_cursor(&mut self) -> io::Result<(u16, u16)> {
+    fn get_cursor(&mut self) -> io::Result<crate::layout::Position> {
         let (x, y) = self.buffered_terminal.cursor_position();
-        Ok((x as u16, y as u16))
+        Ok((x as u16, y as u16).into())
     }
 
-    fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()> {
+    fn set_cursor<P: Into<crate::layout::Position>>(&mut self, position: P) -> io::Result<()> {
+        let crate::layout::Position { x, y } = position.into();
         self.buffered_terminal.add_change(Change::CursorPosition {
             x: Position::Absolute(x as usize),
             y: Position::Absolute(y as usize),

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -117,6 +117,19 @@ impl TestBackend {
     {
         self.assert_buffer(&Buffer::with_lines(expected));
     }
+
+    /// Asserts that the `TestBackend`'s cursor position is equal to the expected one.
+    ///
+    /// This is a shortcut for `assert_eq!(self.get_cursor_position().unwrap(), expected)`.
+    ///
+    /// # Panics
+    /// When they are not equal, a panic occurs with a detailed error message showing the
+    /// differences between the expected and actual position.
+    #[track_caller]
+    pub fn assert_cursor_position<P: Into<Position>>(&mut self, position: P) {
+        let actual = self.get_cursor_position().unwrap();
+        assert_eq!(actual, position.into());
+    }
 }
 
 impl fmt::Display for TestBackend {
@@ -347,6 +360,12 @@ mod tests {
     }
 
     #[test]
+    fn assert_cursor_position() {
+        let mut backend = TestBackend::new(10, 2);
+        backend.assert_cursor_position(Position::ORIGIN);
+    }
+
+    #[test]
     fn set_cursor_position() {
         let mut backend = TestBackend::new(10, 10);
         backend
@@ -499,28 +518,16 @@ mod tests {
         // newline simply moves the cursor down and to the right
 
         backend.append_lines(1).unwrap();
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 1, y: 1 }
-        );
+        backend.assert_cursor_position(Position { x: 1, y: 1 });
 
         backend.append_lines(1).unwrap();
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 2, y: 2 }
-        );
+        backend.assert_cursor_position(Position { x: 2, y: 2 });
 
         backend.append_lines(1).unwrap();
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 3, y: 3 }
-        );
+        backend.assert_cursor_position(Position { x: 3, y: 3 });
 
         backend.append_lines(1).unwrap();
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 4, y: 4 }
-        );
+        backend.assert_cursor_position(Position { x: 4, y: 4 });
 
         // As such the buffer should remain unchanged
         backend.assert_buffer_lines([
@@ -561,10 +568,7 @@ mod tests {
 
         // It also moves the cursor to the right, as is common of the behaviour of
         // terminals in raw-mode
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 1, y: 4 }
-        );
+        backend.assert_cursor_position(Position { x: 1, y: 4 });
     }
 
     #[test]
@@ -584,10 +588,7 @@ mod tests {
         // newlines simply moves the cursor n lines down and to the right by 1
 
         backend.append_lines(4).unwrap();
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 1, y: 4 }
-        );
+        backend.assert_cursor_position(Position { x: 1, y: 4 });
 
         // As such the buffer should remain unchanged
         backend.assert_buffer_lines([
@@ -615,10 +616,7 @@ mod tests {
             .unwrap();
 
         backend.append_lines(3).unwrap();
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 1, y: 4 }
-        );
+        backend.assert_cursor_position(Position { x: 1, y: 4 });
 
         backend.assert_buffer_lines([
             "cccccccccc",
@@ -645,10 +643,7 @@ mod tests {
             .unwrap();
 
         backend.append_lines(5).unwrap();
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 1, y: 4 }
-        );
+        backend.assert_cursor_position(Position { x: 1, y: 4 });
 
         backend.assert_buffer_lines([
             "          ",
@@ -673,10 +668,7 @@ mod tests {
         backend.set_cursor_position(Position::ORIGIN).unwrap();
 
         backend.append_lines(5).unwrap();
-        assert_eq!(
-            backend.get_cursor_position().unwrap(),
-            Position { x: 1, y: 4 }
-        );
+        backend.assert_cursor_position(Position { x: 1, y: 4 });
 
         backend.assert_buffer_lines([
             "bbbbbbbbbb",

--- a/src/terminal/frame.rs
+++ b/src/terminal/frame.rs
@@ -166,8 +166,8 @@ impl Frame<'_> {
     /// Note that this will interfere with calls to `Terminal::hide_cursor()`,
     /// `Terminal::show_cursor()`, and `Terminal::set_cursor()`. Pick one of the APIs and stick
     /// with it.
-    pub fn set_cursor(&mut self, x: u16, y: u16) {
-        self.cursor_position = Some(Position { x, y });
+    pub fn set_cursor<P: Into<Position>>(&mut self, position: P) {
+        self.cursor_position = Some(position.into());
     }
 
     /// Gets the buffer that this `Frame` draws into as a mutable reference.

--- a/src/terminal/frame.rs
+++ b/src/terminal/frame.rs
@@ -163,11 +163,22 @@ impl Frame<'_> {
     /// After drawing this frame, make the cursor visible and put it at the specified (x, y)
     /// coordinates. If this method is not called, the cursor will be hidden.
     ///
-    /// Note that this will interfere with calls to `Terminal::hide_cursor()`,
-    /// `Terminal::show_cursor()`, and `Terminal::set_cursor()`. Pick one of the APIs and stick
-    /// with it.
-    pub fn set_cursor<P: Into<Position>>(&mut self, position: P) {
+    /// Note that this will interfere with calls to [`Terminal::hide_cursor`],
+    /// [`Terminal::show_cursor`], and [`Terminal::set_cursor_position`]. Pick one of the APIs and
+    /// stick with it.
+    pub fn set_cursor_position<P: Into<Position>>(&mut self, position: P) {
         self.cursor_position = Some(position.into());
+    }
+
+    /// After drawing this frame, make the cursor visible and put it at the specified (x, y)
+    /// coordinates. If this method is not called, the cursor will be hidden.
+    ///
+    /// Note that this will interfere with calls to [`Terminal::hide_cursor`],
+    /// [`Terminal::show_cursor`], and [`Terminal::set_cursor_position`]. Pick one of the APIs and
+    /// stick with it.
+    #[deprecated = "the method set_cursor_position indicates more clearly what about the cursor to set"]
+    pub fn set_cursor(&mut self, x: u16, y: u16) {
+        self.set_cursor_position(Position { x, y });
     }
 
     /// Gets the buffer that this `Frame` draws into as a mutable reference.

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -28,9 +28,10 @@ use crate::{backend::ClearType, prelude::*, CompletedFrame, TerminalOptions, Vie
 /// # Examples
 ///
 /// ```rust,no_run
+/// # use ratatui::prelude::*;
 /// use std::io::stdout;
 ///
-/// use ratatui::{prelude::*, widgets::Paragraph};
+/// use ratatui::widgets::Paragraph;
 ///
 /// let backend = CrosstermBackend::new(stdout());
 /// let mut terminal = Terminal::new(backend)?;
@@ -333,7 +334,7 @@ where
     /// # Examples
     ///
     /// ```should_panic
-    /// # use ratatui::prelude::*;
+    /// # use ratatui::layout::Position;;
     /// # let backend = ratatui::backend::TestBackend::new(10, 10);
     /// # let mut terminal = ratatui::Terminal::new(backend)?;
     /// use std::io;

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -37,7 +37,6 @@ use crate::{backend::ClearType, prelude::*, CompletedFrame, TerminalOptions, Vie
 /// terminal.draw(|frame| {
 ///     let area = frame.size();
 ///     frame.render_widget(Paragraph::new("Hello World!"), area);
-///     frame.set_cursor(0, 0);
 /// })?;
 /// # std::io::Result::Ok(())
 /// ```
@@ -265,17 +264,16 @@ where
     /// # Examples
     ///
     /// ```
+    /// # use ratatui::layout::Position;
     /// # let backend = ratatui::backend::TestBackend::new(10, 10);
     /// # let mut terminal = ratatui::Terminal::new(backend)?;
-    /// use std::io;
-    ///
     /// use ratatui::widgets::Paragraph;
     ///
     /// // with a closure
     /// terminal.draw(|frame| {
     ///     let area = frame.size();
     ///     frame.render_widget(Paragraph::new("Hello World!"), area);
-    ///     frame.set_cursor(0, 0);
+    ///     frame.set_cursor(Position { x: 0, y: 0 });
     /// })?;
     ///
     /// // or with a function
@@ -284,7 +282,7 @@ where
     /// fn render(frame: &mut ratatui::Frame) {
     ///     frame.render_widget(Paragraph::new("Hello World!"), frame.size());
     /// }
-    /// # io::Result::Ok(())
+    /// # std::io::Result::Ok(())
     /// ```
     pub fn draw<F>(&mut self, render_callback: F) -> io::Result<CompletedFrame>
     where
@@ -335,6 +333,7 @@ where
     /// # Examples
     ///
     /// ```should_panic
+    /// # use ratatui::prelude::*;
     /// # let backend = ratatui::backend::TestBackend::new(10, 10);
     /// # let mut terminal = ratatui::Terminal::new(backend)?;
     /// use std::io;
@@ -346,7 +345,7 @@ where
     ///     let value: u8 = "not a number".parse().map_err(io::Error::other)?;
     ///     let area = frame.size();
     ///     frame.render_widget(Paragraph::new("Hello World!"), area);
-    ///     frame.set_cursor(0, 0);
+    ///     frame.set_cursor(Position { x: 0, y: 0 });
     ///     io::Result::Ok(())
     /// })?;
     ///
@@ -383,9 +382,9 @@ where
 
         match cursor_position {
             None => self.hide_cursor()?,
-            Some(Position { x, y }) => {
+            Some(position) => {
                 self.show_cursor()?;
-                self.set_cursor(x, y)?;
+                self.set_cursor(position)?;
             }
         }
 
@@ -424,14 +423,15 @@ where
     ///
     /// This is the position of the cursor after the last draw call and is returned as a tuple of
     /// `(x, y)` coordinates.
-    pub fn get_cursor(&mut self) -> io::Result<(u16, u16)> {
+    pub fn get_cursor(&mut self) -> io::Result<Position> {
         self.backend.get_cursor()
     }
 
     /// Sets the cursor position.
-    pub fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()> {
-        self.backend.set_cursor(x, y)?;
-        self.last_known_cursor_pos = Position { x, y };
+    pub fn set_cursor<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+        let position = position.into();
+        self.backend.set_cursor(position)?;
+        self.last_known_cursor_pos = position;
         Ok(())
     }
 
@@ -440,13 +440,12 @@ where
         match self.viewport {
             Viewport::Fullscreen => self.backend.clear_region(ClearType::All)?,
             Viewport::Inline(_) => {
-                self.backend
-                    .set_cursor(self.viewport_area.left(), self.viewport_area.top())?;
+                self.backend.set_cursor(self.viewport_area.as_position())?;
                 self.backend.clear_region(ClearType::AfterCursor)?;
             }
             Viewport::Fixed(area) => {
-                for row in area.top()..area.bottom() {
-                    self.backend.set_cursor(0, row)?;
+                for y in area.top()..area.bottom() {
+                    self.backend.set_cursor(Position { x: 0, y })?;
                     self.backend.clear_region(ClearType::AfterCursor)?;
                 }
             }
@@ -561,7 +560,7 @@ where
             });
             self.backend.draw(iter)?;
             self.backend.flush()?;
-            self.set_cursor(self.viewport_area.left(), self.viewport_area.top())?;
+            self.set_cursor(self.viewport_area.as_position())?;
         }
 
         Ok(())
@@ -574,7 +573,7 @@ fn compute_inline_size<B: Backend>(
     size: Rect,
     offset_in_previous_viewport: u16,
 ) -> io::Result<(Rect, Position)> {
-    let pos: Position = backend.get_cursor()?.into();
+    let pos = backend.get_cursor()?;
     let mut row = pos.y;
 
     let max_height = size.height.min(height);


### PR DESCRIPTION
Idea from https://github.com/ratatui-org/ratatui/pull/1254#issuecomment-2264919603

Usage search: https://github.com/search?q=ratatui+.set_cursor+AND+(NOT+org%3Aratatui-org)+AND+(NOT+is%3Afork)+AND+(NOT+is%3Aarchived)&type=code

