### PR TITLE
chore(workspace): use ratatui dependency from the workspace

### DIFF
--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -68,7 +68,7 @@ unicode-width.workspace = true
 color-eyre.workspace = true
 crossterm.workspace = true
 pretty_assertions.workspace = true
-ratatui = { path = "../ratatui" }
+ratatui.workspace = true
 rstest.workspace = true
 
 [lints]


### PR DESCRIPTION
an attempt to fix #2166
