### PR TITLE
fix(line-gauge): pad default label to display 3 numbers

### DIFF
--- a/ratatui-widgets/src/gauge.rs
+++ b/ratatui-widgets/src/gauge.rs
@@ -431,7 +431,7 @@ impl Widget for &LineGauge<'_> {
         }
 
         let ratio = self.ratio;
-        let default_label = Line::from(format!("{:.0}%", ratio * 100.0));
+        let default_label = Line::from(format!("{:3.0}%", ratio * 100.0));
         let label = self.label.as_ref().unwrap_or(&default_label);
         let (col, row) = buf.set_line(gauge_area.left(), gauge_area.top(), label, gauge_area.width);
         let start = col + 1;
@@ -602,7 +602,7 @@ mod tests {
         let line_gauge = LineGauge::default().ratio(0.5);
         // This should not panic, even if the buffer is too small to render the line gauge.
         line_gauge.render(buffer.area, &mut buffer);
-        assert_eq!(buffer, Buffer::with_lines(["5"]));
+        assert_eq!(buffer, Buffer::with_lines([" "]));
     }
 
     #[test]

--- a/ratatui/tests/widgets_gauge.rs
+++ b/ratatui/tests/widgets_gauge.rs
@@ -233,20 +233,20 @@ fn widgets_line_gauge_renders() {
         })
         .unwrap();
     let mut expected = Buffer::with_lines([
-        "43% ────────────────",
+        " 43% ───────────────",
         "┌Gauge 2───────────┐",
-        "│21% ━━━━━━━━━━━━━━│",
+        "│ 21% ━━━━━━━━━━━━━│",
         "└──────────────────┘",
-        "50% ────────        ",
-        "80% ████████████░░░░",
+        " 50% ───────        ",
+        " 80% ████████████░░░",
     ]);
-    for col in 4..10 {
+    for col in 5..11 {
         expected[(col, 0)].set_fg(Color::Green);
     }
-    for col in 10..20 {
+    for col in 11..20 {
         expected[(col, 0)].set_fg(Color::White);
     }
-    for col in 5..7 {
+    for col in 6..8 {
         expected[(col, 2)].set_fg(Color::Green);
     }
     terminal.backend().assert_buffer(&expected);


### PR DESCRIPTION
the default label used to have a variable width as the gauge progresses, which makes the line width itself flicker on change and is not great.

use a fixed 3 digit widths so anything from 0 to 100% fits without growing the label, keeping the line immobile.

--------------

I'm bad at screenshot but this illustrates the problem a bit; left: before / right: after this patch, you can see as top and bottom aren't aligned on the left.
<img width="374" height="619" alt="line-gauge" src="https://github.com/user-attachments/assets/b0e5daab-0ec7-497f-813d-2b6e1cce2482" />
