### PR TITLE
refactor: bring unicode context awareness to Span::Widget::render

### DIFF
--- a/ratatui-core/src/text/span.rs
+++ b/ratatui-core/src/text/span.rs
@@ -461,18 +461,14 @@ impl Widget for &Span<'_> {
                 buf[(x, y)]
                     .append_symbol(grapheme.symbol)
                     .set_style(grapheme.style);
-            } else if x == area.x {
-                // the first grapheme (without a zero-width prefix) should be set on the cell
-                buf[(x, y)]
-                    .set_symbol(grapheme.symbol)
-                    .set_style(grapheme.style);
             } else if symbol_width == 0 {
                 // append zero-width graphemes to the previous cell
                 buf[(x - 1, y)]
                     .append_symbol(grapheme.symbol)
                     .set_style(grapheme.style);
             } else {
-                // just a normal grapheme (not first, not zero-width, not overflowing the area)
+                // just a normal grapheme (not first with zero-width prefix, not zero-width,
+                // not overflowing the area)
                 buf[(x, y)]
                     .set_symbol(grapheme.symbol)
                     .set_style(grapheme.style);


### PR DESCRIPTION
## Summary

This PR refactors `Span::Widget::render` to introduce better unicode context awareness, especially around handling zero-width grapheme clusters (e.g., LRM U+200E) that may appear as prefixes before visible grapheme clusters.

Functionally, it behaves exactly the same as before — the previous implementation was simpler and concise, but it was somewhat difficult to grasp the intent when reading the code later. This change makes the logic more explicit and easier to follow for future readers. It might be a matter of taste, but I'd appreciate a review on whether this tradeoff improves clarity.

## Background

Previously, zero-width grapheme clusters at the start of a span were handled implicitly via positional logic (`i == 0`, `x == area.x`), which could obscure the actual intent and made reasoning about grapheme rendering harder.

## Changes

 - Explicitly iterates zero-width grapheme prefixes before rendering visible clusters.
 - Introduces a small contextual state (`had_zero_width_prefix`) to control rendering flow.
 - Improves readability by separating prefix handling from inline iteration logic.