### PR TITLE
feat: Allow add/sub modifiers to be omitted in Style serialization.

### DIFF
--- a/ratatui-core/src/style.rs
+++ b/ratatui-core/src/style.rs
@@ -935,7 +935,7 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "serde"))]
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_then_deserialize() {
         let style = Style {


### PR DESCRIPTION
It's really useful that Style supports Deserialize, this allows TUI
apps to have configurable theming without much extra code.

However, deserializing a style currently fails if `add_modifier` and `sub_modifier` are
not specified. That means the following TOML config:

```toml
[theme.highlight]
fg = "white"
bg = "black"
```

Will fail to deserialize with "missing field `add_modifier`". It should be possible
to omit modifiers and have them default to "none".

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
