### PR TITLE
Doc only fixes: its vs it's mistakes

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -138,7 +138,7 @@ This change simplifies the trait and makes it easier to implement.
 
 [#1293]: https://github.com/ratatui-org/ratatui/pull/1293
 
-`Frame::size` is renamed to `Frame::area` as its the more correct name.
+`Frame::size` is renamed to `Frame::area` as it's the more correct name.
 
 ## [v0.27.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.27.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,7 +451,7 @@ improved performance. Also, we added brand new examples for tracing and creating
 
   ```text
   This PR deprecates `gauge_style` in favor of `filled_style` and
-  `unfilled_style` which can have it's foreground and background styled.
+  `unfilled_style` which can have its foreground and background styled.
 
   `cargo run --example=line_gauge --features=crossterm`
   ```
@@ -1292,7 +1292,7 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   anything that can be a breaking change.
 
   Lints are not enabled as that should be the job of #974. I created this
-  as a separate PR as its mostly independent and would only clutter up the
+  as a separate PR as it's mostly independent and would only clutter up the
   diff of #974 even more.
 
   Also see
@@ -1362,7 +1362,7 @@ compilation.
   *(uncategorized)* Remove literal suffix by @EdJoPaTo
 
   ````text
-  its not needed and can just be assumed
+  it's not needed and can just be assumed
   ````
 
   related:clippy::(un)separated_literal_suffix

--- a/src/terminal/frame.rs
+++ b/src/terminal/frame.rs
@@ -60,7 +60,7 @@ impl Frame<'_> {
     /// If your app listens for a resize event from the backend, it should ignore the values from
     /// the event for any calculations that are used to render the current frame and use this value
     /// instead as this is the area of the buffer that is used to render the current frame.
-    #[deprecated = "use .area() as its the more correct name"]
+    #[deprecated = "use .area() as it's the more correct name"]
     pub const fn size(&self) -> Rect {
         self.viewport_area
     }


### PR DESCRIPTION
...nothing too major.

it's --> "it is"
its --> "it" possesses something

I noticed this in the deprecation message for Frame::area, and went looking for more mistakes. I only found three in total.