### PR TITLE
docs(examples): use ratatui::crossterm in examples

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -41,9 +41,11 @@ use octocrab::{
     OctocrabBuilder, Page,
 };
 use ratatui::{
+    buffer::Buffer,
     crossterm::event::{Event, EventStream, KeyCode},
-    layout::Offset,
-    prelude::{Buffer, Constraint, Line, Modifier, Rect, Stylize},
+    layout::{Constraint, Offset, Rect},
+    style::{Modifier, Stylize},
+    text::Line,
     widgets::{
         Block, BorderType, HighlightSpacing, Row, StatefulWidget, Table, TableState, Widget,
     },
@@ -263,17 +265,17 @@ mod terminal {
     use std::io;
 
     use ratatui::{
+        backend::CrosstermBackend,
         crossterm::{
             execute,
             terminal::{
                 disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
             },
         },
-        prelude::{CrosstermBackend, Terminal as RatatuiTerminal},
     };
 
     /// A type alias for the terminal type used in this example.
-    pub type Terminal = RatatuiTerminal<CrosstermBackend<io::Stdout>>;
+    pub type Terminal = ratatui::Terminal<CrosstermBackend<io::Stdout>>;
 
     pub fn init() -> io::Result<Terminal> {
         set_panic_hook();

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -262,11 +262,15 @@ impl From<&PullRequest> for Row<'_> {
 mod terminal {
     use std::io;
 
-    use crossterm::{
-        execute,
-        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    use ratatui::{
+        crossterm::{
+            execute,
+            terminal::{
+                disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+            },
+        },
+        prelude::{CrosstermBackend, Terminal as RatatuiTerminal},
     };
-    use ratatui::prelude::{CrosstermBackend, Terminal as RatatuiTerminal};
 
     /// A type alias for the terminal type used in this example.
     pub type Terminal = RatatuiTerminal<CrosstermBackend<io::Stdout>>;

--- a/examples/barchart-grouped.rs
+++ b/examples/barchart-grouped.rs
@@ -18,9 +18,11 @@ use std::iter::zip;
 use color_eyre::Result;
 use ratatui::{
     crossterm::event::{self, Event, KeyCode},
-    prelude::{Color, Constraint, Direction, Frame, Layout, Line, Style},
-    style::Stylize,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style, Stylize},
+    text::Line,
     widgets::{Bar, BarChart, BarGroup, Block},
+    Frame,
 };
 
 use self::terminal::Terminal;

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -18,7 +18,8 @@ use rand::{thread_rng, Rng};
 use ratatui::{
     crossterm::event::{self, Event, KeyCode},
     layout::{Constraint, Direction, Layout},
-    prelude::{Color, Line, Style, Stylize},
+    style::{Color, Style, Stylize},
+    text::Line,
     widgets::{Bar, BarChart, BarGroup, Block},
 };
 

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -136,7 +136,7 @@ fn run_app<B: Backend>(
         terminal.draw(|f| ui(f, &app))?;
 
         let timeout = tick_rate.saturating_sub(last_tick.elapsed());
-        if crossterm::event::poll(timeout)? {
+        if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 if key.code == KeyCode::Char('q') {
                     return Ok(());

--- a/examples/demo/crossterm.rs
+++ b/examples/demo/crossterm.rs
@@ -54,7 +54,7 @@ fn run_app<B: Backend>(
         terminal.draw(|f| ui::draw(f, &mut app))?;
 
         let timeout = tick_rate.saturating_sub(last_tick.elapsed());
-        if crossterm::event::poll(timeout)? {
+        if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
                     match key.code {

--- a/examples/hyperlink.rs
+++ b/examples/hyperlink.rs
@@ -27,14 +27,19 @@ use color_eyre::{
 };
 use itertools::Itertools;
 use ratatui::{
+    backend::CrosstermBackend,
+    buffer::Buffer,
     crossterm::{
         event::{self, Event, KeyCode},
         execute,
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
         ExecutableCommand,
     },
-    prelude::*,
+    layout::Rect,
+    style::Stylize,
+    text::{Line, Text},
     widgets::WidgetRef,
+    Terminal,
 };
 
 fn main() -> Result<()> {

--- a/examples/hyperlink.rs
+++ b/examples/hyperlink.rs
@@ -25,14 +25,17 @@ use color_eyre::{
     config::{EyreHook, HookBuilder, PanicHook},
     eyre, Result,
 };
-use crossterm::{
-    event::{self, Event, KeyCode},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    ExecutableCommand,
-};
 use itertools::Itertools;
-use ratatui::{prelude::*, widgets::WidgetRef};
+use ratatui::{
+    crossterm::{
+        event::{self, Event, KeyCode},
+        execute,
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+        ExecutableCommand,
+    },
+    prelude::*,
+    widgets::WidgetRef,
+};
 
 fn main() -> Result<()> {
     init_error_handling()?;

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -15,11 +15,10 @@
 
 use std::{error::Error, io};
 
-use crossterm::event::KeyEvent;
 use ratatui::{
     backend::Backend,
     buffer::Buffer,
-    crossterm::event::{self, Event, KeyCode, KeyEventKind},
+    crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
     layout::{Constraint, Layout, Rect},
     style::{
         palette::tailwind::{BLUE, GREEN, SLATE},

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -35,6 +35,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     crossterm::{
         event::{self, Event, KeyCode},
+        execute,
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     },
     text::Line,
@@ -79,7 +80,7 @@ fn main() -> Result<()> {
 
 /// Initializes the terminal.
 fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
-    crossterm::execute!(io::stdout(), EnterAlternateScreen)?;
+    execute!(io::stdout(), EnterAlternateScreen)?;
     enable_raw_mode()?;
 
     let backend = CrosstermBackend::new(io::stdout());
@@ -93,7 +94,7 @@ fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
 /// Resets the terminal.
 fn reset_terminal() -> Result<()> {
     disable_raw_mode()?;
-    crossterm::execute!(io::stdout(), LeaveAlternateScreen)?;
+    execute!(io::stdout(), LeaveAlternateScreen)?;
 
     Ok(())
 }

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -18,10 +18,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crossterm::event::KeyEventKind;
 use ratatui::{
     buffer::Buffer,
-    crossterm::event::{self, Event, KeyCode},
+    crossterm::event::{self, Event, KeyCode, KeyEventKind},
     layout::{Constraint, Layout, Rect},
     style::{Color, Stylize},
     text::{Line, Masked, Span},
@@ -171,11 +170,13 @@ mod common {
         config::{EyreHook, HookBuilder, PanicHook},
         eyre,
     };
-    use crossterm::ExecutableCommand;
     use ratatui::{
         backend::CrosstermBackend,
-        crossterm::terminal::{
-            disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+        crossterm::{
+            terminal::{
+                disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+            },
+            ExecutableCommand,
         },
         Terminal,
     };

--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -83,7 +83,7 @@ fn run_app<B: Backend>(
         terminal.draw(|f| ui(f, &mut app))?;
 
         let timeout = tick_rate.saturating_sub(last_tick.elapsed());
-        if crossterm::event::poll(timeout)? {
+        if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 match key.code {
                     KeyCode::Char('q') => return Ok(()),

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -131,7 +131,7 @@ fn run_app<B: Backend>(
         terminal.draw(|f| ui(f, &app))?;
 
         let timeout = tick_rate.saturating_sub(last_tick.elapsed());
-        if crossterm::event::poll(timeout)? {
+        if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 if key.code == KeyCode::Char('q') {
                     return Ok(());

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -34,13 +34,13 @@ use color_eyre::{
     eyre::{self, Context},
     Result,
 };
-use crossterm::{
-    event::{self, Event, KeyCode},
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    ExecutableCommand,
-};
 use ratatui::{
     backend::{Backend, CrosstermBackend},
+    crossterm::{
+        event::{self, Event, KeyCode},
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+        ExecutableCommand,
+    },
     widgets::{Block, Paragraph},
     Terminal,
 };


### PR DESCRIPTION
We import from `ratatui::crossterm`` instead of crossterm directly in
the examples to ensure that the version of the crossterm crate used is
the same one as the one used by ratatui. This helps avoid compilation
errors resulting from multiple versions of the same crate.

Also avoids importing from the prelude in the examples.