### PR TITLE
test: regenerate trybuild stderr

### DIFF
--- a/ratatui-macros/tests/ui/fails.stderr
+++ b/ratatui-macros/tests/ui/fails.stderr
@@ -9,9 +9,9 @@ error: No rules expected the token `,` while trying to match the end of the macr
 error: unexpected end of macro invocation
   --> tests/ui/fails.rs:8:18
    |
-8  |       let [a, b] = constraints![
+ 8 |       let [a, b] = constraints![
    |  __________________^
-9  | |       == 1/2,
+ 9 | |       == 1/2,
 10 | |       == 2,
 11 | |     ];
    | |_____^ missing tokens in macro arguments
@@ -50,9 +50,3 @@ error: argument never used
    |                   -------  ^^^^^^^^^^^^^ argument never used
    |                   |
    |                   formatting specifier missing
-
-error[E0527]: pattern requires 2 elements but array has 3
- --> tests/ui/fails.rs:8:9
-  |
-8 |     let [a, b] = constraints![
-  |         ^^^^^^ expected 3 elements


### PR DESCRIPTION
### Overview

Updated the `.stderr` file corresponding to the `ratatui-macros/tests/ui/fails.rs` compile-fail test.  

### Changes

- Updated `tests/ui/fails.stderr` to match the new compiler output.

### Impact

- Affects only the trybuild UI tests
- No impact on production code

### Notes

- The `.stderr` was generated using `TRYBUILD=overwrite cargo test`.

Closes https://github.com/ratatui/ratatui/issues/2094