### PR TITLE
feat: cell diff options

### DIFF
--- a/ratatui-core/src/buffer.rs
+++ b/ratatui-core/src/buffer.rs
@@ -6,4 +6,4 @@ mod buffer;
 mod cell;
 
 pub use buffer::Buffer;
-pub use cell::Cell;
+pub use cell::{Cell, CellDiffOption};


### PR DESCRIPTION
### feat: cell diff options

Problem: Escape sequences always cause a cell to count as "multiwidth",
even when it doesn't render wider than one cell, or not as wide as the
escape sequence would be computed as.

Solution: Convert `skip:bool` to enum. Add enum option `ForceWidth` to
force a cell width for diffing.

When using the option, this also fixes some bug where diffing is not
idempotent and causes a diff operation for `(symbol.len() - 1)` times.

There are three new specific test cases:

1. Rendering hyperlinks by squeezing the escape sequence into the first
   cell and forcing the width to the unicode width of the text part.
   This is much easier to implement for a Link widget, as it would only
   need to get the unicode-width once and not iterate over graphemes
   like Spans must do.
2. Rendering hyperlinks by squeezing the opening sequence into the first
   cell with the first grapheme and forcing the width to that of the
   first grapheme. Then rendering each grapheme as usual. Then squeezing
   the closing sequence into the last cell with the last grapheme and
   forcing the width to that of the last grapheme.
   This is harder to implement for a Link widget, as it would have to
   iterate over graphemes with their width like Spans do.
3. Kitty image sequence with utf-8 placeholders, similar to 2 but with
   known constant grapheme widths.

### Link widget that leverages this

https://github.com/benjajaja/tui-link

![](https://github.com/user-attachments/assets/40ac5f9e-9025-4bd9-8e88-b5c5a235b8ec)

It would be cooler if we could just add something like `.link(url)` to `Span`s, because it would much simpler to insert some link and leverage all the Line/Text/Paragraph wrapping and whatnot. With a custom widget you need to take care of the `Area` where you'd want to render it, so it's not that clean. But we could iterate on this later, if even possible.

<details>
<summary>Click to expand old comment</summary>
Problem: setting escape sequences, e.g. image protocols, always causes a
cell to count as "multiwidth", even when it doesn't render wider than
one cell. For images specifically, when rendering a tiny image into just
one cell, the cell to the right will always be skipped - even if that
cell has nothing to do with the widget / buffer that the image is
operating on.
In general, this affects any escape sequence or otherwise invisible text
in a symbol that does not actually render wider than one cell: the next
cell will be erroneously skipped.

Solution: Convert `skip:bool` to enum. Add enum option `UnitWidth` to
force a cell width of 1 for diffing.

When using the option, this also fixes some bug where diffing is not
idempotent and causes a diff operation for `(symbol.len() - 1)` times.
</details>