### PR TITLE
feat!: replace Margin and Padding with Gaps

### DIFF
--- a/benches/block.rs
+++ b/benches/block.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Bencher, Criterion};
 use ratatui::{
     buffer::Buffer,
-    layout::{Alignment, Rect},
+    layout::{Alignment, Gaps, Rect},
     widgets::{
         block::{Position, Title},
-        Block, Padding, Widget,
+        Block, Widget,
     },
 };
 
@@ -30,7 +30,7 @@ fn block(c: &mut Criterion) {
         group.bench_with_input(
             format!("render_all_feature/{width}x{height}"),
             &Block::bordered()
-                .padding(Padding::new(5, 5, 2, 2))
+                .padding(Gaps::horizontal_vertical(5, 2))
                 .title("test title")
                 .title(
                     Title::from("bottom left title")

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -28,12 +28,12 @@ use ratatui::{
         execute,
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     },
-    layout::{Alignment, Constraint, Layout, Rect},
+    layout::{Alignment, Constraint, Gaps, Layout, Rect},
     style::{Style, Stylize},
     text::Line,
     widgets::{
         block::{Position, Title},
-        Block, BorderType, Borders, Padding, Paragraph, Wrap,
+        Block, BorderType, Borders, Paragraph, Wrap,
     },
     Frame,
 };
@@ -244,7 +244,12 @@ fn render_multiple_title_positions(paragraph: &Paragraph, frame: &mut Frame, are
 
 fn render_padding(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
     let block = Block::bordered()
-        .padding(Padding::new(5, 10, 1, 2))
+        .padding(Gaps {
+            left: 5,
+            right: 10,
+            top: 1,
+            bottom: 2,
+        })
         .title("Padding");
     frame.render_widget(paragraph.clone().block(block), area);
 }

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -26,14 +26,14 @@ use ratatui::{
     },
     layout::{
         Constraint::{self, Fill, Length, Max, Min, Percentage, Ratio},
-        Layout, Rect,
+        Gaps, Layout, Rect,
     },
     style::{palette::tailwind, Color, Modifier, Style, Stylize},
     symbols,
     text::Line,
     widgets::{
-        Block, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget,
-        Tabs, Widget,
+        Block, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Tabs,
+        Widget,
     },
     Terminal,
 };
@@ -206,12 +206,7 @@ impl App {
         );
         Paragraph::new(width_bar.dark_gray())
             .centered()
-            .block(Block::new().padding(Padding {
-                left: 0,
-                right: 0,
-                top: 1,
-                bottom: 0,
-            }))
+            .block(Block::new().padding(Gaps::top(1)))
             .render(area, buf);
     }
 

--- a/examples/demo2/tabs/about.rs
+++ b/examples/demo2/tabs/about.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
-    layout::{Alignment, Constraint, Layout, Margin, Rect},
-    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget, Wrap},
+    layout::{Alignment, Constraint, Gaps, Layout, Rect},
+    widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap},
 };
 
 use crate::{RgbSwatch, THEME};
