### PR TITLE
build: simplify Windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ exclude = [
 edition = "2021"
 rust-version = "1.74.0"
 
-[badges]
-
 [dependencies]
 bitflags = "2.3"
 cassowary = "0.3"
@@ -37,12 +35,15 @@ palette = { version = "0.7.6", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = { version = "0.26.3" }
-termion = { version = "4.0.0", optional = true }
 termwiz = { version = "0.22.0", optional = true }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-truncate = "1"
 unicode-width = "0.1.13"
+
+[target.'cfg(not(windows))'.dependencies]
+# termion is not supported on Windows
+termion = { version = "4.0.0", optional = true }
 
 [dev-dependencies]
 argh = "0.1.12"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,14 +5,7 @@ skip_core_tasks = true
 
 [env]
 # all features except the backend ones
-ALL_FEATURES = "all-widgets,macros,serde"
-
-[env.ALL_FEATURES_FLAG]
-# Windows does not support building termion, so this avoids the build failure by providing two
-# sets of flags, one for Windows and one for other platforms.
-source = "${CARGO_MAKE_RUST_TARGET_OS}"
-default_value = "--features=all-widgets,macros,serde,crossterm,termion,termwiz,underline-color,unstable"
-mapping = { "windows" = "--features=all-widgets,macros,serde,crossterm,termwiz,underline-color,unstable" }
+NON_BACKEND_FEATURES = "all-widgets,macros,serde"
 
 [tasks.default]
 alias = "ci"
@@ -23,7 +16,7 @@ dependencies = ["lint", "clippy", "check", "test"]
 
 [tasks.lint]
 description = "Lint code style (formatting, typos, docs, markdown)"
-dependencies = ["lint-format", "lint-typos", "lint-docs", "lint-markdown"]
+dependencies = ["lint-format", "lint-typos", "lint-docs"]
 
 [tasks.lint-format]
 description = "Lint code formatting"
@@ -48,8 +41,7 @@ toolchain = "nightly"
 command = "cargo"
 args = [
   "rustdoc",
-  "--no-default-features",
-  "${ALL_FEATURES_FLAG}",
+  "--all-features",
   "--",
   "-Zunstable-options",
   "--check",
@@ -64,22 +56,12 @@ args = ["**/*.md", "!target"]
 [tasks.check]
 description = "Check code for errors and warnings"
 command = "cargo"
-args = [
-  "check",
-  "--all-targets",
-  "--no-default-features",
-  "${ALL_FEATURES_FLAG}",
-]
+args = ["check", "--all-targets", "--all-features"]
 
 [tasks.build]
 description = "Compile the project"
 command = "cargo"
-args = [
-  "build",
-  "--all-targets",
-  "--no-default-features",
-  "${ALL_FEATURES_FLAG}",
-]
+args = ["build", "--all-targets", "--all-features"]
 
 [tasks.clippy]
 description = "Run Clippy for linting"
@@ -87,10 +69,9 @@ command = "cargo"
 args = [
   "clippy",
   "--all-targets",
+  "--all-features",
   "--tests",
   "--benches",
-  "--no-default-features",
-  "${ALL_FEATURES_FLAG}",
   "--",
   "-D",
   "warnings",
@@ -108,18 +89,12 @@ run_task = { name = ["test-lib", "test-doc"] }
 description = "Run default tests"
 dependencies = ["install-nextest"]
 command = "cargo"
-args = [
-  "nextest",
-  "run",
-  "--all-targets",
-  "--no-default-features",
-  "${ALL_FEATURES_FLAG}",
-]
+args = ["nextest", "run", "--all-targets", "--all-features"]
 
 [tasks.test-doc]
 description = "Run documentation tests"
 command = "cargo"
-args = ["test", "--doc", "--no-default-features", "${ALL_FEATURES_FLAG}"]
+args = ["test", "--doc", "--all-features"]
 
 [tasks.test-backend]
 # takes a command line parameter to specify the backend to test (e.g. "crossterm")
@@ -132,7 +107,7 @@ args = [
   "--all-targets",
   "--no-default-features",
   "--features",
-  "${ALL_FEATURES},${@}",
+  "${NON_BACKEND_FEATURES},${@}",
 ]
 
 [tasks.coverage]
@@ -143,8 +118,7 @@ args = [
   "--lcov",
   "--output-path",
   "target/lcov.info",
-  "--no-default-features",
-  "${ALL_FEATURES_FLAG}",
+  "--all-features",
 ]
 
 [tasks.run-example]

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -20,7 +20,7 @@ use argh::FromArgs;
 mod app;
 #[cfg(feature = "crossterm")]
 mod crossterm;
-#[cfg(feature = "termion")]
+#[cfg(all(not(windows), feature = "termion"))]
 mod termion;
 #[cfg(feature = "termwiz")]
 mod termwiz;
@@ -43,9 +43,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tick_rate = Duration::from_millis(cli.tick_rate);
     #[cfg(feature = "crossterm")]
     crate::crossterm::run(tick_rate, cli.enhanced_graphics)?;
-    #[cfg(feature = "termion")]
+    #[cfg(all(not(windows), feature = "termion", not(feature = "crossterm")))]
     crate::termion::run(tick_rate, cli.enhanced_graphics)?;
-    #[cfg(feature = "termwiz")]
+    #[cfg(all(
+        feature = "termwiz",
+        not(feature = "crossterm"),
+        not(feature = "termion")
+    ))]
     crate::termwiz::run(tick_rate, cli.enhanced_graphics)?;
     Ok(())
 }

