### PR TITLE
feat(no_std): make palette and serde features depends on std

### DIFF
--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -41,7 +41,7 @@ layout-cache = ["std"]
 anstyle = ["dep:anstyle"]
 
 ## enables conversions from colors in the [`palette`] crate to [`Color`](crate::style::Color).
-palette = ["dep:palette"]
+palette = ["std", "dep:palette"]
 
 ## enables the backend code that sets the underline color. Underline color is only supported by
 ## the Crossterm backend, and is not supported on Windows 7.
@@ -53,7 +53,7 @@ scrolling-regions = []
 
 ## enables serialization and deserialization of style and color types using the [`serde`] crate.
 ## This is useful if you want to save themes to a file.
-serde = ["dep:serde", "bitflags/serde", "compact_str/serde"]
+serde = ["std", "dep:serde", "bitflags/serde", "compact_str/serde"]
 
 [dependencies]
 anstyle = { workspace = true, optional = true }

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -44,6 +44,7 @@ std = ["ratatui-core/std", "ratatui-widgets/std"]
 ## enables serialization and deserialization of style and color types using the [`serde`] crate.
 ## This is useful if you want to save themes to a file.
 serde = [
+  "std",
   "dep:serde",
   "ratatui-core/serde",
   "ratatui-widgets/serde",
@@ -56,7 +57,7 @@ serde = [
 layout-cache = ["std", "ratatui-core/layout-cache"]
 
 ## enables conversions from colors in the [`palette`] crate to [`Color`](crate::style::Color).
-palette = ["ratatui-core/palette", "dep:palette"]
+palette = ["std", "ratatui-core/palette", "dep:palette"]
 
 ## Use terminal scrolling regions to make some operations less prone to
 ## flickering. (i.e. Terminal::insert_before).


### PR DESCRIPTION
This is a nitpick, main thing it does is making it easier to see which features require std.