### PR TITLE
fix: fix u16 overflow in Terminal::insert_before.

### DIFF
--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -570,9 +570,9 @@ where
         draw_fn(&mut buffer);
 
         // Split buffer into screen-sized chunks and draw
-        let max_chunk_size = (self.viewport_area.top() * area.width).into();
+        let max_chunk_size = (self.viewport_area.top() as usize) * (area.width as usize);
         for buffer_content_chunk in buffer.content.chunks(max_chunk_size) {
-            let chunk_size = buffer_content_chunk.len() as u16 / area.width;
+            let chunk_size = (buffer_content_chunk.len() / (area.width as usize)) as u16;
 
             self.backend
                 .append_lines(self.viewport_area.height.saturating_sub(1) + chunk_size)?;


### PR DESCRIPTION
If the amount of characters in the screen above the viewport was greater than u16::MAX, a multiplication would overflow. The multiply was used to compute the maximum chunk size. The fix is to just do the multiplication as a usize and also do the subsequent division as a usize.

There is currently another outstanding issue that limits the amount of characters that can be inserted when calling Terminal::insert_before to u16::MAX. However, this bug can still occur even if the viewport and the amount of characters being inserted are both less than u16::MAX, since it's dependant on how large the screen is above the viewport.

Fixes #1322

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
