### PR TITLE
perf: move benchmarks into a single benchmark harness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,35 +180,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 codegen-units = 1
 lto = true
 
-[[bench]]
-name = "barchart"
-harness = false
-
-[[bench]]
-name = "block"
-harness = false
-
-[[bench]]
-name = "line"
-harness = false
-
-[[bench]]
-name = "list"
-harness = false
-
-[[bench]]
-name = "rect"
-harness = false
-
 [lib]
 bench = false
 
 [[bench]]
-name = "paragraph"
-harness = false
-
-[[bench]]
-name = "sparkline"
+name = "main"
 harness = false
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,10 @@ harness = false
 name = "list"
 harness = false
 
+[[bench]]
+name = "rect"
+harness = false
+
 [lib]
 bench = false
 

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,20 @@
+pub mod main {
+    pub mod barchart;
+    pub mod block;
+    pub mod line;
+    pub mod list;
+    pub mod paragraph;
+    pub mod rect;
+    pub mod sparkline;
+}
+pub use main::*;
+
+criterion::criterion_main!(
+    barchart::benches,
+    block::benches,
+    line::benches,
+    list::benches,
+    paragraph::benches,
+    rect::benches,
+    sparkline::benches
+);

--- a/benches/main/barchart.rs
+++ b/benches/main/barchart.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
+use criterion::{criterion_group, Bencher, BenchmarkId, Criterion};
 use rand::Rng;
 use ratatui::{
     buffer::Buffer,
@@ -70,4 +70,3 @@ fn render(bencher: &mut Bencher, barchart: &BarChart) {
 }
 
 criterion_group!(benches, barchart);
-criterion_main!(benches);

--- a/benches/main/block.rs
+++ b/benches/main/block.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BatchSize, Bencher, Criterion};
+use criterion::{criterion_group, BatchSize, Bencher, Criterion};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -59,4 +59,3 @@ fn render(bencher: &mut Bencher, block: &Block, size: Rect) {
 }
 
 criterion_group!(benches, block);
-criterion_main!(benches);

--- a/benches/main/line.rs
+++ b/benches/main/line.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -36,4 +36,3 @@ fn line_render(criterion: &mut Criterion) {
 }
 
 criterion_group!(benches, line_render);
-criterion_main!(benches);

--- a/benches/main/list.rs
+++ b/benches/main/list.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BatchSize, Bencher, BenchmarkId, Criterion};
+use criterion::{criterion_group, BatchSize, Bencher, BenchmarkId, Criterion};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -70,4 +70,3 @@ fn render_stateful(bencher: &mut Bencher, list: &List, mut state: ListState) {
 }
 
 criterion_group!(benches, list);
-criterion_main!(benches);

--- a/benches/main/paragraph.rs
+++ b/benches/main/paragraph.rs
@@ -1,6 +1,4 @@
-use criterion::{
-    black_box, criterion_group, criterion_main, BatchSize, Bencher, BenchmarkId, Criterion,
-};
+use criterion::{black_box, criterion_group, BatchSize, Bencher, BenchmarkId, Criterion};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -94,4 +92,3 @@ fn random_lines(count: u16) -> String {
 }
 
 criterion_group!(benches, paragraph);
-criterion_main!(benches);

--- a/benches/main/rect.rs
+++ b/benches/main/rect.rs
@@ -1,0 +1,24 @@
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
+use ratatui::layout::Rect;
+
+fn rect_rows_benchmark(c: &mut Criterion) {
+    let rect_sizes = vec![
+        Rect::new(0, 0, 1, 16),
+        Rect::new(0, 0, 1, 1024),
+        Rect::new(0, 0, 1, 65535),
+    ];
+    let mut group = c.benchmark_group("rect_rows");
+    for rect in rect_sizes {
+        group.bench_with_input(BenchmarkId::new("rows", rect.height), &rect, |b, rect| {
+            b.iter(|| {
+                for row in rect.rows() {
+                    // Perform any necessary operations on each row
+                    black_box(row);
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, rect_rows_benchmark);

--- a/benches/main/sparkline.rs
+++ b/benches/main/sparkline.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
+use criterion::{criterion_group, Bencher, BenchmarkId, Criterion};
 use rand::Rng;
 use ratatui::{
     buffer::Buffer,
@@ -42,4 +42,3 @@ fn render(bencher: &mut Bencher, sparkline: &Sparkline) {
 }
 
 criterion_group!(benches, sparkline);
-criterion_main!(benches);


### PR DESCRIPTION
Consolidates the benchmarks into a single executable rather than having to create a new cargo.toml setting per and makes it easier to rearrange these when adding new benchmarks.