@@ -68,16 +68,10 @@ impl Widget for AboutTab {
 }
 
 fn render_crate_description(area: Rect, buf: &mut Buffer) {
-    let area = area.inner(Margin {
-        vertical: 4,
-        horizontal: 2,
-    });
+    let area = area.inner(Gaps::horizontal_vertical(2, 4));
     Clear.render(area, buf); // clear out the color swatches
     Block::new().style(THEME.content).render(area, buf);
-    let area = area.inner(Margin {
-        vertical: 1,
-        horizontal: 2,
-    });
+    let area = area.inner(Gaps::horizontal_vertical(2, 1));
     let text = "- cooking up terminal user interfaces -
 
     Ratatui is a Rust crate that provides widgets (e.g. Paragraph, Table) and draws them to the \
@@ -89,8 +83,7 @@ fn render_crate_description(area: Rect, buf: &mut Buffer) {
                 .title(" Ratatui ")
                 .title_alignment(Alignment::Center)
                 .borders(Borders::TOP)
-                .border_style(THEME.description_title)
-                .padding(Padding::new(0, 0, 0, 0)),
+                .border_style(THEME.description_title),
         )
         .wrap(Wrap { trim: true })
         .scroll((0, 0))
@@ -108,10 +101,7 @@ pub fn render_logo(selected_row: usize, area: Rect, buf: &mut Buffer) {
     } else {
         THEME.logo.rat_eye_alt
     };
-    let area = area.inner(Margin {
-        vertical: 0,
-        horizontal: 2,
-    });
+    let area = area.inner(Gaps::horizontal(2));
     for (y, (line1, line2)) in RATATUI_LOGO.iter().tuples().enumerate() {
         for (x, (ch1, ch2)) in line1.chars().zip(line2.chars()).enumerate() {
             let x = area.left() + x as u16;

--- a/examples/demo2/tabs/email.rs
+++ b/examples/demo2/tabs/email.rs
@@ -1,12 +1,12 @@
 use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
-    layout::{Constraint, Layout, Margin, Rect},
+    layout::{Constraint, Gaps, Layout, Rect},
     style::{Styled, Stylize},
     text::Line,
     widgets::{
-        Block, BorderType, Borders, Clear, List, ListItem, ListState, Padding, Paragraph,
-        Scrollbar, ScrollbarState, StatefulWidget, Tabs, Widget,
+        Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Scrollbar,
+        ScrollbarState, StatefulWidget, Tabs, Widget,
     },
 };
 use unicode_width::UnicodeWidthStr;
@@ -68,10 +68,7 @@ impl EmailTab {
 impl Widget for EmailTab {
     fn render(self, area: Rect, buf: &mut Buffer) {
         RgbSwatch.render(area, buf);
-        let area = area.inner(Margin {
-            vertical: 1,
-            horizontal: 2,
-        });
+        let area = area.inner(Gaps::horizontal_vertical(2, 1));
         Clear.render(area, buf);
         let vertical = Layout::vertical([Constraint::Length(5), Constraint::Min(0)]);
         let [inbox, email] = vertical.areas(area);
@@ -129,7 +126,7 @@ fn render_email(selected_index: usize, area: Rect, buf: &mut Buffer) {
     let email = EMAILS.get(selected_index);
     let block = Block::new()
         .style(theme.body)
-        .padding(Padding::new(2, 2, 0, 0))
+        .padding(Gaps::horizontal(2))
         .borders(Borders::TOP)
         .border_type(BorderType::Thick);
     let inner = block.inner(area);

--- a/examples/demo2/tabs/recipe.rs
+++ b/examples/demo2/tabs/recipe.rs
@@ -1,11 +1,11 @@
 use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
-    layout::{Alignment, Constraint, Layout, Margin, Rect},
+    layout::{Alignment, Constraint, Gaps, Layout, Rect},
     style::{Style, Stylize},
     text::Line,
     widgets::{
-        Block, Clear, Padding, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState,
+        Block, Clear, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState,
         StatefulWidget, Table, TableState, Widget, Wrap,
     },
 };
@@ -114,16 +114,18 @@ impl RecipeTab {
 impl Widget for RecipeTab {
     fn render(self, area: Rect, buf: &mut Buffer) {
         RgbSwatch.render(area, buf);
-        let area = area.inner(Margin {
-            vertical: 1,
-            horizontal: 2,
-        });
+        let area = area.inner(Gaps::horizontal_vertical(2, 1));
         Clear.render(area, buf);
         Block::new()
             .title("Ratatouille Recipe".bold().white())
             .title_alignment(Alignment::Center)
             .style(THEME.content)
-            .padding(Padding::new(1, 1, 2, 1))
+            .padding(Gaps {
+                left: 1,
+                right: 1,
+                top: 2,
+                bottom: 1,
+            })
             .render(area, buf);
 
         let scrollbar_area = Rect {
@@ -133,10 +135,7 @@ impl Widget for RecipeTab {
         };
         render_scrollbar(self.row_index, scrollbar_area, buf);
 
-        let area = area.inner(Margin {
-            horizontal: 2,
-            vertical: 1,
-        });
+        let area = area.inner(Gaps::horizontal_vertical(2, 1));
         let [recipe, ingredients] =
             Layout::horizontal([Constraint::Length(44), Constraint::Min(0)]).areas(area);
 
@@ -152,7 +151,7 @@ fn render_recipe(area: Rect, buf: &mut Buffer) {
         .collect_vec();
     Paragraph::new(lines)
         .wrap(Wrap { trim: true })
-        .block(Block::new().padding(Padding::new(0, 1, 0, 0)))
+        .block(Block::new().padding(Gaps::right(1)))
         .render(area, buf);
 }
 

--- a/examples/demo2/tabs/traceroute.rs
+++ b/examples/demo2/tabs/traceroute.rs
@@ -1,13 +1,13 @@
 use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
-    layout::{Alignment, Constraint, Layout, Margin, Rect},
+    layout::{Alignment, Constraint, Gaps, Layout, Rect},
     style::{Styled, Stylize},
     symbols::Marker,
     widgets::{
         canvas::{self, Canvas, Map, MapResolution, Points},
-        Block, BorderType, Clear, Padding, Row, Scrollbar, ScrollbarOrientation, ScrollbarState,
-        Sparkline, StatefulWidget, Table, TableState, Widget,
+        Block, BorderType, Clear, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Sparkline,
+        StatefulWidget, Table, TableState, Widget,
     },
 };
 
@@ -33,10 +33,7 @@ impl TracerouteTab {
 impl Widget for TracerouteTab {
     fn render(self, area: Rect, buf: &mut Buffer) {
         RgbSwatch.render(area, buf);
-        let area = area.inner(Margin {
-            vertical: 1,
-            horizontal: 2,
-        });
+        let area = area.inner(Gaps::horizontal_vertical(2, 1));
         Clear.render(area, buf);
         Block::new().style(THEME.content).render(area, buf);
         let horizontal = Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]);
@@ -57,7 +54,7 @@ fn render_hops(selected_row: usize, area: Rect, buf: &mut Buffer) {
         .map(|hop| Row::new(vec![hop.host, hop.address]))
         .collect_vec();
     let block = Block::new()
-        .padding(Padding::new(1, 1, 1, 1))
+        .padding(Gaps::all(1))
         .title_alignment(Alignment::Center)
         .title("Traceroute bad.horse".bold().white());
     StatefulWidget::render(
@@ -118,7 +115,12 @@ fn render_map(selected_row: usize, area: Rect, buf: &mut Buffer) {
         .background_color(theme.background_color)
         .block(
             Block::new()
-                .padding(Padding::new(1, 0, 1, 0))
+                .padding(Gaps {
+                    left: 1,
+                    right: 0,
+                    top: 1,
+                    bottom: 0,
+                })
                 .style(theme.style),
         )
         .marker(Marker::HalfBlock)

--- a/examples/demo2/tabs/weather.rs
+++ b/examples/demo2/tabs/weather.rs
@@ -2,12 +2,12 @@ use itertools::Itertools;
 use palette::Okhsv;
 use ratatui::{
     buffer::Buffer,
-    layout::{Constraint, Direction, Layout, Margin, Rect},
+    layout::{Constraint, Direction, Gaps, Layout, Rect},
     style::{Color, Style, Stylize},
     symbols,
     widgets::{
         calendar::{CalendarEventStore, Monthly},
-        Bar, BarChart, BarGroup, Block, Clear, LineGauge, Padding, Widget,
+        Bar, BarChart, BarGroup, Block, Clear, LineGauge, Widget,
     },
 };
 use time::OffsetDateTime;
@@ -34,17 +34,11 @@ impl WeatherTab {
 impl Widget for WeatherTab {
     fn render(self, area: Rect, buf: &mut Buffer) {
         RgbSwatch.render(area, buf);
-        let area = area.inner(Margin {
-            vertical: 1,
-            horizontal: 2,
-        });
+        let area = area.inner(Gaps::horizontal_vertical(2, 1));
         Clear.render(area, buf);
         Block::new().style(THEME.content).render(area, buf);
 
-        let area = area.inner(Margin {
-            horizontal: 2,
-            vertical: 1,
-        });
+        let area = area.inner(Gaps::horizontal_vertical(2, 1));
         let [main, _, gauges] = Layout::vertical([
             Constraint::Min(0),
             Constraint::Length(1),
@@ -66,7 +60,7 @@ impl Widget for WeatherTab {
 fn render_calendar(area: Rect, buf: &mut Buffer) {
     let date = OffsetDateTime::now_utc().date();
     Monthly::new(date, CalendarEventStore::today(Style::new().red().bold()))
-        .block(Block::new().padding(Padding::new(0, 0, 2, 0)))
+        .block(Block::new().padding(Gaps::top(2)))
         .show_month_header(Style::new().bold())
         .show_weekdays_header(Style::new().italic())
         .render(area, buf);
@@ -125,7 +119,7 @@ fn render_horizontal_barchart(area: Rect, buf: &mut Buffer) {
     ];
     let group = BarGroup::default().label("GPU".into()).bars(&data);
     BarChart::default()
-        .block(Block::new().padding(Padding::new(0, 0, 2, 0)))
+        .block(Block::new().padding(Gaps::top(2)))
         .direction(Direction::Horizontal)
         .data(group)
         .bar_gap(1)

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -24,10 +24,10 @@ use ratatui::{
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
         ExecutableCommand,
     },
-    layout::{Alignment, Constraint, Layout, Rect},
+    layout::{Alignment, Constraint, Gaps, Layout, Rect},
     style::{palette::tailwind, Color, Style, Stylize},
     text::Span,
-    widgets::{block::Title, Block, Borders, Gauge, Padding, Paragraph, Widget},
+    widgets::{block::Title, Block, Borders, Gauge, Paragraph, Widget},
     Terminal,
 };
 
@@ -209,7 +209,7 @@ fn title_block(title: &str) -> Block {
     let title = Title::from(title).alignment(Alignment::Center);
     Block::new()
         .borders(Borders::NONE)
-        .padding(Padding::vertical(1))
+        .padding(Gaps::vertical(1))
         .title(title)
         .fg(CUSTOM_LABEL_COLOR)
 }

--- a/examples/line_gauge.rs
+++ b/examples/line_gauge.rs
@@ -24,9 +24,9 @@ use ratatui::{
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
         ExecutableCommand,
     },
-    layout::{Alignment, Constraint, Layout, Rect},
+    layout::{Alignment, Constraint, Gaps, Layout, Rect},
     style::{palette::tailwind, Color, Style, Stylize},
-    widgets::{block::Title, Block, Borders, LineGauge, Padding, Paragraph, Widget},
+    widgets::{block::Title, Block, Borders, LineGauge, Paragraph, Widget},
     Terminal,
 };
 
@@ -185,7 +185,7 @@ fn title_block(title: &str) -> Block {
         .title(title)
         .borders(Borders::NONE)
         .fg(CUSTOM_LABEL_COLOR)
-        .padding(Padding::vertical(1))
+        .padding(Gaps::vertical(1))
 }
 
 fn init_error_hooks() -> color_eyre::Result<()> {

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -20,7 +20,7 @@ use ratatui::{
     backend::Backend,
     buffer::Buffer,
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
-    layout::{Constraint, Layout, Rect},
+    layout::{Constraint, Gaps, Layout, Rect},
     style::{
         palette::tailwind::{BLUE, GREEN, SLATE},
         Color, Modifier, Style, Stylize,
@@ -28,8 +28,8 @@ use ratatui::{
     symbols,
     text::Line,
     widgets::{
-        Block, Borders, HighlightSpacing, List, ListItem, ListState, Padding, Paragraph,
-        StatefulWidget, Widget, Wrap,
+        Block, Borders, HighlightSpacing, List, ListItem, ListState, Paragraph, StatefulWidget,
+        Widget, Wrap,
     },
     Terminal,
 };
@@ -261,7 +261,7 @@ impl App {
             .border_set(symbols::border::EMPTY)
             .border_style(TODO_HEADER_STYLE)
             .bg(NORMAL_ROW_BG)
-            .padding(Padding::horizontal(1));
+            .padding(Gaps::horizontal(1));
 
         // We can now render the item info
         Paragraph::new(info)

--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -28,7 +28,7 @@ use ratatui::{
         execute,
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     },
-    layout::{Alignment, Constraint, Layout, Margin},
+    layout::{Alignment, Constraint, Gaps, Layout},
     style::{Color, Style, Stylize},
     symbols::scrollbar,
     text::{Line, Masked, Span},
@@ -193,10 +193,7 @@ fn ui(f: &mut Frame, app: &mut App) {
             .begin_symbol(None)
             .track_symbol(None)
             .end_symbol(None),
-        chunks[2].inner(Margin {
-            vertical: 1,
-            horizontal: 0,
-        }),
+        chunks[2].inner(Gaps::vertical(1)),
         &mut app.vertical_scroll_state,
     );
 
@@ -211,10 +208,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .thumb_symbol("🬋")
             .end_symbol(None),
-        chunks[3].inner(Margin {
-            vertical: 0,
-            horizontal: 1,
-        }),
+        chunks[3].inner(Gaps::horizontal(1)),
         &mut app.horizontal_scroll_state,
     );
 
@@ -229,10 +223,7 @@ fn ui(f: &mut Frame, app: &mut App) {
         Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .thumb_symbol("░")
             .track_symbol(Some("─")),
-        chunks[4].inner(Margin {
-            vertical: 0,
-            horizontal: 1,
-        }),
+        chunks[4].inner(Gaps::horizontal(1)),
         &mut app.horizontal_scroll_state,
     );
 }

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -23,7 +23,7 @@ use ratatui::{
         execute,
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     },
-    layout::{Constraint, Layout, Margin, Rect},
+    layout::{Constraint, Gaps, Layout, Rect},
     style::{self, Color, Modifier, Style, Stylize},
     text::{Line, Text},
     widgets::{
@@ -325,10 +325,7 @@ fn render_scrollbar(f: &mut Frame, app: &mut App, area: Rect) {
             .orientation(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)
             .end_symbol(None),
-        area.inner(Margin {
-            vertical: 1,
-            horizontal: 1,
-        }),
+        area.inner(Gaps::all(1)),
         &mut app.scroll_state,
     );
 }

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -24,11 +24,11 @@ use ratatui::{
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
         ExecutableCommand,
     },
-    layout::{Constraint, Layout, Rect},
+    layout::{Constraint, Gaps, Layout, Rect},
     style::{palette::tailwind, Color, Stylize},
     symbols,
     text::Line,
-    widgets::{Block, Padding, Paragraph, Tabs, Widget},
+    widgets::{Block, Paragraph, Tabs, Widget},
     Terminal,
 };
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
@@ -213,7 +213,7 @@ impl SelectedTab {
     fn block(self) -> Block<'static> {
         Block::bordered()
             .border_set(symbols::border::PROPORTIONAL_TALL)
-            .padding(Padding::horizontal(1))
+            .padding(Gaps::horizontal(1))
             .border_style(self.palette().c700)
     }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -4,6 +4,7 @@ mod alignment;
 mod constraint;
 mod direction;
 mod flex;
+mod gaps;
 mod layout;
 mod margin;
 mod position;
@@ -14,7 +15,9 @@ pub use alignment::Alignment;
 pub use constraint::Constraint;
 pub use direction::Direction;
 pub use flex::Flex;
+pub use gaps::Gaps;
 pub use layout::Layout;
+#[allow(deprecated)]
 pub use margin::Margin;
 pub use position::Position;
 pub use rect::*;

--- a/src/layout/gaps.rs
+++ b/src/layout/gaps.rs
@@ -1,0 +1,186 @@
+/// Gaps around or within something in all 4 directions.
+///
+/// This is inspired by the [CSS margin](https://developer.mozilla.org/en-US/docs/Web/CSS/margin) / [CSS padding](https://developer.mozilla.org/en-US/docs/Web/CSS/padding).
+///
+/// # Examples
+///
+/// ```rust
+/// # use ratatui::layout::Gaps;
+/// let some = Gaps {
+///     top: 1,
+///     right: 2,
+///     bottom: 3,
+///     left: 4,
+/// };
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Gaps {
+    pub top: u16,
+    pub right: u16,
+    pub bottom: u16,
+    pub left: u16,
+}
+
+impl Gaps {
+    /// `Gaps` with zero gap in all directions
+    pub const ZERO: Self = Self::all(0);
+
+    /// Create with the same gaps in all directions.
+    /// This is similar to the css with one argument: `margin: 1`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ratatui::layout::Gaps;
+    /// assert_eq!(
+    ///     Gaps::all(1),
+    ///     Gaps {
+    ///         top: 1,
+    ///         right: 1,
+    ///         bottom: 1,
+    ///         left: 1
+    ///     }
+    /// );
+    /// ```
+    #[must_use]
+    pub const fn all(all: u16) -> Self {
+        Self {
+            top: all,
+            right: all,
+            bottom: all,
+            left: all,
+        }
+    }
+
+    /// Create on the horizontal and vertical axis.
+    ///
+    /// This is similar to the css with two arguments: `margin: horizontal vertical`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ratatui::layout::Gaps;
+    /// assert_eq!(
+    ///     Gaps::horizontal_vertical(1, 2),
+    ///     Gaps {
+    ///         top: 2,
+    ///         right: 1,
+    ///         bottom: 2,
+    ///         left: 1
+    ///     }
+    /// );
+    /// ```
+    #[must_use]
+    pub const fn horizontal_vertical(horizontal: u16, vertical: u16) -> Self {
+        Self {
+            top: vertical,
+            right: horizontal,
+            bottom: vertical,
+            left: horizontal,
+        }
+    }
+
+    /// Create with the same value for `left` and `right` while the rest stays zero.
+    #[must_use]
+    pub const fn horizontal(value: u16) -> Self {
+        Self {
+            left: value,
+            right: value,
+            top: 0,
+            bottom: 0,
+        }
+    }
+
+    /// Create with the same value for `top` and `bottom` while the rest stays zero.
+    #[must_use]
+    pub const fn vertical(value: u16) -> Self {
+        Self {
+            left: 0,
+            right: 0,
+            top: value,
+            bottom: value,
+        }
+    }
+
+    /// Create with only the `top` value set.
+    #[must_use]
+    pub const fn top(value: u16) -> Self {
+        Self {
+            left: 0,
+            right: 0,
+            top: value,
+            bottom: 0,
+        }
+    }
+
+    /// Create with only the `right` value set.
+    #[must_use]
+    pub const fn right(value: u16) -> Self {
+        Self {
+            left: 0,
+            right: value,
+            top: 0,
+            bottom: 0,
+        }
+    }
+
+    /// Create with only the `bottom` value set.
+    #[must_use]
+    pub const fn bottom(value: u16) -> Self {
+        Self {
+            left: 0,
+            right: 0,
+            top: 0,
+            bottom: value,
+        }
+    }
+
+    /// Create with only the `left` value set.
+    #[must_use]
+    pub const fn left(value: u16) -> Self {
+        Self {
+            left: value,
+            right: 0,
+            top: 0,
+            bottom: 0,
+        }
+    }
+
+    /// Returns the total horizontal space taken on the left and right.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ratatui::layout::Gaps;
+    /// let some = Gaps {
+    ///     top: 1,
+    ///     right: 2,
+    ///     bottom: 3,
+    ///     left: 4,
+    /// };
+    /// assert_eq!(some.total_horizontal(), 6);
+    /// ```
+    #[must_use]
+    pub const fn total_horizontal(self) -> u16 {
+        self.left.saturating_add(self.right)
+    }
+
+    /// Returns the total vertical space taken on the top and bottom.
+    ///     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ratatui::layout::Gaps;
+    /// let some = Gaps {
+    ///     top: 1,
+    ///     right: 2,
+    ///     bottom: 3,
+    ///     left: 4,
+    /// };
+    /// assert_eq!(some.total_vertical(), 4);
+    /// ```
+    #[must_use]
+    pub const fn total_vertical(self) -> u16 {
+        self.top.saturating_add(self.bottom)
+    }
+}

--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -112,7 +112,7 @@ thread_local! {
 pub struct Layout {
     direction: Direction,
     constraints: Vec<Constraint>,
-    margin: Margin,
+    margin: Gaps,
     flex: Flex,
     spacing: u16,
 }
@@ -308,10 +308,7 @@ impl Layout {
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn margin(mut self, margin: u16) -> Self {
-        self.margin = Margin {
-            horizontal: margin,
-            vertical: margin,
-        };
+        self.margin = Gaps::all(margin);
         self
     }
 
@@ -329,7 +326,8 @@ impl Layout {
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn horizontal_margin(mut self, horizontal: u16) -> Self {
-        self.margin.horizontal = horizontal;
+        self.margin.left = horizontal;
+        self.margin.right = horizontal;
         self
     }
 
@@ -347,7 +345,8 @@ impl Layout {
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn vertical_margin(mut self, vertical: u16) -> Self {
-        self.margin.vertical = vertical;
+        self.margin.top = vertical;
+        self.margin.bottom = vertical;
         self
     }
 
@@ -1098,7 +1097,7 @@ mod tests {
             Layout::default(),
             Layout {
                 direction: Direction::Vertical,
-                margin: Margin::new(0, 0),
+                margin: Gaps::ZERO,
                 constraints: vec![],
                 flex: Flex::default(),
                 spacing: 0,
@@ -1143,7 +1142,7 @@ mod tests {
             Layout::vertical([Constraint::Min(0)]),
             Layout {
                 direction: Direction::Vertical,
-                margin: Margin::new(0, 0),
+                margin: Gaps::ZERO,
                 constraints: vec![Constraint::Min(0)],
                 flex: Flex::default(),
                 spacing: 0,
@@ -1157,7 +1156,7 @@ mod tests {
             Layout::horizontal([Constraint::Min(0)]),
             Layout {
                 direction: Direction::Horizontal,
-                margin: Margin::new(0, 0),
+                margin: Gaps::ZERO,
                 constraints: vec![Constraint::Min(0)],
                 flex: Flex::default(),
                 spacing: 0,
@@ -1241,21 +1240,21 @@ mod tests {
 
     #[test]
     fn margins() {
-        assert_eq!(Layout::default().margin(10).margin, Margin::new(10, 10));
+        assert_eq!(Layout::default().margin(10).margin, Gaps::all(10));
         assert_eq!(
             Layout::default().horizontal_margin(10).margin,
-            Margin::new(10, 0)
+            Gaps::horizontal(10)
         );
         assert_eq!(
             Layout::default().vertical_margin(10).margin,
-            Margin::new(0, 10)
+            Gaps::vertical(10)
         );
         assert_eq!(
             Layout::default()
                 .horizontal_margin(10)
                 .vertical_margin(20)
                 .margin,
-            Margin::new(10, 20)
+            Gaps::horizontal_vertical(10, 20)
         );
     }
 

--- a/src/layout/margin.rs
+++ b/src/layout/margin.rs
@@ -1,7 +1,10 @@
+#![allow(deprecated)]
+
 use std::fmt;
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[deprecated = "use ratatui::layout::Gaps"]
 pub struct Margin {
     pub horizontal: u16,
     pub vertical: u16,

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -117,22 +117,22 @@ impl Rect {
         self.y.saturating_add(self.height)
     }
 
-    /// Returns a new `Rect` inside the current one, with the given margin on each side.
+    /// Returns a new `Rect` inside the current one, with the given gaps on each side.
     ///
-    /// If the margin is larger than the `Rect`, the returned `Rect` will have no area.
+    /// If the gaps are larger than the `Rect`, the returned `Rect` will have no area.
     #[must_use = "method returns the modified value"]
-    pub const fn inner(self, margin: Margin) -> Self {
-        let doubled_margin_horizontal = margin.horizontal.saturating_mul(2);
-        let doubled_margin_vertical = margin.vertical.saturating_mul(2);
+    pub const fn inner(self, gaps: Gaps) -> Self {
+        let total_horizontal = gaps.total_horizontal();
+        let total_vertical = gaps.total_vertical();
 
-        if self.width < doubled_margin_horizontal || self.height < doubled_margin_vertical {
+        if self.width < total_horizontal || self.height < total_vertical {
             Self::ZERO
         } else {
             Self {
-                x: self.x.saturating_add(margin.horizontal),
-                y: self.y.saturating_add(margin.vertical),
-                width: self.width.saturating_sub(doubled_margin_horizontal),
-                height: self.height.saturating_sub(doubled_margin_vertical),
+                x: self.x.saturating_add(gaps.left),
+                y: self.y.saturating_add(gaps.top),
+                width: self.width.saturating_sub(total_horizontal),
+                height: self.height.saturating_sub(total_vertical),
             }
         }
     }
@@ -406,7 +406,7 @@ mod tests {
     #[test]
     fn inner() {
         assert_eq!(
-            Rect::new(1, 2, 3, 4).inner(Margin::new(1, 2)),
+            Rect::new(1, 2, 3, 4).inner(Gaps::horizontal_vertical(1, 2)),
             Rect::new(2, 4, 1, 0)
         );
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,11 +23,13 @@ pub use crate::backend::CrosstermBackend;
 pub use crate::backend::TermionBackend;
 #[cfg(feature = "termwiz")]
 pub use crate::backend::TermwizBackend;
+#[allow(deprecated)]
+pub use crate::layout::Margin;
 pub(crate) use crate::widgets::{StatefulWidgetRef, WidgetRef};
 pub use crate::{
     backend::{self, Backend},
     buffer::{self, Buffer},
-    layout::{self, Alignment, Constraint, Direction, Layout, Margin, Position, Rect, Size},
+    layout::{self, Alignment, Constraint, Direction, Gaps, Layout, Position, Rect, Size},
     style::{self, Color, Modifier, Style, Stylize},
     symbols::{self},
     text::{self, Line, Masked, Span, Text},

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -38,6 +38,7 @@ mod sparkline;
 mod table;
 mod tabs;
 
+#[allow(deprecated)]
 pub use self::{
     barchart::{Bar, BarChart, BarGroup},
     block::{Block, BorderType, Padding},

--- a/src/widgets/block/padding.rs
+++ b/src/widgets/block/padding.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 /// Defines the padding for a [`Block`].
 ///
 /// See the [`padding`] method of [`Block`] to configure its padding.
@@ -23,6 +25,7 @@
 /// [`padding`]: crate::widgets::Block::padding
 /// [CSS padding]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[deprecated = "use ratatui::layout::Gaps"]
 pub struct Padding {
     /// Left padding
     pub left: u16,

--- a/src/widgets/canvas/rectangle.rs
+++ b/src/widgets/canvas/rectangle.rs
@@ -98,7 +98,7 @@ mod tests {
             "██████████",
         ]);
         expected.set_style(buffer.area, Style::new().red());
-        expected.set_style(buffer.area.inner(Margin::new(1, 1)), Style::reset());
+        expected.set_style(buffer.area.inner(Gaps::all(1)), Style::reset());
         assert_eq!(buffer, expected);
     }
 
@@ -132,8 +132,8 @@ mod tests {
             "█▄▄▄▄▄▄▄▄█",
         ]);
         expected.set_style(buffer.area, Style::new().red().on_red());
-        expected.set_style(buffer.area.inner(Margin::new(1, 0)), Style::reset().red());
-        expected.set_style(buffer.area.inner(Margin::new(1, 1)), Style::reset());
+        expected.set_style(buffer.area.inner(Gaps::horizontal(1)), Style::reset().red());
+        expected.set_style(buffer.area.inner(Gaps::all(1)), Style::reset());
         assert_eq!(buffer, expected);
     }
 
@@ -176,8 +176,8 @@ mod tests {
             "⣇⣀⣀⣀⣀⣀⣀⣀⣀⣸",
         ]);
         expected.set_style(buffer.area, Style::new().red());
-        expected.set_style(buffer.area.inner(Margin::new(1, 1)), Style::new().green());
-        expected.set_style(buffer.area.inner(Margin::new(2, 2)), Style::reset());
+        expected.set_style(buffer.area.inner(Gaps::all(1)), Style::new().green());
+        expected.set_style(buffer.area.inner(Gaps::all(2)), Style::reset());
         assert_eq!(buffer, expected);
     }
 }

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -65,11 +65,8 @@ use crate::{
 /// // and the scrollbar, those are separate widgets
 /// frame.render_stateful_widget(
 ///     scrollbar,
-///     area.inner(Margin {
-///         // using an inner vertical margin of 1 unit makes the scrollbar inside the block
-///         vertical: 1,
-///         horizontal: 0,
-///     }),
+///     // using an inner vertical margin of 1 unit makes the scrollbar inside the block
+///     area.inner(Gaps::vertical(1)),
 ///     &mut scrollbar_state,
 /// );
 /// # }

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -1,9 +1,9 @@
 use ratatui::{
     backend::TestBackend,
     buffer::Buffer,
-    layout::Alignment,
+    layout::{Alignment, Gaps},
     text::{Line, Span, Text},
-    widgets::{Block, Padding, Paragraph, Wrap},
+    widgets::{Block, Paragraph, Wrap},
     Terminal,
 };
 
@@ -192,12 +192,7 @@ fn widgets_paragraph_can_wrap_its_content() {
 
 #[test]
 fn widgets_paragraph_works_with_padding() {
-    let block = Block::bordered().padding(Padding {
-        left: 2,
-        right: 2,
-        top: 1,
-        bottom: 1,
-    });
+    let block = Block::bordered().padding(Gaps::horizontal_vertical(2, 1));
     let paragraph = Paragraph::new(vec![Line::from(SAMPLE_STRING)])
         .block(block.clone())
         .wrap(Wrap { trim: true });


### PR DESCRIPTION
This is breaking for sure and will very likely generate a lot of churn.

Fixes #931

Also increases code readability as arguments always keep their intention in the method name. If that's not enough, the Struct pattern `Gaps {left: …, … }` should be used to keep the readability. I didn't create a `new` method for exactly this reason in order to keep readability of code up.

I intentionally `Padding::proportional` as characters on terminals are not 2x1 and it's only a very broad approximation. It's likely a better idea to use something custom for the given use case than some magic `n*2`.