--- a/examples/demo/termion.rs
+++ b/examples/demo/termion.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::{error::Error, io, sync::mpsc, thread, time::Duration};
 
 use ratatui::{

--- a/examples/demo/termwiz.rs
+++ b/examples/demo/termwiz.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::{
     error::Error,
     time::{Duration, Instant},

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -109,9 +109,9 @@ use crate::{
     layout::{Position, Size},
 };
 
-#[cfg(feature = "termion")]
+#[cfg(all(not(windows), feature = "termion"))]
 mod termion;
-#[cfg(feature = "termion")]
+#[cfg(all(not(windows), feature = "termion"))]
 pub use self::termion::TermionBackend;
 
 #[cfg(feature = "crossterm")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@
 pub use crossterm;
 pub use terminal::{CompletedFrame, Frame, Terminal, TerminalOptions, Viewport};
 /// re-export the `termion` crate so that users don't have to add it as a dependency
-#[cfg(feature = "termion")]
+#[cfg(all(not(windows), feature = "termion"))]
 pub use termion;
 /// re-export the `termwiz` crate so that users don't have to add it as a dependency
 #[cfg(feature = "termwiz")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,7 +19,7 @@
 
 #[cfg(feature = "crossterm")]
 pub use crate::backend::CrosstermBackend;
-#[cfg(feature = "termion")]
+#[cfg(all(not(windows), feature = "termion"))]
 pub use crate::backend::TermionBackend;
 #[cfg(feature = "termwiz")]
 pub use crate::backend::TermwizBackend;

--- a/tests/backend_termion.rs
+++ b/tests/backend_termion.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "termion")]
+#[cfg(all(not(windows), feature = "termion"))]
 #[test]
 fn backend_termion_should_only_write_diffs() -> Result<(), Box<dyn std::error::Error>> {
     use std::{fmt::Write, io::Cursor};


### PR DESCRIPTION
Termion is not supported on Windows, so we need to avoid building it.

Adds a conditional dependency to the Cargo.toml file to only include
termion when the target is not Windows. This allows contributors to
build using the `--all-features` flag on Windows rather than needing
to specify the features individually.

---

Testing:
cargo build --all-features now succeeds on windows (11 Arm 64)