### PR TITLE
feat(layout): create XLayout to extend Layout (POC)

### DIFF
--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -23,6 +23,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+xlayout = []
 
 ## enables std
 std = [

--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -670,6 +670,7 @@ impl fmt::Debug for Buffer {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
     use alloc::format;
     use alloc::string::ToString;
     use core::iter;

--- a/ratatui-core/src/layout.rs
+++ b/ratatui-core/src/layout.rs
@@ -319,6 +319,7 @@ mod margin;
 mod position;
 mod rect;
 mod size;
+mod xlayout;
 
 pub use alignment::{Alignment, HorizontalAlignment, VerticalAlignment};
 pub use constraint::Constraint;
@@ -329,3 +330,8 @@ pub use margin::Margin;
 pub use position::Position;
 pub use rect::{Columns, Offset, Positions, Rect, Rows};
 pub use size::Size;
+pub use xlayout::{
+    Align, ConstraintList, FillRecord, FillRecordSegment, FillRecordStep, Hint, HintRange,
+    IntoConstraint, LinearMargin, LinearSizeRange, RangeLevel, SegmentTarget, SizeRange,
+    XConstraint, XLayout, XMargin,
+};

--- a/ratatui-core/src/layout/size.rs
+++ b/ratatui-core/src/layout/size.rs
@@ -47,6 +47,8 @@ pub struct Size {
 impl Size {
     /// A zero sized Size
     pub const ZERO: Self = Self::new(0, 0);
+    /// A max sized Size
+    pub const MAX: Self = Self::new(u16::MAX, u16::MAX);
 
     /// Create a new `Size` struct
     pub const fn new(width: u16, height: u16) -> Self {

--- a/ratatui-core/src/layout/xlayout.rs
+++ b/ratatui-core/src/layout/xlayout.rs
@@ -1,0 +1,1900 @@
+#![warn(missing_docs)]
+
+//! The [`XLayout`] type is an extended version of [`Layout`] that provides additional options for
+//! layout flexibility.
+
+mod constraint;
+mod hint;
+mod record;
+
+use alloc::rc::Rc;
+use alloc::vec::Vec;
+use core::array::TryFromSliceError;
+use core::fmt::{Debug, Display, Formatter};
+use core::ops::{Add, AddAssign, Index};
+
+pub use constraint::{
+    Align, ConstraintList, IntoConstraint, LinearMargin, LinearSizeRange, SizeRange, XConstraint,
+    XMargin,
+};
+pub use hint::{Hint, HintRange};
+use record::OptionFillRecord;
+pub use record::{FillRecord, FillRecordSegment, FillRecordStep};
+use strum::{Display, EnumIs, EnumString};
+
+use crate::layout::layout::{Segments, Spacers};
+use crate::layout::{Constraint, Direction, Flex, Layout, Rect, Size, Spacing};
+
+/// During the layout algorithm the step size is multiplied by this factor in order
+/// to allow the constraints to take less than a whole step.
+/// A whole step would be [`HintRange::fill_scale`], and this factor allows
+/// the constraint to take steps as small as `fill_scale / STEP_FACTOR`.
+const STEP_FACTOR: u64 = 32;
+
+/// In an [`XConstraint`] each range includes three values: min, preferred, and max.
+/// This value dynamically specifies one particular value of those three.
+#[derive(Debug, Display, Clone, Copy, Eq, PartialEq, Hash, EnumIs, EnumString)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum RangeLevel {
+    /// The smallest value represented by the range.
+    Min,
+    /// The ideal value represented by the range.
+    Preferred,
+    /// The largest value represented by the range.
+    Max,
+}
+
+/// `XLayout` is an *extended* layout engine for dividing terminal space using constraints and
+/// direction. It does what [`Layout`] does, plus offering more options to provide greater control
+/// over layouts. `XLayout` tries to resemble `Layout` in every way possible, with the same methods
+/// used in the same ways, so that one can easily switch between using `XLayout` and `Layout` within
+/// a project, depending on your layout needs. `XLayout` uses [`XConstraint`], but `XConstraint`
+/// implements `From<Constraint>` so that `XLayout` can be given the exact same constraints that
+/// `Layout` accepts and produce similar results. `XLayout` also implements `From<Layout>` so one
+/// can build a `Layout` and then convert it to an `XLayout` to add something requiring the extended
+/// options before performing the split.
+///
+/// A layout is a set of constraints that can be applied to a given area to split it into smaller
+/// rectangular areas. This is the core building block for creating structured user interfaces in
+/// terminal applications.
+///
+/// A layout is composed of:
+/// - a direction (horizontal or vertical)
+/// - a set of constraints. See [`XConstraint`] for a discussion on the fields of an extended
+///   constraint.
+/// - a margin, the space between the edge of the main area and the split which can be set
+///   independently along the top, bottom, left, and right sides of the area.
+/// - spacing between segments is controlled by adding additional constraints which are flagged as
+///   [`XConstraint::is_separator`], causing them to not produce segments but still take up space in
+///   the area.
+///
+/// The algorithm used to compute the layout is based giving each constraint turns to allocate space
+/// from the area for that constraint's segment. See [`SegmentTarget`] for details of how segments
+/// grow in each phase. Layout ends once the entire area has been allocated.
+///
+/// If the reason why some constraint was allocated some portion of the area is unclear,
+/// [`XLayout::split_for_debug`] can be used to create a diagnostic record of the allocation process
+/// and how much space was allocated to each constraint in each phase and why. See [`FillRecord`]
+/// for a step-by-step guide to how space is allocated for each constraint.
+///
+/// # Construction
+///
+/// - [`default`](Default::default) - Create a layout with default values (vertical direction, no
+///   constraints, no margin)
+/// - [`new`](Self::new) - Create a new layout with a given direction and constraints
+/// - [`vertical`](Self::vertical) - Create a new vertical layout with the given constraints
+/// - [`horizontal`](Self::horizontal) - Create a new horizontal layout with the given constraints
+///
+/// # Configuration
+///
+/// - [`direction`](Self::direction) - Set the direction of the layout
+/// - [`constraints`](Self::constraints) - Set the constraints of the layout
+/// - [`margin`](Self::margin) - Set uniform margin on all sides
+/// - [`horizontal_margin`](Self::horizontal_margin) - Set the horizontal margin of the layout
+/// - [`vertical_margin`](Self::vertical_margin) - Set the vertical margin of the layout
+///
+/// # Layout Operations
+///
+/// - [`areas`](Self::areas) - Split area into fixed number of rectangles (compile-time known)
+/// - [`spacers`](Self::spacers) - Get spacer rectangles between layout areas
+/// - [`split`](Self::split) - Split area into rectangles (runtime determined count)
+/// - [`split_with_spacers`](Self::split_with_spacers) - Split area and return both areas and
+///   spacers
+///
+/// # Example
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::{Constraint, Direction, Rect, XLayout};
+/// use ratatui_core::text::Text;
+/// use ratatui_core::widgets::Widget;
+///
+/// fn render(area: Rect, buf: &mut Buffer) {
+///     let layout = XLayout::vertical([Constraint::Length(5), Constraint::Fill(1)]);
+///     let [top, bottom] = layout.areas(area);
+///     Text::from("foo").render(top, buf);
+///     Text::from("bar").render(bottom, buf);
+/// }
+/// ```
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct XLayout {
+    /// The axis of layout, determining whether the area is split into a
+    /// horizontal row of segments or a vertical column of segments.
+    direction: Direction,
+    /// The constraints that control the number of segments and the size
+    /// and position of each segment.
+    constraints: Vec<XConstraint>,
+    /// The amount to reduce the rectangle before layout begins.
+    margin: XMargin,
+}
+
+#[inline]
+const fn constraint_priority(constraint: Constraint) -> i16 {
+    #[allow(clippy::match_same_arms)]
+    match constraint {
+        Constraint::Min(_) => 1,
+        Constraint::Max(_) => 7,
+        Constraint::Length(_) => 4,
+        Constraint::Percentage(_) => 3,
+        Constraint::Ratio(_, _) => 2,
+        Constraint::Fill(_) => 1,
+    }
+}
+
+/// A heuristic to try to replicate the behavior of [`Flex::Legacy`] by finding the
+/// last constraint of lowest priority.
+fn position_of_last_lowest<I: IntoIterator<Item = Constraint>>(list: I) -> usize {
+    let mut max_p = i16::MAX;
+    let mut max_i = 0;
+    for (i, c) in list.into_iter().enumerate() {
+        let p = constraint_priority(c);
+        if p < max_p {
+            max_p = p;
+            max_i = i;
+        }
+        if p == max_p {
+            max_i = i;
+        }
+    }
+    max_i
+}
+
+/// A heuristic to try to replicate the behavior of [`Flex::Legacy`] by modifying
+/// the last lowest constraint.
+const fn legacy_effect(hint: HintRange, is_last_lowest: bool) -> HintRange {
+    if is_last_lowest {
+        HintRange {
+            overfill: true,
+            ..hint
+        }
+    } else {
+        hint
+    }
+}
+
+/// True if the given constraints contain at least one [`Constraint::Fill`]
+/// with a value greater than zero.
+fn has_nonzero_fill(constraints: &[Constraint]) -> bool {
+    constraints.iter().any(|c| {
+        if let Constraint::Fill(n) = c {
+            *n > 0
+        } else {
+            false
+        }
+    })
+}
+
+/// Surprisingly, `Constraint::Fill(0)` does not always cause [`Layout`] to
+/// produce a zero-sized segment. If *all* of the fills are zero, then they are
+/// treated as if all of the fills were 1. To simplify the conversion,
+/// turn every `Constraint::Fill(0)` into a `Constraint::Fill(1)` if all of the fills
+/// are zero.
+fn correct_zero_fills(constraints: &mut [Constraint]) {
+    if has_nonzero_fill(constraints) {
+        return;
+    }
+    for c in constraints {
+        if let Constraint::Fill(n) = c {
+            if *n == 0 {
+                *n = 1;
+            }
+        }
+    }
+}
+
+impl<I> From<I> for XLayout
+where
+    I: IntoIterator,
+    I::Item: Into<XConstraint>,
+{
+    fn from(value: I) -> Self {
+        Self {
+            direction: Direction::Vertical,
+            constraints: value.into_iter().map(Into::into).collect(),
+            margin: XMargin::ZERO,
+        }
+    }
+}
+
+/// Depending on the value of [`Layout::flex`] and [`Layout::spacing`], construct separator
+/// constraints to be inserted: (at the start, between each pair, at the end). For example,
+/// [`Flex::Center`] would have two equal-sized separators at the start and the end.
+/// [`Flex::SpaceBetween`] would have repeat the same separator between each pair of constraints.
+fn separators_for_flex(
+    value: &Layout,
+) -> (
+    Option<XConstraint>,
+    Option<XConstraint>,
+    Option<XConstraint>,
+) {
+    // Depending on `flex` certain separators may be only necessary if we do not have a constraint
+    // that fills space.
+    let not_filling = !value.constraints.iter().any(|c| c.is_fill() || c.is_min());
+    let start_space;
+    let end_space;
+    match value.flex {
+        Flex::Start => {
+            start_space = None;
+            end_space = not_filling.then_some(HintRange::filler(1).separator());
+        }
+        Flex::End => {
+            start_space = not_filling.then_some(HintRange::filler(1).separator());
+            end_space = None;
+        }
+        Flex::Center => {
+            start_space = not_filling.then_some(HintRange::filler(1).separator());
+            end_space = start_space.clone();
+        }
+        Flex::SpaceAround | Flex::SpaceEvenly => {
+            start_space = match value.spacing {
+                Spacing::Space(0) | Spacing::Overlap(_) => {
+                    not_filling.then_some(HintRange::filler(1).separator())
+                }
+                Spacing::Space(n) => Some(HintRange::filler(1).with_min(n).separator()),
+            };
+            end_space = start_space.clone();
+        }
+        Flex::SpaceBetween | Flex::Legacy => {
+            start_space = None;
+            end_space = None;
+        }
+    }
+    let inner_space = match value.flex {
+        Flex::Legacy | Flex::Start | Flex::End | Flex::Center => match value.spacing {
+            Spacing::Space(0) | Spacing::Overlap(0) => None,
+            Spacing::Space(n) => Some(n.separator()),
+            Spacing::Overlap(n) => {
+                Some(HintRange::from_hint(Hint::Overlap(n)).scale(0).separator())
+            }
+        },
+        Flex::SpaceBetween => match value.spacing {
+            Spacing::Space(0) | Spacing::Overlap(0) => {
+                not_filling.then_some(HintRange::filler(1).separator())
+            }
+            Spacing::Space(n) => Some(HintRange::filler(1).with_min(n).separator()),
+            Spacing::Overlap(n) => Some(XConstraint::overlap(n)),
+        },
+        Flex::SpaceEvenly => match value.spacing {
+            Spacing::Space(0) | Spacing::Overlap(_) => {
+                not_filling.then_some(HintRange::filler(1).separator())
+            }
+            Spacing::Space(n) => Some(HintRange::filler(1).with_min(n).separator()),
+        },
+        Flex::SpaceAround => match value.spacing {
+            Spacing::Space(0) | Spacing::Overlap(_) => {
+                not_filling.then_some(HintRange::filler(2).separator())
+            }
+            Spacing::Space(n) => Some(
+                HintRange::filler(2)
+                    .with_min(n.saturating_mul(2))
+                    .separator(),
+            ),
+        },
+    };
+    (start_space, inner_space, end_space)
+}
+
+impl From<Layout> for XLayout {
+    /// Generate an `XLayout` from the given `Layout` with the goal of perfectly replicating any
+    /// split that would be produced by the given `Layout`.
+    fn from(mut value: Layout) -> Self {
+        correct_zero_fills(&mut value.constraints);
+        let has_fills = value.constraints.iter().any(Constraint::is_fill) || value.flex.is_legacy();
+        // Attempt to replicated the special behaviour `Flex::Legacy` has for the last lowest
+        // priority constraint.
+        let legacy_target = if value.flex == Flex::Legacy {
+            Some(position_of_last_lowest(value.constraints.iter().copied()))
+        } else {
+            None
+        };
+        // Construct separators to go around and between the constraints, based on the value of
+        // [`Layout::flex`] and [`Layout::spacing`].
+        let (start_space, inner_space, end_space) = separators_for_flex(&value);
+        let mut priority_offset: i16 = 0;
+        let mut iter = value.constraints.into_iter().enumerate().map(|(i, c)| {
+            let mut xc = XConstraint::from(c);
+            // For `Flex::Legacy`, increase the priority to the right, causing each constraint to be
+            // handled in order from left-to-right.
+            if value.flex.is_legacy() {
+                xc.hint.priority = xc.hint.priority.saturating_add(priority_offset);
+                priority_offset = priority_offset.saturating_add(1);
+            }
+            // If there are fill constraints, then put a max on `Min` constraints to prevent them
+            // from growing.
+            if let Constraint::Min(_) = c {
+                if has_fills {
+                    xc.hint.max = xc.hint.min;
+                    xc.hint.preferred = xc.hint.min;
+                } else {
+                    xc.hint.overfill = true;
+                }
+            }
+            (i, xc)
+        });
+        let mut constraints = Vec::new();
+        if let Some(space) = start_space {
+            constraints.push(space);
+        }
+        if let Some((_, mut xc)) = iter.next() {
+            xc.hint = legacy_effect(xc.hint, legacy_target == Some(0));
+            constraints.push(xc);
+        }
+        for (i, mut xc) in iter {
+            if let Some(space) = inner_space.clone() {
+                constraints.push(space);
+            }
+            xc.hint = legacy_effect(xc.hint, legacy_target == Some(i));
+            constraints.push(xc);
+        }
+        if let Some(space) = end_space {
+            constraints.push(space);
+        }
+        Self {
+            direction: value.direction,
+            constraints,
+            margin: value.margin.into(),
+        }
+    }
+}
+
+impl<C: Into<XConstraint>> Add<C> for XLayout {
+    type Output = Self;
+
+    fn add(mut self, rhs: C) -> Self::Output {
+        self.constraints.push(rhs.into());
+        self
+    }
+}
+
+impl<C: Into<XConstraint>> AddAssign<C> for XLayout {
+    fn add_assign(&mut self, rhs: C) {
+        self.constraints.push(rhs.into());
+    }
+}
+
+impl Add<ConstraintList> for XLayout {
+    type Output = Self;
+    fn add(mut self, rhs: ConstraintList) -> Self::Output {
+        self.constraints.append(&mut rhs.into());
+        self
+    }
+}
+
+impl AddAssign<ConstraintList> for XLayout {
+    fn add_assign(&mut self, rhs: ConstraintList) {
+        self.constraints.append(&mut rhs.into());
+    }
+}
+
+impl Add<XLayout> for XConstraint {
+    type Output = XLayout;
+
+    fn add(self, mut rhs: XLayout) -> Self::Output {
+        rhs.constraints.insert(0, self);
+        rhs
+    }
+}
+
+impl Add<XLayout> for HintRange {
+    type Output = XLayout;
+
+    fn add(self, mut rhs: XLayout) -> Self::Output {
+        rhs.constraints.insert(0, self.into());
+        rhs
+    }
+}
+
+impl Add<XLayout> for Size {
+    type Output = XLayout;
+
+    fn add(self, mut rhs: XLayout) -> Self::Output {
+        rhs.constraints.insert(0, self.into());
+        rhs
+    }
+}
+
+impl Add<XLayout> for SizeRange {
+    type Output = XLayout;
+
+    fn add(self, mut rhs: XLayout) -> Self::Output {
+        rhs.constraints.insert(0, self.into());
+        rhs
+    }
+}
+
+impl Add<XLayout> for Hint {
+    type Output = XLayout;
+
+    fn add(self, mut rhs: XLayout) -> Self::Output {
+        rhs.constraints.insert(0, self.into());
+        rhs
+    }
+}
+
+impl Add<XLayout> for u16 {
+    type Output = XLayout;
+
+    fn add(self, mut rhs: XLayout) -> Self::Output {
+        rhs.constraints.insert(0, self.into());
+        rhs
+    }
+}
+
+impl XLayout {
+    /// Creates a new layout with default values.
+    ///
+    /// The `constraints` parameter accepts any type that implements `IntoIterator<Item =
+    /// Into<XConstraint>>`. This includes arrays, slices, vectors, iterators. `Into<XConstraint>`
+    /// is implemented on `u16` and other types, so you can pass an array, `Vec`, etc. of `u16`
+    /// to this function to create a layout with fixed size chunks.
+    ///
+    /// See [`XLayout::constraints`] for various ways to construct an `XConstraint`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Direction, Hint, XConstraint, XLayout};
+    ///
+    /// XLayout::new(
+    ///     Direction::Horizontal,
+    ///     [Hint::Length(5), Hint::Percentage(25)],
+    /// ) + XConstraint::SPACER;
+    ///
+    /// XLayout::new(
+    ///     Direction::Vertical,
+    ///     [1, 2, 3].iter().map(|&c| Hint::Length(c)),
+    /// ) + XConstraint::SPACER;
+    ///
+    /// XLayout::new(Direction::Horizontal, vec![1, 2]);
+    /// ```
+    pub fn new<I>(direction: Direction, constraints: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<XConstraint>,
+    {
+        Self {
+            direction,
+            constraints: constraints.into_iter().map(Into::into).collect(),
+            ..Default::default()
+        }
+    }
+    /// Creates a new vertical layout with default values.
+    ///
+    /// The `constraints` parameter accepts any type that implements `IntoIterator<Item =
+    /// Into<XConstraint>>`. This includes arrays, slices, vectors, iterators, etc.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Hint, XLayout};
+    ///
+    /// let layout = XLayout::vertical([Hint::Length(5), Hint::Percentage(50)]);
+    /// ```
+    pub fn vertical<I>(constraints: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<XConstraint>,
+    {
+        Self::new(Direction::Vertical, constraints.into_iter().map(Into::into))
+    }
+    /// Creates a new horizontal layout with default values.
+    ///
+    /// The `constraints` parameter accepts any type that implements `IntoIterator<Item =
+    /// Into<Constraint>>`. This includes arrays, slices, vectors, iterators, etc.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Hint, XLayout};
+    ///
+    /// let layout = XLayout::horizontal([Hint::Length(5), Hint::Percentage(50)]);
+    /// ```
+    pub fn horizontal<I>(constraints: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<XConstraint>,
+    {
+        Self::new(
+            Direction::Horizontal,
+            constraints.into_iter().map(Into::into),
+        )
+    }
+
+    /// Set the direction of the layout.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Direction, Rect, XLayout};
+    ///
+    /// let layout = XLayout::default()
+    ///     .direction(Direction::Horizontal)
+    ///     .constraints([Constraint::Length(5), Constraint::Fill(1)])
+    ///     .split(Rect::new(0, 0, 10, 10));
+    /// assert_eq!(layout[..], [Rect::new(0, 0, 5, 10), Rect::new(5, 0, 5, 10)]);
+    ///
+    /// let layout = XLayout::default()
+    ///     .direction(Direction::Vertical)
+    ///     .constraints([Constraint::Length(5), Constraint::Fill(1)])
+    ///     .split(Rect::new(0, 0, 10, 10));
+    /// assert_eq!(layout[..], [Rect::new(0, 0, 10, 5), Rect::new(0, 5, 10, 5)]);
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn direction(mut self, direction: Direction) -> Self {
+        self.direction = direction;
+        self
+    }
+
+    /// Sets the constraints of the layout.
+    ///
+    /// The `constraints` parameter accepts any type that implements `IntoIterator<Item =
+    /// Into<XConstraint>>`. This includes arrays, slices, vectors, iterators. `Into<XConstraint>`
+    /// is implemented on several types to provide shortcuts for specifying useful constraints.
+    /// * `u16`: Becomes a constraint with the values of [`XConstraint::FULL`] except that min and
+    ///   preferred of [`HintRange`] are set to the value of the `u16` using [`Hint::Length`].
+    /// * `Range<u16>`, `RangeInclusive<u16>`, `RangeTo<u16>`, etc.: Ranges such as `1..=5` become a
+    ///   [`XConstraint::FULL`] except [`HintRange`] has min set to the low end of the range, while
+    ///   preferred and max are set to the high end of the range using [`Hint::Length`].
+    /// * `(u16, u16)`: Becomes a `Size` with the given width and height, which is then converted to
+    ///   an [`XConstraint`].
+    /// * `(Range<u16>, Range<u16>)`: Becomes a `SizeRange` with its horizontal range matching the
+    ///   first value and its vertical range matching the second value, which is then converted to
+    ///   `XConstraint`. The preferred value on each axis is set to the high end of the given
+    ///   ranges.
+    /// * [`Size`]: Becomes a `SizeRange` with min, preferred, and max all set to the given `Size`,
+    ///   which is then converted to an `XConstraint`.
+    /// * [`SizeRange`]: Becomes an `XConstraint` with the values of [`XConstraint::FULL`] except
+    ///   with the given value as its `size` and with the hint range set to [`HintRange::SIZE`],
+    ///   which suggests that the layout should confirm closely to the size range of this
+    ///   constraint.
+    /// * [`HintRange`]: Becomes an `XConstraint` with the values of [`XConstraint::FULL`] except
+    ///   that the hint is the given value.
+    /// * [`Constraint::Length`]: Becomes an [`HintRange::FULL`] with `preferred` and `max` set to
+    ///   [`Hint::Length`] with the same value.
+    /// * [`Constraint::Percentage`]: Becomes a [`HintRange::FULL`] with `preferred` and `max` set
+    ///   to [`Hint::Percentage`] with the same value.
+    /// * [`Constraint::Ratio`]: Becomes a [`HintRange::FULL`] with `preferred` and `max` set to
+    ///   [`Hint::Ratio`] with the same value.
+    /// * [`Constraint::Min`]: Becomes a [`HintRange::FULL`] with `min` set to [`Hint::Length`] with
+    ///   the same value and with `priority` set to 100.
+    /// * [`Constraint::Max`]: Becomes a [`HintRange::FULL`] with `preferred` and `max` set to
+    ///   [`Hint::Length`] with the same value and with `priority` set to 100. It is exactly like
+    ///   `Constraint::Length` except its higher priority value causes it to wait before allocating
+    ///   its preferred space. See [`HintRange::priority`] for details.
+    ///
+    /// Note that the constraints are applied to the whole area that is to be split, so using
+    /// percentages and ratios with the other constraints may not have the desired effect of
+    /// splitting the area up. (e.g. splitting 100 into [min 20, 50%, 50%], may not result in [20,
+    /// 40, 40] but rather an indeterminate result between [20, 50, 30] and [20, 30, 50]).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect, XLayout};
+    ///
+    /// let layout = XLayout::default()
+    ///     .constraints([
+    ///         Constraint::Percentage(20),
+    ///         Constraint::Ratio(1, 5),
+    ///         Constraint::Length(2),
+    ///         Constraint::Min(2),
+    ///         Constraint::Max(2),
+    ///     ])
+    ///     .split(Rect::new(0, 0, 10, 10));
+    /// assert_eq!(
+    ///     layout[..],
+    ///     [
+    ///         Rect::new(0, 0, 10, 2),
+    ///         Rect::new(0, 2, 10, 2),
+    ///         Rect::new(0, 4, 10, 2),
+    ///         Rect::new(0, 6, 10, 2),
+    ///         Rect::new(0, 8, 10, 2),
+    ///     ]
+    /// );
+    ///
+    /// XLayout::default().constraints([Constraint::Fill(1)]);
+    /// XLayout::default().constraints(&[Constraint::Fill(1)]);
+    /// XLayout::default().constraints(vec![Constraint::Fill(1)]);
+    /// XLayout::default().constraints([Constraint::Fill(1)].iter().filter(|_| true));
+    /// XLayout::default().constraints([1, 2, 3].iter().map(|&c| Constraint::Length(c)));
+    /// XLayout::default().constraints([1, 2, 3]);
+    /// XLayout::default().constraints(vec![1, 2, 3]);
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn constraints<I>(mut self, constraints: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<XConstraint>,
+    {
+        self.constraints = constraints.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the margin of the layout.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect, XLayout};
+    ///
+    /// let layout = XLayout::default()
+    ///     .constraints([Constraint::Fill(1)])
+    ///     .margin(2)
+    ///     .split(Rect::new(0, 0, 10, 10));
+    /// assert_eq!(layout[..], [Rect::new(2, 2, 6, 6)]);
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn margin<M: Into<XMargin>>(mut self, margin: M) -> Self {
+        self.margin = margin.into();
+        self
+    }
+
+    /// Set the horizontal margin of the layout.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect, XLayout};
+    ///
+    /// let layout = XLayout::default()
+    ///     .constraints([Constraint::Fill(1)])
+    ///     .horizontal_margin(2)
+    ///     .split(Rect::new(0, 0, 10, 10));
+    /// assert_eq!(layout[..], [Rect::new(2, 0, 6, 10)]);
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn horizontal_margin<M: Into<LinearMargin>>(mut self, horizontal: M) -> Self {
+        self.margin.set_linear(Direction::Horizontal, horizontal);
+        self
+    }
+
+    /// Set the vertical margin of the layout.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect, XLayout};
+    ///
+    /// let layout = XLayout::default()
+    ///     .constraints([Constraint::Fill(1)])
+    ///     .vertical_margin(2)
+    ///     .split(Rect::new(0, 0, 10, 10));
+    /// assert_eq!(layout[..], [Rect::new(0, 2, 10, 6)]);
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn vertical_margin<M: Into<LinearMargin>>(mut self, vertical: M) -> Self {
+        self.margin.set_linear(Direction::Vertical, vertical);
+        self
+    }
+
+    /// Split the rect into a number of sub-rects according to the constraints.
+    ///
+    /// An ergonomic wrapper around [`XLayout::split`] that returns an array of `Rect`s instead of
+    /// `Rc<[Rect]>`.
+    ///
+    /// This method requires the number of constraints to be known at compile time. If you don't
+    /// know the number of constraints at compile time, use [`XLayout::split`] instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of constraints is not equal to the length of the returned array.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect, XLayout};
+    ///
+    /// let area = Rect::new(0, 0, 10, 10);
+    /// let layout = XLayout::vertical([Constraint::Length(1), Constraint::Fill(1)]);
+    /// let [top, main] = layout.areas(area);
+    ///
+    /// // or explicitly specify the number of constraints:
+    /// let areas = layout.areas::<2>(area);
+    /// ```
+    pub fn areas<const N: usize>(&self, area: Rect) -> [Rect; N] {
+        let areas = self.split(area);
+        areas.as_ref().try_into().unwrap_or_else(|_| {
+            panic!(
+                "invalid number of rects: expected {N}, found {}",
+                areas.len()
+            )
+        })
+    }
+
+    /// Split the rect into a number of sub-rects according to the given [`Layout`].
+    ///
+    /// An ergonomic wrapper around [`XLayout::split`] that returns an array of `Rect`s instead of
+    /// `Rc<[Rect]>`.
+    ///
+    /// This method requires the number of constraints to be known at compile time. If you don't
+    /// know the number of constraints at compile time, use [`XLayout::split`] instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the number of constraints is not equal to the length of the returned
+    /// array.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect, XLayout};
+    ///
+    /// let area = Rect::new(0, 0, 10, 10);
+    /// let layout = XLayout::vertical([Constraint::Length(1), Constraint::Min(0)]);
+    /// let [top, main] = layout.try_areas(area)?;
+    ///
+    /// // or explicitly specify the number of constraints:
+    /// let areas = layout.try_areas::<2>(area)?;
+    /// # Ok::<(), core::array::TryFromSliceError>(())
+    /// ```
+    pub fn try_areas<const N: usize>(&self, area: Rect) -> Result<[Rect; N], TryFromSliceError> {
+        self.split(area).as_ref().try_into()
+    }
+
+    /// Split the rect into a number of sub-rects according to the constraints and return just
+    /// the spacers between the areas.
+    ///
+    /// The number of areas is determined by the number of non-separator constraints. Constraints
+    /// with the [`XConstraint::is_separator`] flag set do not add areas to the layout, nor do
+    /// they add spacers to the list returned by this method.
+    ///
+    /// The number of spacers will always be one greater than the number of areas, with one spacer
+    /// before the first area, between each area, and after the last area. If there is no space
+    /// between two areas, or the areas overlap, then the spacer `Rect` will still be in the
+    /// list, but it will have zero size.
+    ///
+    /// This method requires the number of spacers to be known at compile time. If you don't
+    /// know the number of spacers at compile time, use [`XLayout::split_with_spacers`] instead.
+    ///
+    /// This method is similar to [`XLayout::areas`], and can be called with the same parameters,
+    /// but it returns just the spacers between the areas.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of constraints + 1 is not equal to the length of the returned array.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect, XLayout};
+    ///
+    /// let area = Rect::new(0, 0, 10, 10);
+    /// let layout = XLayout::vertical([Constraint::Length(1), Constraint::Fill(1)]);
+    /// let [top, main] = layout.areas(area);
+    /// let [before, inbetween, after] = layout.spacers(area);
+    ///
+    /// // or explicitly specify the number of constraints:
+    /// let spacers = layout.spacers::<3>(area);
+    /// ```
+    pub fn spacers<const N: usize>(&self, area: Rect) -> [Rect; N] {
+        let (_, spacers) = self.split_with_spacers(area);
+        spacers
+            .as_ref()
+            .try_into()
+            .expect("invalid number of rects")
+    }
+    /// Split the given area into smaller ones based on the constraints and the direction.
+    /// This method is similar to `split`, but it returns two sets of rectangles: one for the areas
+    /// and one for the spaces before, after, and between the areas.
+    ///
+    /// The number of areas is determined by the number of non-separator constraints. Constraints
+    /// with the [`XConstraint::is_separator`] flag set do not add areas to the list returned by
+    /// this method.
+    ///
+    /// The number of spacers will always be one greater than the number of areas, with one spacer
+    /// before the first area, between each area, and after the last area. If there is no space
+    /// between two areas, or the areas overlap, then the spacer `Rect` will still be in the
+    /// list, but it will have zero size.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratatui_core::layout::{Constraint, Direction, IntoConstraint, Rect, XLayout};
+    ///
+    /// let (areas, spacers) = XLayout::default()
+    ///     .direction(Direction::Vertical)
+    ///     .constraints([Constraint::Length(5), Constraint::Fill(1)])
+    ///     .split_with_spacers(Rect::new(2, 2, 10, 10));
+    /// assert_eq!(areas[..], [Rect::new(2, 2, 10, 5), Rect::new(2, 7, 10, 5)]);
+    /// assert_eq!(
+    ///     spacers[..],
+    ///     [
+    ///         Rect::new(2, 2, 10, 0),
+    ///         Rect::new(2, 7, 10, 0),
+    ///         Rect::new(2, 12, 10, 0)
+    ///     ]
+    /// );
+    ///
+    /// let (areas, spacers) = XLayout::default()
+    ///     .direction(Direction::Horizontal)
+    ///     .constraints([
+    ///         Constraint::Ratio(1, 3).into(),
+    ///         1.separator(),
+    ///         Constraint::Ratio(2, 3).into(),
+    ///     ])
+    ///     .split_with_spacers(Rect::new(0, 0, 10, 2));
+    /// assert_eq!(areas[..], [Rect::new(0, 0, 3, 2), Rect::new(4, 0, 6, 2)]);
+    /// assert_eq!(
+    ///     spacers[..],
+    ///     [
+    ///         Rect::new(0, 0, 0, 2),
+    ///         Rect::new(3, 0, 1, 2),
+    ///         Rect::new(10, 0, 0, 2)
+    ///     ]
+    /// );
+    /// ```
+    pub fn split_with_spacers(&self, area: Rect) -> (Segments, Spacers) {
+        let area = area - self.margin;
+        let rules = self.build_segment_set(area, None);
+        let segments = rules.build_segments(self.direction, area, &self.constraints);
+        let spacers = build_spacers(self.direction, area, &segments);
+        (segments, spacers)
+    }
+    /// Split a given area into smaller ones based on the constraints and the direction.
+    ///
+    /// Note that the constraints are applied to the whole area that is to be split, so using
+    /// percentages and ratios with the other constraints may not have the desired effect of
+    /// splitting the area up. (e.g. splitting 100 into [min 20, 50%, 50%], may not result in [20,
+    /// 40, 40] but rather an indeterminate result between [20, 50, 30] and [20, 30, 50]) as
+    /// the two 50% each fight to claim half of the 100 when only 80 is actually available.
+    ///
+    /// Here is the actual result:
+    ///
+    /// ```
+    /// use ratatui_core::layout::{Constraint, Direction, Rect, XLayout};
+    /// let layout = XLayout::default()
+    ///     .direction(Direction::Horizontal)
+    ///     .constraints([
+    ///         Constraint::Min(20),
+    ///         Constraint::Percentage(50),
+    ///         Constraint::Percentage(50),
+    ///     ])
+    ///     .split(Rect::new(2, 2, 100, 10));
+    /// assert_eq!(
+    ///     layout[..],
+    ///     [
+    ///         Rect::new(2, 2, 20, 10),
+    ///         Rect::new(22, 2, 40, 10),
+    ///         Rect::new(62, 2, 40, 10)
+    ///     ]
+    /// );
+    /// ```
+    ///
+    /// In this case it actually did result in [20, 40, 40] because the two `Percentage(50)`
+    /// constraints have equal priority and so they shared what was available equally. They were
+    /// each trying to take 50 out of 100, and space was allocated to them at the same rate
+    /// until all the space was used up, leaving each with 40.
+    ///
+    /// There is a helper method that can be used to split the whole area into smaller ones based on
+    /// the layout: [`Layout::areas()`]. That method is a shortcut for calling this method. It
+    /// allows you to destructure the result directly into variables, which is useful when you know
+    /// at compile time the number of areas that will be created.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratatui_core::layout::{Constraint, Direction, Layout, Rect};
+    /// let layout = Layout::default()
+    ///     .direction(Direction::Vertical)
+    ///     .constraints([Constraint::Length(5), Constraint::Fill(1)])
+    ///     .split(Rect::new(2, 2, 10, 10));
+    /// assert_eq!(layout[..], [Rect::new(2, 2, 10, 5), Rect::new(2, 7, 10, 5)]);
+    ///
+    /// let layout = Layout::default()
+    ///     .direction(Direction::Horizontal)
+    ///     .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
+    ///     .split(Rect::new(0, 0, 9, 2));
+    /// assert_eq!(layout[..], [Rect::new(0, 0, 3, 2), Rect::new(3, 0, 6, 2)]);
+    /// ```
+    pub fn split(&self, area: Rect) -> Segments {
+        let area = area - self.margin;
+        let rules = self.build_segment_set(area, None);
+        rules.build_segments(self.direction, area, &self.constraints)
+    }
+
+    /// This method performs the same split as [`XLayout::split`] and similar methods,
+    /// but it throws away the result of that split and instead returns as record of the steps
+    /// that it took in order to allocate space to each constraint. This can help debug a layout
+    /// if the segments are not where they should be. See [`FillRecord`] for more information.
+    pub fn split_for_debug(&self, area: Rect) -> FillRecord {
+        let area = area - self.margin;
+        let record = FillRecord::default();
+        let rules = self.build_segment_set(area, Some(record));
+        rules.record.0.unwrap()
+    }
+
+    /// Calculate the size range of this layout based on the `size` of and `margin` of each
+    /// constraint. The [`XConstraint::size`] represents the space needed by the content of that
+    /// segment, and this method calculates the size needed by the entire layout if it were to be
+    /// nested within another layout. The result of this method can be converted into an
+    /// `XConstraint` and used to build the layout that will contain this layout.
+    ///
+    /// If there are any constraints that include hints that request an overlap, the size of this
+    /// layout is reduced according to the overlap. Otherwise, all hints are ignored when
+    /// calculating the size.
+    ///
+    /// # Example
+    /// ```
+    /// use ratatui_core::layout::{Rect, Size, SizeRange, XLayout};
+    /// use ratatui_core::text::Text;
+    /// let area = Rect::new(0, 0, 25, 10);
+    /// let a = Text::from("Alpha\nAlpha"); // 5x2
+    /// let b = Text::from("Bravo Charlie"); // 13x1
+    /// let c = Text::from("Chilly\nChaps\nChuckles"); // 8x3
+    /// let d = Text::from("Delta Fox"); // 9x1
+    /// let inner = XLayout::vertical([a.size(), b.size(), d.size()]);
+    /// assert_eq!(inner.size(), SizeRange::from((13, 4)));
+    /// let outer = XLayout::horizontal([c.size().into(), inner.size()]);
+    /// let [segC, segInner] = outer.areas(area);
+    /// let [segA, segB, segD] = inner.areas(segInner);
+    /// assert_eq!(segC, Rect::new(1, 3, 8, 3));
+    /// assert_eq!(segInner, Rect::new(11, 3, 13, 4));
+    /// assert_eq!(segA, Rect::new(15, 3, 5, 2));
+    /// assert_eq!(segB, Rect::new(11, 5, 13, 1));
+    /// assert_eq!(segD, Rect::new(13, 6, 9, 1));
+    /// ```
+    pub fn size(&self) -> SizeRange {
+        SizeRange {
+            horizontal: self.linear_size(Direction::Horizontal),
+            vertical: self.linear_size(Direction::Vertical),
+        }
+    }
+    /// The same as [`XLayout::size`] but it calculates the size along only one axis.
+    pub fn linear_size(&self, direction: Direction) -> LinearSizeRange {
+        if self.direction == direction {
+            LinearSizeRange::new(
+                self.sum(RangeLevel::Min),
+                self.sum(RangeLevel::Preferred),
+                self.sum(RangeLevel::Max),
+            )
+        } else {
+            LinearSizeRange::new(
+                self.max(RangeLevel::Min),
+                self.max(RangeLevel::Preferred),
+                self.min(RangeLevel::Max),
+            )
+        }
+    }
+    /// Iterate through the priorities of the constraints of a layout to return each distinct
+    /// priority level from lowest to highest. This returns the value of the priority, not the
+    /// constraint, and each priority value is returned only once, even if multiple constraints
+    /// have the same value.
+    const fn priorities(&self) -> PriorityIter<'_> {
+        PriorityIter {
+            source: self,
+            front: None,
+            back: None,
+        }
+    }
+    /// The minimum value of the [`SizeRange`] of each constraint at the given level
+    /// and measured perpendicular to the layout direction. Return `u16::MAX` if the constraint
+    /// list is empty.
+    fn min(&self, level: RangeLevel) -> u16 {
+        self.fold(level, u16::MAX, u16::min)
+    }
+    /// The maximum value of the [`SizeRange`] of each constraint at the given level
+    /// and measured perpendicular to the layout direction. Return zero if the constraint list
+    /// is empty.
+    fn max(&self, level: RangeLevel) -> u16 {
+        self.fold(level, 0, u16::max)
+    }
+    /// Applies the given function to fold the values of [`SizeRange`] of each constraint
+    /// at the given level and measured perpendicular to the layout direction.
+    /// Returns `initial` if the constraint list is empty. Otherwise, `func` is applied
+    /// to the running total and the value of the current constraint to produce the
+    /// new running total.
+    fn fold<F>(&self, level: RangeLevel, initial: u16, func: F) -> u16
+    where
+        F: Fn(u16, u16) -> u16,
+    {
+        let mut total = initial;
+        let dir = self.direction.perpendicular();
+        for c in &self.constraints {
+            let size = c
+                .margin
+                .linear(dir)
+                .total()
+                .saturating_add(c.size.linear(dir)[level]);
+            total = func(total, size);
+        }
+        total.saturating_add(self.margin.linear(dir).total())
+    }
+    /// Sums the values of [`SizeRange`] of each constraint at the given level
+    /// measured parallel to the layout direction.
+    fn sum(&self, level: RangeLevel) -> u16 {
+        let mut sum = self.margin.linear(self.direction).total();
+        let mut overlap: u16 = 0;
+        for c in &self.constraints {
+            sum = sum.saturating_add(c.size.linear(self.direction)[level]);
+            sum = sum.saturating_add(c.margin.linear(self.direction).total());
+            if let Hint::Overlap(v) = c.hint[level] {
+                overlap = overlap.saturating_add(v);
+            }
+        }
+        sum.saturating_sub(overlap)
+    }
+    /// The core of the layout algorithm that takes an area to be split and produces a
+    /// [`SegmentSet`] that specifies the size of each segment. It does everything except
+    /// translate the segment sizes into rectangles. The creation of rectangles is the
+    /// responsibility of [`SegmentSet::build_segments`].
+    fn build_segment_set(&self, area: Rect, record: Option<FillRecord>) -> SegmentSet {
+        use FillState::Finished;
+        use RangeLevel::{Max, Min, Preferred};
+        use SegmentTarget::{Forced, Overfill, Range};
+        let area_length = match self.direction {
+            Direction::Horizontal => area.width,
+            Direction::Vertical => area.height,
+        };
+        let rules = self
+            .constraints
+            .iter()
+            .map(|c| SegmentRule::new(c, self.direction, area_length))
+            .collect::<Vec<_>>();
+        let area_length = i32::from(area_length);
+        let min_total = rules.iter().map(|r| r.min).sum::<i32>();
+        let mut set = SegmentSet::new(rules, area_length, record);
+        // Try skipping the min phase, since a min phase can give some segments a head-start
+        // in the preferred phase that changes the outcome.
+        // Only do the min phase now if we know it will finish the layout.
+        let skip_min = min_total < area_length;
+        if !skip_min && set.fill_by_priorities(Range(Min), self.priorities()) == Finished {
+            return set;
+        }
+        let result = set.fill_by_priorities(Range(Preferred), self.priorities());
+        if skip_min && !set.are_all_at_min() {
+            // Skipping the min phase was a mistake, since some did not reach min in the
+            // preferred phase, so reset back to initial and do the min and preferred phases.
+            set.reset();
+            if set.fill_by_priorities(Range(Min), self.priorities()) == Finished {
+                return set;
+            }
+            if set.fill_by_priorities(Range(Preferred), self.priorities()) == Finished {
+                return set;
+            }
+        }
+        if result == Finished {
+            return set;
+        }
+        if set.fill_by_priorities(Range(Max), self.priorities().rev()) == Finished {
+            return set;
+        }
+        if set.fill_by_priorities(Overfill, self.priorities().rev()) == Finished {
+            return set;
+        }
+        _ = set.fill_by_priorities(Forced, self.priorities().rev());
+        set
+    }
+}
+
+/// Iterate through the priorities of the constraints of a layout to return each distinct priority
+/// level from lowest to highest. This returns the value of the priority, not the constraint,
+/// and each priority value is returned only once, even if multiple constraints have the same value.
+struct PriorityIter<'a> {
+    /// The constraints containing the priorities to iterate over.
+    source: &'a XLayout,
+    /// The lowest constraint priority that we have returned so far.
+    front: Option<i16>,
+    /// The highest constraint priority that we have returned so far.
+    back: Option<i16>,
+}
+
+impl PriorityIter<'_> {
+    /// True if the given priority may be returned from `next` due to being within the range
+    /// between [`front`](Self::front) and [`back`](Self::back).
+    fn is_in_range(&self, priority: i16) -> bool {
+        self.front.is_none_or(|p| p < priority) && self.back.is_none_or(|p| priority < p)
+    }
+}
+
+impl Iterator for PriorityIter<'_> {
+    type Item = i16;
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = self
+            .source
+            .constraints
+            .iter()
+            .map(|p| p.hint.priority)
+            .filter(|p| self.is_in_range(*p))
+            .min();
+        if result.is_some() {
+            self.front = result;
+        }
+        result
+    }
+}
+
+impl DoubleEndedIterator for PriorityIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let result = self
+            .source
+            .constraints
+            .iter()
+            .map(|p| p.hint.priority)
+            .filter(|p| self.is_in_range(*p))
+            .max();
+        if result.is_some() {
+            self.back = result;
+        }
+        result
+    }
+}
+
+/// Is the layout algorithm done yet?
+#[derive(Eq, PartialEq, Clone, Copy)]
+enum FillState {
+    /// The algorithm has finished due to filling the entire area.
+    Finished,
+    /// The algorithm has work yet to do.
+    Continue,
+}
+
+/// The collection of segments that the layout algorithm operates on.
+struct SegmentSet {
+    /// The segments that the algorithm gradually grows.
+    rules: Vec<SegmentRule>,
+    /// The amount of space that has already been allocated.
+    rules_length: i32,
+    /// The total amount of space available to allocate.
+    area_length: i32,
+    /// A record of the steps taken by the algorithm.
+    record: OptionFillRecord,
+}
+
+/// Integer division that rounds up.
+const fn div_ceil(a: u64, b: u64) -> u64 {
+    if a == 0 {
+        return 0;
+    }
+    a.saturating_sub(1).saturating_div(b).saturating_add(1)
+}
+
+/// Integer division that rounds up or down as appropriate.
+const fn div_round(a: u64, b: u64) -> u64 {
+    if a == 0 {
+        return 0;
+    }
+    let q = a / b;
+    let r = a % b;
+    q.saturating_add((r * 2 >= b) as u64)
+}
+
+impl SegmentSet {
+    /// Construct a new set from a list of rules and an area size.
+    /// The `record` is optional and is normally `None` unless the algorithm is being run
+    /// to debug its constraints.
+    fn new(rules: Vec<SegmentRule>, area_length: i32, record: Option<FillRecord>) -> Self {
+        let rules_length = rules.iter().map(|r| r.size).sum();
+        let mut record = OptionFillRecord(record);
+        record.set_segments(area_length, &rules);
+        Self {
+            rules,
+            rules_length,
+            area_length,
+            record,
+        }
+    }
+    /// Reset the segments to the state at the start of the algorithm, thereby allowing
+    /// the algorithm to try an alternative strategy in case the first approach failed.
+    fn reset(&mut self) {
+        self.record.reset();
+        for rule in &mut self.rules {
+            rule.size = rule.initial_size;
+        }
+        self.rules_length = self.rules.iter().map(|r| r.size).sum();
+    }
+    /// Checks that every segment has reached its minimum size.
+    fn are_all_at_min(&self) -> bool {
+        self.rules.iter().all(|r| r.min <= r.size)
+    }
+    /// Iterate through the given iterator of priorities, for each priority,
+    /// activate the segments with that priority and let them fill to the given
+    /// target. Return `Finished` if the layout is complete.
+    fn fill_by_priorities<I: Iterator<Item = i16>>(
+        &mut self,
+        target: SegmentTarget,
+        priorities: I,
+    ) -> FillState {
+        for p in priorities {
+            if self.fill_to(p, target) == FillState::Finished {
+                return FillState::Finished;
+            }
+        }
+        FillState::Continue
+    }
+    /// Activate segments with the given priority if they can be activated, and
+    /// then iterate through those segments repeatedly until they have all reached
+    /// the given target or the layout is finished. Return `Finished` if the layout
+    /// is finished.
+    fn fill_to(&mut self, priority: i16, target: SegmentTarget) -> FillState {
+        loop {
+            if self.area_length <= self.rules_length {
+                return FillState::Finished;
+            }
+            // The speed is how much all the active segments might allocate this round
+            // per STEP_FACTOR units of step size.
+            let speed: u64 = self
+                .rules
+                .iter()
+                .filter(|r| r.can_fill(priority, target))
+                .map(|r| r.fill_scale)
+                .sum();
+            // Speed == 0 means there are no active segments, so stop and move on to the
+            // next round.
+            if speed == 0 {
+                return FillState::Continue;
+            }
+            // Determine how much space remains to be allocated.
+            let remainder =
+                u64::try_from(self.area_length.saturating_sub(self.rules_length)).unwrap_or(0);
+            // Determine how big a step size we can allow each segment this round without
+            // possibility of overflowing the area.
+            let step_size = div_ceil(remainder.saturating_mul(STEP_FACTOR), speed);
+            // Iterate through all the active segments in spiral order (for symmetry), and give them
+            // all the same step size so they each get a fair chance to reach their target.
+            for (index, s) in
+                SpiralIter::new(&mut self.rules).filter(|(_, r)| r.can_fill(priority, target))
+            {
+                let limit = self.area_length.saturating_sub(self.rules_length);
+                let before = s.size;
+                // Grow the segment without exceeding the target or overflowing the area.
+                s.fill_steps_to(step_size, target, limit);
+                let grow = s.size.saturating_sub(before);
+                s.size = s.size.max(s.size);
+                // Record what just happened, if we are in debug mode.
+                self.record
+                    .add_step(index, before, s.size, step_size, target);
+                self.rules_length = self.rules_length.saturating_add(grow);
+                if self.area_length <= self.rules_length {
+                    return FillState::Finished;
+                }
+            }
+        }
+    }
+    /// Generate rectangles for the segments at their current sizes.
+    fn build_segments(
+        &self,
+        direction: Direction,
+        area: Rect,
+        constraints: &[XConstraint],
+    ) -> Segments {
+        match direction {
+            Direction::Horizontal => self.build_segments_x(area, constraints),
+            Direction::Vertical => self.build_segments_y(area, constraints),
+        }
+    }
+    /// Generate rectangles for the segments assuming that layout is horizontal.
+    fn build_segments_x(&self, area: Rect, constraints: &[XConstraint]) -> Segments {
+        let mut result = Vec::new();
+        let mut x = area.left();
+        let y = area.y;
+        let height = area.height;
+        for (c, rule) in constraints.iter().zip(&self.rules) {
+            let start = x;
+            x = x.saturating_add_signed(i16::try_from(rule.size).unwrap_or(0));
+            if c.is_separator {
+                continue;
+            }
+            let width = x.saturating_sub(start);
+            let r = Rect::new(start, y, width, height);
+            result.push(c.inner_rect(r));
+        }
+        Rc::from(&*result)
+    }
+    /// Generate rectangles for the segments assuming that layout is vertical.
+    fn build_segments_y(&self, area: Rect, constraints: &[XConstraint]) -> Segments {
+        let mut result = Vec::new();
+        let mut y = area.top();
+        let x = area.x;
+        let width = area.width;
+        for (c, rule) in constraints.iter().zip(&self.rules) {
+            let start = y;
+            y = y.saturating_add_signed(i16::try_from(rule.size).unwrap_or(0));
+            if c.is_separator {
+                continue;
+            }
+            let height = y.saturating_sub(start);
+            let r = Rect::new(x, start, width, height);
+            result.push(c.inner_rect(r));
+        }
+        Rc::from(&*result)
+    }
+}
+
+/// Improve symmetry by iterating inward from both ends toward the center
+/// of the list. If the list were `[a,b,c,d,e]`, the iterator would produce
+/// (1,a), (5,e), (2,b), (4,d), (3,c). It produces `(usize, &mut T)`.
+struct SpiralIter<'a, T> {
+    /// The slice to iterate over.
+    items: &'a mut [T],
+    /// The index of the first element of the slice.
+    front_index: usize,
+    /// True if the next element should be from the front of the slice.
+    /// Otherwise, the next element should be the last element of the slice.
+    front_turn: bool,
+}
+
+impl<'a, T> SpiralIter<'a, T> {
+    /// Construct a new iterator over the given slice.
+    const fn new(items: &'a mut [T]) -> Self {
+        Self {
+            items,
+            front_index: 0,
+            front_turn: true,
+        }
+    }
+}
+
+impl<'a, T> Iterator for SpiralIter<'a, T> {
+    type Item = (usize, &'a mut T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let items = core::mem::take(&mut self.items);
+        if let Some((item, next)) = if self.front_turn {
+            items.split_first_mut()
+        } else {
+            items.split_last_mut()
+        } {
+            let index = if self.front_turn {
+                self.front_index
+            } else {
+                self.front_index + next.len()
+            };
+            if self.front_turn {
+                self.front_index += 1;
+            }
+            self.items = next;
+            self.front_turn = !self.front_turn;
+            Some((index, item))
+        } else {
+            None
+        }
+    }
+}
+
+/// Transpose the x and y axis of a `Rect`, so horizontal becomes vertical and x becomes y,
+/// allowing us to pretend all `Rect`s are arranged along the x-axis and then flip them
+/// if necessary to the y-axis at the end.
+const fn transpose(rect: Rect) -> Rect {
+    Rect::new(rect.y, rect.x, rect.height, rect.width)
+}
+
+/// Construct a list of spacers from an area and a list of segments within that area.
+fn build_spacers(direction: Direction, area: Rect, segments: &[Rect]) -> Spacers {
+    // Pretend that direction is horizontal by transposing the area's x and y.
+    let area = if direction == Direction::Vertical {
+        transpose(area)
+    } else {
+        area
+    };
+    let mut result = Vec::new();
+    let mut x = area.left();
+    let y = area.y;
+    let height = area.height;
+    for seg in segments {
+        let seg = if direction == Direction::Vertical {
+            transpose(*seg)
+        } else {
+            *seg
+        };
+        let width = seg.x.saturating_sub(x);
+        result.push(Rect::new(x, y, width, height));
+        x = if seg.width > 0 {
+            seg.right()
+        } else {
+            // If seg.width == 0 then we cannot trust seg.right()
+            // to be accurate.
+            x.saturating_add(width)
+        };
+    }
+    let width = area.right().saturating_sub(x);
+    result.push(Rect::new(x, y, width, height));
+    if direction == Direction::Vertical {
+        for r in &mut result {
+            *r = transpose(*r);
+        }
+    }
+    Rc::from(&*result)
+}
+
+/// These represent the stages of layout. Each stage involves allocating
+/// some portion of the area to each constraint base on that constraint's hints.
+/// At each stage each constraint has some target that it wants to grow to, and
+/// the layout algorithm checks how much space is available and divides it among
+/// the active constraints to allow them to grow toward their targets.
+///
+/// A constraint is active if it has not yet reached its target size for the phase
+/// and if its [`HintRange::priority`] value indicates that it is that constraint's
+/// turn to grow. As active constraints reach their target and become inactive, the
+/// remaining available area is again divide between the remaining constraints
+/// until either all active constraints have reached their targets or there is no
+/// more remaining space.
+///
+/// Assuming that there is some space remaining to allocate, layout proceeds to the
+/// next phase in order:
+///
+/// 1. Range(Min): The target of each constraint comes from [`HintRange::min`].
+/// 2. Range(Preferred): The target of each constraint comes from [`HintRange::preferred`].
+/// 3. Range(Max): The target of each constraint comes from [`HintRange::max`].
+/// 4. Overfill: Only constraints with [`HintRange::overfill`] are active during this phase, and
+///    constraints grow until the whole area is filled.
+/// 5. Forced: All constraints grow until the whole areas is filled.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, EnumIs)]
+pub enum SegmentTarget {
+    /// There are three `Range` stages: min, preferred, and max, each corresponding to
+    /// a `RangeLevel` within a [`HintRange`]. The actual target size for each constraint
+    /// is determined based on the [`Hint`], the constraint's [`SizeRange`], and the size
+    /// of the area to fill.
+    ///
+    /// Regardless of the min hint's value, the min phase target cannot be smaller than
+    /// the min of the `SizeRange` in the layout direction. And if the alignment in the
+    /// layout direction is [`Align::Full`] then the target of the max phase cannot be larger
+    /// than the max of the `SizeRange`. If the hint is [`Hint::Size`] then the target takes
+    /// its value directly from the `SizeRange`.
+    Range(RangeLevel),
+    /// The overfill phase is where constraints fill beyond their max target if necessary to
+    /// completely fill the area, so the target is infinite, but only constraints with the
+    /// [`HintRange::overfill`] flag set are active.
+    Overfill,
+    /// This phase is only possible if no constraint has the [`HintRange::overfill`] flag set,
+    /// since otherwise the [`SegmentTarget::Overfill`] phase would have inevitably allocated the
+    /// entire area. Therefore, in order to ensure that the area is filled, the forced phase
+    /// causes all constraints to grow even without the overfill flag, thereby ending the layout
+    /// process.
+    Forced,
+}
+
+impl Display for SegmentTarget {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Range(r) => Debug::fmt(r, f),
+            _ => Debug::fmt(&self, f),
+        }
+    }
+}
+
+impl SegmentTarget {
+    /// True if this is the [`SegmentTarget::Range`] variant,
+    /// and the given predicate returns true.
+    pub fn is_range_and<P>(self, pred: P) -> bool
+    where
+        P: FnOnce(RangeLevel) -> bool,
+    {
+        match self {
+            Self::Range(r) => pred(r),
+            _ => false,
+        }
+    }
+}
+
+/// This represents a segment's constraint within a given area to be split.
+/// The hint values that were relative to an unknown area size in the [`XConstraint`]
+/// have been converted to absolute values, so we are ready to begin allocating
+/// space within the area.
+#[derive(Debug)]
+struct SegmentRule {
+    /// The initial size of the segment, for the purposes of resetting the algorithm.
+    initial_size: i32,
+    /// The minimum size of the area to allocate for the segment, if possible.
+    /// It may be negative to indicate an overlap.
+    min: i32,
+    /// The preferred size of the area to allocate for the segment, if possible.
+    /// A high value for `priority` helps to ensure that the preferred size is respected.
+    /// It may be negative to indicate an overlap.
+    preferred: i32,
+    /// The maximum size of the area to allocate for the segment, though the segment
+    /// may be allocated more if necessary to fill the area. To prevent overfilling,
+    /// ensure that `overfill` is false and `priority` is a low value.
+    /// It may be negative to indicate an overlap.
+    max: i32,
+    /// The rate at which to allocate space for the segment.
+    /// If this is zero, then the segment is never allocated any space, even if that means
+    /// that the area fails to be filled, even if `overflow` is true.
+    /// Segments with a fill scale of 2 are allocated space twice as quickly as segments
+    /// with a fill scale of 1, and so on. The default is 1.
+    fill_scale: u64,
+    /// If true, then the segment should be allocated space beyond its max when this is necessary
+    /// in order to fill the area. If false, then the segment will never be allocated space beyond
+    /// its max unless no segment has `overfill` set to true. The default is `false`.
+    overfill: bool,
+    /// A number that determines the order in which segments are allocated space.
+    /// Segments with lower values are allocated first when allocating the min space
+    /// for each segment, and when allocating the preferred space.
+    /// When allocating the maximum space and the overfill space, segments with higher
+    /// values allocate first. This means that lower values are more likely to be allocated
+    /// close to their preferred size, while higher values are more likely to be shrunk or
+    /// stretched as needed.
+    priority: i16,
+    /// The current space allocated to the segment. This value changes during the allocation
+    /// process.
+    size: i32,
+}
+
+impl Index<RangeLevel> for SegmentRule {
+    type Output = i32;
+
+    fn index(&self, index: RangeLevel) -> &Self::Output {
+        match index {
+            RangeLevel::Min => &self.min,
+            RangeLevel::Preferred => &self.preferred,
+            RangeLevel::Max => &self.max,
+        }
+    }
+}
+
+impl SegmentRule {
+    /// Construct a `SegmentRule` using the state of the layout and the size of the area.
+    /// This transforms a constraint from an abstract notion with no knowledge of what area
+    /// it will be laying out, into a set of concrete specific goals.
+    fn new(constraint: &XConstraint, direction: Direction, area_length: u16) -> Self {
+        let range = constraint.size.linear(direction);
+        let margin = constraint.margin.linear(direction).total();
+        // Convert the three hints from Hint values to i32, now that we know
+        // the size of the area.
+        let mut min = constraint
+            .hint
+            .min
+            .absolute_for(constraint, direction, area_length);
+        let mut preferred =
+            constraint
+                .hint
+                .preferred
+                .absolute_for(constraint, direction, area_length);
+        let mut max = constraint
+            .hint
+            .max
+            .absolute_for(constraint, direction, area_length);
+        // If the alignment is Full, then max cannot be larger than the max of the size.
+        if constraint.get_align_for(direction) == Align::Full {
+            let range_max = i32::from(range.max.saturating_add(margin));
+            max = max.min(range_max);
+        }
+        // If the minimum size is greater than 0, this segment will contain some
+        // important content, therefore increase min to be at least that minimum size.
+        let range_min = i32::from(range.min.saturating_add(margin));
+        if range_min > 0 {
+            min = min.max(range_min);
+        }
+        preferred = preferred.max(min);
+        // Preferred must not be larger than max, since that would allow the segment
+        // to accidentally exceed max during the preferred phase.
+        preferred = preferred.min(max);
+        // Normally the initial size of a segment would be 0, but if the fill_scale is 0
+        // then this segment cannot grow, so make a special exception and set its initial
+        // size to its min size.
+        let size = if constraint.hint.fill_scale == 0 {
+            min
+        } else {
+            // If min is less than 0, then this segment is creating overlap,
+            // so start its size as a negative number. Otherwise, let the initial size be 0.
+            min.min(0)
+        };
+        Self {
+            initial_size: size,
+            min,
+            preferred,
+            max,
+            fill_scale: u64::from(constraint.hint.fill_scale),
+            priority: constraint.hint.priority,
+            overfill: constraint.hint.overfill,
+            size,
+        }
+    }
+    /// Construct a [`FillRecordSegment`] for this segment, to record it for debugging purposes.
+    fn record(&self) -> FillRecordSegment {
+        FillRecordSegment {
+            min: self.min,
+            preferred: self.preferred,
+            max: self.max,
+            fill_scale: i32::try_from(self.fill_scale).unwrap_or(i32::MAX),
+            priority: self.priority,
+            overfill: self.overfill,
+        }
+    }
+    /// Is this segment active for the given priority and target?
+    fn can_fill(&self, priority: i16, target: SegmentTarget) -> bool {
+        self.priority == priority
+            && self.fill_scale > 0
+            && (target.is_range_and(|t| self.dist(t) > 0)
+                || target.is_overfill() && self.overfill
+                || target.is_forced())
+    }
+    /// The distance from the current size to the given target.
+    #[inline]
+    fn dist(&self, target: RangeLevel) -> i32 {
+        self[target] - self.size
+    }
+    /// Update the size of this segment as much as possible within the limits of
+    /// `step_size`, the target, and the limit which represents the remaining area.
+    fn fill_steps_to(&mut self, step_size: u64, target: SegmentTarget, limit: i32) {
+        let max = self.size.saturating_add(limit);
+        // We are only allowed to allocate fill_scale units for each STEP_FACTOR of step_size,
+        // So `grow_fac` represents how much we can grow this step times STEP_FACTOR.
+        let grow_fac = self.fill_scale.saturating_mul(step_size);
+        // Divide by STEP_FACTOR and round up if appropriate to calculate the actual limit
+        // of how much we can grow this step.
+        let grow_mod = grow_fac % STEP_FACTOR;
+        let grow = (grow_fac / STEP_FACTOR)
+            .saturating_add(u64::from(grow_mod * 2 > STEP_FACTOR))
+            .max(1);
+        // Calculate the new size by adding `grow` and clamp it to `max`.
+        let mut size = self
+            .size
+            .saturating_add(i32::try_from(grow).unwrap_or(1))
+            .min(max);
+        // If we have a target we are aiming for, clamp our size to no greater than the target.
+        if let SegmentTarget::Range(target) = target {
+            size = size.min(self[target]);
+        }
+        self.size = size;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::layout::{
+        ConstraintList, Direction, Hint, HintRange, IntoConstraint, Rect, SizeRange,
+        VerticalAlignment, XConstraint, XLayout, XMargin,
+    };
+    #[test]
+    fn empty_layout() {
+        let segments = XLayout::default().split(Rect::new(0, 0, 12, 4));
+        assert!(segments.is_empty());
+    }
+    #[test]
+    fn layout_too_large() {
+        let [area] = XLayout::horizontal([HintRange::FULL.with_min(15).scale(0)])
+            .areas(Rect::new(0, 0, 12, 4));
+        assert_eq!(area, Rect::new(0, 0, 15, 4));
+        let [area] = XLayout::vertical([HintRange::FULL.with_min(15).scale(0)])
+            .areas(Rect::new(0, 0, 12, 4));
+        assert_eq!(area, Rect::new(0, 0, 12, 15));
+    }
+    #[test]
+    fn overlap_beyond_area() {
+        let [area] = XLayout::horizontal(XConstraint::overlap(5).scale(0).list() + HintRange::FULL)
+            .areas(Rect::new(10, 10, 12, 4));
+        assert_eq!(area, Rect::new(5, 10, 17, 4));
+        let [area] = XLayout::vertical(XConstraint::overlap(5).scale(0).list() + HintRange::FULL)
+            .areas(Rect::new(10, 10, 12, 4));
+        assert_eq!(area, Rect::new(10, 5, 12, 9));
+    }
+    #[test]
+    fn centered_text() {
+        use crate::text::Text;
+        let text = Text::from("1234\n123456");
+        let [area] = XLayout::from([text.size()]).areas(Rect::new(0, 0, 12, 4));
+        assert_eq!(area, Rect::new(3, 1, 6, 2));
+    }
+    #[test]
+    fn centered_size() {
+        let [area] = XLayout::from([(10, 6)]).areas(Rect::new(0, 0, 20, 10));
+        assert_eq!(area, Rect::new(5, 2, 10, 6));
+    }
+    #[test]
+    fn vertical_stack_top() {
+        let [a, b] =
+            (XLayout::from([(10, 6), (4, 4)]) + XConstraint::SPACER).areas(Rect::new(0, 0, 20, 20));
+        assert_eq!([a, b], [Rect::new(5, 0, 10, 6), Rect::new(8, 6, 4, 4)]);
+    }
+    #[test]
+    fn vertical_stack_bottom() {
+        let [a, b] =
+            (XConstraint::SPACER + XLayout::from([(10, 6), (4, 4)])).areas(Rect::new(0, 0, 20, 20));
+        assert_eq!([a, b], [Rect::new(5, 10, 10, 6), Rect::new(8, 16, 4, 4)]);
+    }
+    #[test]
+    fn horizontal_stack_left() {
+        let [a, b] =
+            XLayout::horizontal(ConstraintList::from([(10, 6), (4, 4)]) + XConstraint::SPACER)
+                .areas(Rect::new(0, 0, 20, 20));
+        assert_eq!([a, b], [Rect::new(0, 7, 10, 6), Rect::new(10, 8, 4, 4)]);
+    }
+    #[test]
+    fn horizontal_stack_right() {
+        let [a, b] = XLayout::horizontal(XConstraint::SPACER.list() + (10, 6) + (4, 4))
+            .areas(Rect::new(0, 0, 20, 20));
+        assert_eq!([a, b], [Rect::new(6, 7, 10, 6), Rect::new(16, 8, 4, 4)]);
+    }
+    #[test]
+    #[allow(clippy::many_single_char_names)]
+    fn horizontal_stack_separated() {
+        let layout = XLayout::horizontal((10, 6).list() + XConstraint::SPACER + (4, 4));
+        let area = Rect::new(0, 0, 20, 20);
+        let [a, b] = layout.areas(area);
+        let [x, y, z] = layout.spacers(area);
+        assert_eq!(
+            [x, a, y, b, z],
+            [
+                Rect::new(0, 0, 0, 20),
+                Rect::new(0, 7, 10, 6),
+                Rect::new(10, 0, 6, 20),
+                Rect::new(16, 8, 4, 4),
+                Rect::new(20, 0, 0, 20)
+            ]
+        );
+    }
+    #[test]
+    fn horizontal_top_bottom() {
+        let layout = XLayout::horizontal(
+            (10, 6).y_align(VerticalAlignment::Top).list()
+                + XConstraint::SPACER
+                + (4, 4).y_align(VerticalAlignment::Bottom),
+        );
+        let area = Rect::new(0, 0, 20, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 10, 6), Rect::new(16, 16, 4, 4),]);
+    }
+    #[test]
+    fn horizontal_bottom_top() {
+        let layout = XLayout::horizontal(
+            (10, 6).y_align(VerticalAlignment::Bottom).list()
+                + XConstraint::SPACER
+                + (4, 4).y_align(VerticalAlignment::Top),
+        );
+        let area = Rect::new(0, 0, 20, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 14, 10, 6), Rect::new(16, 0, 4, 4),]);
+    }
+    #[test]
+    fn horizontal_divided() {
+        let layout = XLayout::horizontal((.., ..).list() + (3, ..).separator() + (.., ..));
+        let area = Rect::new(0, 0, 21, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 9, 20), Rect::new(12, 0, 9, 20),]);
+    }
+    #[test]
+    fn vertical_divide_and_squeeze() {
+        let layout = XLayout::vertical((.., 8).list() + (.., 2).separator().priority(-1) + (.., 8));
+        let area = Rect::new(0, 0, 20, 10);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 20, 4), Rect::new(0, 6, 20, 4),]);
+    }
+    #[test]
+    fn uneven_squeeze() {
+        let layout = XLayout::vertical(
+            (.., 8).scale(1).list() + (.., 2).separator().scale(0) + (.., 8).scale(2),
+        );
+        let area = Rect::new(0, 0, 20, 8);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 20, 2), Rect::new(0, 4, 20, 4),]);
+    }
+    #[test]
+    fn stretch() {
+        use crate::layout::Align::Full;
+        let layout = XLayout::vertical(
+            (.., 8).y_align(Full).list() + (.., 2).separator().scale(0) + (.., 4).y_align(Full),
+        );
+        let area = Rect::new(0, 0, 20, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 20, 11), Rect::new(0, 13, 20, 7),],);
+    }
+    #[test]
+    fn percent_left_right() {
+        let layout = XLayout::horizontal(
+            Hint::Percentage(25).list() + XConstraint::SPACER + Hint::Percentage(25),
+        );
+        let area = Rect::new(0, 0, 10, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 3, 20), Rect::new(7, 0, 3, 20),],);
+    }
+    #[test]
+    fn ratio_left_right1() {
+        let layout =
+            XLayout::horizontal(Hint::Ratio(1, 4).list() + XConstraint::SPACER + Hint::Ratio(1, 4));
+        let area = Rect::new(0, 0, 10, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 3, 20), Rect::new(7, 0, 3, 20),],);
+    }
+    #[test]
+    fn ratio_left_right2() {
+        let layout =
+            XLayout::horizontal(Hint::Ratio(1, 3).list() + XConstraint::SPACER + Hint::Ratio(2, 4));
+        let area = Rect::new(0, 0, 10, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 3, 20), Rect::new(5, 0, 5, 20),],);
+    }
+    #[test]
+    fn wide_narrow() {
+        let layout = XLayout::horizontal((4..=6).list() + (1..=10));
+        let area = Rect::new(0, 0, 10, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(0, 0, 5, 20), Rect::new(5, 0, 5, 20),]);
+    }
+    #[test]
+    fn layout_margin() {
+        let layout = XLayout::horizontal((4..=6).list() + (1..=10)).margin(XMargin {
+            top: 1,
+            bottom: 2,
+            left: 3,
+            right: 4,
+        });
+        let area = Rect::new(0, 0, 10, 20);
+        let [a, b] = layout.areas(area);
+        assert_eq!([a, b], [Rect::new(3, 1, 2, 17), Rect::new(5, 1, 1, 17),],);
+    }
+    #[test]
+    #[allow(clippy::many_single_char_names)]
+    fn segment_margin_horizontal() {
+        let margin = XMargin {
+            top: 1,
+            bottom: 2,
+            left: 3,
+            right: 4,
+        };
+        let layout = XLayout::horizontal((4..=6).list() + (1..=10).margin(margin));
+        let area = Rect::new(0, 0, 10, 20);
+        let [a, b] = layout.areas(area);
+        let [x, y, z] = layout.spacers(area);
+        assert_eq!(
+            [x, a, y, b, z],
+            [
+                Rect::new(0, 0, 0, 20),
+                Rect::new(0, 0, 4, 20),
+                Rect::new(4, 0, 0, 20),
+                Rect::new(0, 0, 0, 0),
+                Rect::new(4, 0, 6, 20),
+            ]
+        );
+    }
+    #[test]
+    #[allow(clippy::many_single_char_names)]
+    fn segment_margin_vertical() {
+        let margin = XMargin {
+            top: 1,
+            bottom: 2,
+            left: 3,
+            right: 4,
+        };
+        let layout = XLayout::vertical((4..=6).list() + (1..=10).margin(margin));
+        let area = Rect::new(0, 0, 10, 20);
+        let [a, b] = layout.areas(area);
+        let [x, y, z] = layout.spacers(area);
+        assert_eq!(
+            [x, a, y, b, z],
+            [
+                Rect::new(0, 0, 10, 0),
+                Rect::new(0, 0, 10, 8),
+                Rect::new(0, 8, 10, 1),
+                Rect::new(3, 9, 3, 9),
+                Rect::new(0, 18, 10, 2),
+            ]
+        );
+    }
+    #[rstest]
+    #[case::size1(SizeRange::new(25,7), [(3,4),(21,7),(1,1)], Direction::Horizontal)]
+    #[case::size2(SizeRange::new(21,12), [(3,4),(21,7),(1,1)], Direction::Vertical)]
+    #[case::size3(SizeRange::new(10..=21,12), (3,4).list() + (10..=21,7) + (1,1), Direction::Vertical)]
+    #[case::size4(SizeRange::new(3..=21,(12,13)), (3,4..6).list() + (..=21,7) + (1,1), Direction::Vertical)]
+    #[case::size5(SizeRange::new((4,25),(7,7,5)), (3,4..6).list() + (..=21,7) + (1,1), Direction::Horizontal)]
+    fn size<I>(#[case] expected: SizeRange, #[case] constraints: I, #[case] direction: Direction)
+    where
+        I: IntoIterator,
+        I::Item: Into<XConstraint>,
+    {
+        let layout = XLayout::new(direction, constraints);
+        assert_eq!(layout.size(), expected);
+    }
+}

--- a/ratatui-core/src/layout/xlayout/constraint.rs
+++ b/ratatui-core/src/layout/xlayout/constraint.rs
@@ -1,0 +1,1206 @@
+//! The [`XConstraint`] type is the fundamental building block of [`XLayout`], and it is supported
+//! by [`ConstraintList`], [`Align`], [`SizeRange`], and [`XMargin`].
+
+use alloc::vec::Vec;
+use core::fmt::{Debug, Formatter, Write};
+use core::ops::{
+    Add, AddAssign, Deref, DerefMut, Index, IndexMut, Range, RangeBounds, RangeFrom, RangeFull,
+    RangeInclusive, RangeTo, RangeToInclusive, Sub, SubAssign,
+};
+
+use strum::{Display, EnumIs, EnumString};
+
+use crate::layout::{
+    Constraint, Direction, Hint, HintRange, HorizontalAlignment, Margin, RangeLevel, Rect, Size,
+    VerticalAlignment, XLayout,
+};
+
+/// Trait for types that can be converted into [`XConstraint`]. These methods all take
+/// self and automatically convert it into a constraint before performing their operation
+/// and returning the resulting value, usually a constraint with some modifications.
+/// This allows non-constraint values to be treated as if they are constraint values when
+/// constructing an [`XLayout`].
+pub trait IntoConstraint: Into<XConstraint> {
+    /// Create an [`XConstraint`] from this value.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn constraint(self) -> XConstraint {
+        <Self as Into<XConstraint>>::into(self)
+    }
+    /// Create a [`ConstraintList`] from this value.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn list(self) -> ConstraintList {
+        ConstraintList::single(self)
+    }
+    /// Create a separator constraint by setting the [`XConstraint::is_separator`] flag to true,
+    /// thereby preventing the constraint from creating a segment when it is used in an
+    /// [`XLayout`] to split an area. Separator constraints only serve to help position
+    /// other segments.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn separator(self) -> XConstraint {
+        self.constraint().separator()
+    }
+    /// Create a constraint with the given alignment on the x axis.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn x_align<A: Into<Align>>(self, align: A) -> XConstraint {
+        self.constraint().x_align(align)
+    }
+    /// Create a constraint with the given alignment on the y axis.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn y_align<A: Into<Align>>(self, align: A) -> XConstraint {
+        self.constraint().y_align(align)
+    }
+    /// Create a constraint with the given margin.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn margin<M: Into<XMargin>>(self, margin: M) -> XConstraint {
+        self.constraint().margin(margin)
+    }
+    /// Create a constraint with for a segment with sizes in the given range.
+    /// When a [`Rect`] is split into segments, the segments do not necessarily fill the
+    /// portion of `Rect` that was allocated to them. Setting the area range of a constraint
+    /// controls how large the segment should be within the allocated area. See [`SizeRange`]
+    /// for details.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn size<A: Into<SizeRange>>(self, size: A) -> XConstraint {
+        self.constraint().size(size)
+    }
+    /// Create a constraint with the given minimum value for the [`SizeRange`].
+    /// Use [`IntoConstraint::size`] to set all three levels of the range at once.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn size_min(self, size: Size) -> XConstraint {
+        self.constraint().size_min(size)
+    }
+    /// Create a constraint with the given preferred value for the [`SizeRange`].
+    /// Use [`IntoConstraint::size`] to set all three levels of the range at once.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn size_preferred(self, size: Size) -> XConstraint {
+        self.constraint().size_preferred(size)
+    }
+    /// Create a constraint with the given maximum value for the [`SizeRange`].
+    /// Use [`IntoConstraint::size`] to set all three levels of the range at once.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn size_max(self, size: Size) -> XConstraint {
+        self.constraint().size_max(size)
+    }
+    /// Create a constraint with the given hint to control its layout.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn hint(self, hint: HintRange) -> XConstraint {
+        self.constraint().hint(hint)
+    }
+    /// Create a constraint with the given value for [`HintRange::min`].
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn with_min<H: Into<Hint>>(self, hint: H) -> XConstraint {
+        self.constraint().with_min(hint)
+    }
+    /// Create a constraint with the given value for [`HintRange::preferred`].
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn preferred<H: Into<Hint>>(self, hint: H) -> XConstraint {
+        self.constraint().preferred(hint)
+    }
+    /// Create a constraint with the given value for [`HintRange::max`].
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn with_max<H: Into<Hint>>(self, hint: H) -> XConstraint {
+        self.constraint().with_max(hint)
+    }
+    /// Create a constraint with no maximum hint by setting its max hint to [`Hint::FULL`].
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn without_max(self) -> XConstraint {
+        self.constraint().with_max(Hint::FULL)
+    }
+    /// Create a constraint with the given [`HintRange::fill_scale`].
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn scale(self, fill_scale: u16) -> XConstraint {
+        self.constraint().scale(fill_scale)
+    }
+    /// Create a constraint with the given [`HintRange::priority`] to control in what
+    /// order the constraint gets to allocate space relative to the other constraints.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn priority(self, priority: i16) -> XConstraint {
+        self.constraint().priority(priority)
+    }
+    /// Create a constraint with the given [`HintRange::overfill`] to control whether
+    /// this constraint allocates space beyond its maximum.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    fn overfill(self, overfill: bool) -> XConstraint {
+        self.constraint().overfill(overfill)
+    }
+}
+
+impl<V: Into<XConstraint>> IntoConstraint for V {}
+
+/// The layout process for [`XLayout`] is controlled by a list of constraints,
+/// much like [`Layout`](super::Layout), but these are extended constraints that
+/// contain far more settings to fine-tune the layout. Instead of needing to choose
+/// whether a constraint has a maximum or a minimum, every `XConstraint` is allowed to have
+/// both, as well as a preferred size, a margin, and an alignment.
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct XConstraint {
+    /// The margin between the segment and the segment's allocated area.
+    /// This is a fixed amount of space that will be subtracted from the sides
+    /// of the allocated area before the size and position of the segment are calculated.
+    pub margin: XMargin,
+    /// The horizontal alignment of the segment within the space allocated for the segment.
+    /// If more space is allocated by the layout than is needed for the segment, then the segment
+    /// can be at the left, at the right, horizontally centered, or stretched to fill the
+    /// allocated space.
+    pub x_align: Align,
+    /// The vertical alignment of the segment within the space allocated for the segment.
+    /// If more space is allocated by the layout than is needed for the segment, then the segment
+    /// can be at the top, at the bottom, vertically centered, or stretched to fill the
+    /// allocated space.
+    pub y_align: Align,
+    /// The size range needed for the resulting segment, including minimum size, preferred size,
+    /// and maximum size in both the horizontal and the vertical. The layout direction
+    /// determines which axis of the size range will be used. Ideally this should be supplied
+    /// by the widget that will be rendered in the segment, and calculated based upon the
+    /// widget's content.
+    pub size: SizeRange,
+    /// A hint to control the layout process, such in which order segments should have space
+    /// allocated, how much space a segment needs at minimum, and so on. See [`HintRange`] for
+    /// details.
+    pub hint: HintRange,
+    /// A separator constraint does not cause [`XLayout`] to produce a segment when splitting an
+    /// area. Separator constraints only serve to help position other segments by taking up
+    /// space.
+    pub is_separator: bool,
+}
+
+impl Debug for XConstraint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.write_str("XConstraint(")?;
+        if self.is_separator {
+            f.write_str("separator, ")?;
+        }
+        write!(
+            f,
+            "({:?}, {:?}), {:?}, {:?})",
+            self.x_align, self.y_align, self.size, self.hint
+        )
+    }
+}
+
+impl From<&Constraint> for XConstraint {
+    fn from(value: &Constraint) -> Self {
+        HintRange::from(*value).into_constraint()
+    }
+}
+
+impl From<&u16> for XConstraint {
+    fn from(value: &u16) -> Self {
+        HintRange::from(*value).into_constraint()
+    }
+}
+
+impl From<&Hint> for XConstraint {
+    fn from(value: &Hint) -> Self {
+        HintRange::from(*value).into_constraint()
+    }
+}
+
+impl<R: Into<HintRange>> From<R> for XConstraint {
+    fn from(value: R) -> Self {
+        value.into().into_constraint()
+    }
+}
+
+impl From<&HintRange> for XConstraint {
+    fn from(value: &HintRange) -> Self {
+        value.constraint()
+    }
+}
+
+impl From<SizeRange> for XConstraint {
+    fn from(value: SizeRange) -> Self {
+        value.into_constraint()
+    }
+}
+
+impl<R: Into<LinearSizeRange>, S: Into<LinearSizeRange>> From<(R, S)> for XConstraint {
+    fn from((width, height): (R, S)) -> Self {
+        SizeRange::new(width, height).into()
+    }
+}
+
+impl From<Size> for XConstraint {
+    fn from(value: Size) -> Self {
+        SizeRange::new(value.width, value.height).into()
+    }
+}
+
+impl From<&Size> for XConstraint {
+    fn from(value: &Size) -> Self {
+        SizeRange::new(value.width, value.height).into()
+    }
+}
+
+impl From<&SizeRange> for XConstraint {
+    fn from(value: &SizeRange) -> Self {
+        value.constraint()
+    }
+}
+
+/// A margin along a single axis, either horizontal or vertical.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LinearMargin {
+    /// The top or left margin.
+    pub start: u16,
+    /// The bottom or right margin.
+    pub end: u16,
+}
+
+impl From<u16> for LinearMargin {
+    fn from(value: u16) -> Self {
+        Self {
+            start: value,
+            end: value,
+        }
+    }
+}
+
+impl From<(u16, u16)> for LinearMargin {
+    fn from((start, end): (u16, u16)) -> Self {
+        Self { start, end }
+    }
+}
+
+impl LinearMargin {
+    /// Create a new linear margin from start and end values.
+    pub const fn new(start: u16, end: u16) -> Self {
+        Self { start, end }
+    }
+    /// The sum of the two sides of the margin.
+    pub const fn total(self) -> u16 {
+        self.start.saturating_add(self.end)
+    }
+    /// Create a full [`XMargin`] by specifying an axis for this margin.
+    /// The other axis will have a margin of 0.
+    pub const fn into_margin(self, direction: Direction) -> XMargin {
+        match direction {
+            Direction::Horizontal => XMargin {
+                left: self.start,
+                right: self.end,
+                top: 0,
+                bottom: 0,
+            },
+            Direction::Vertical => XMargin {
+                top: self.start,
+                bottom: self.end,
+                left: 0,
+                right: 0,
+            },
+        }
+    }
+}
+
+impl XConstraint {
+    /// The default constraint. It has no margin, it is aligned to [`Align::Full`] both
+    /// horizontally and vertically, its `size` is [`SizeRange::FULL`], and
+    /// its hint range is [`HintRange::FULL`]. It creates a segment with no minimum or maximum
+    /// size and it prefers to fill whatever space is available.
+    pub const FULL: Self = Self {
+        margin: XMargin::ZERO,
+        x_align: Align::Full,
+        y_align: Align::Full,
+        size: SizeRange::FULL,
+        hint: HintRange::FULL,
+        is_separator: false,
+    };
+
+    /// A separator constraint with a preferred size of zero which can grow to [`Hint::FULL`]
+    /// at maximum to allow segments to not need to stretch.
+    pub const SPACER: Self = Self {
+        hint: HintRange {
+            preferred: Hint::ZERO,
+            priority: 1,
+            ..HintRange::FULL
+        },
+        is_separator: true,
+        ..Self::FULL
+    };
+
+    /// A separator constraint that has negative size for its min and preferred,
+    /// creating the given amount of overlap. Its max is set to [`Hint::ZERO`] so that
+    /// the overlap is removed if the layout is struggling to fill the available space,
+    /// and `priority` is set to 100 to encourage the overlap to be removed before any
+    /// segments get stretched.
+    pub const fn overlap(amount: u16) -> Self {
+        Self {
+            hint: HintRange {
+                min: Hint::Overlap(amount),
+                preferred: Hint::Overlap(amount),
+                max: Hint::ZERO,
+                priority: 100,
+                ..HintRange::FULL
+            },
+            is_separator: true,
+            ..Self::FULL
+        }
+    }
+
+    /// The alignment of this constraint along the given axis.
+    pub const fn get_align_for(&self, direction: Direction) -> Align {
+        match direction {
+            Direction::Horizontal => self.x_align,
+            Direction::Vertical => self.y_align,
+        }
+    }
+    /// Convert the constraint into a separator by setting its separator flag to true,
+    /// thereby preventing it from creating a segment when it is used in an
+    /// [`XLayout`] to split an area. Separator constraints only serve to help position
+    /// other segments.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn separator(self) -> Self {
+        Self {
+            is_separator: true,
+            ..self
+        }
+    }
+    /// Set the horizontal alignment of the constraint.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn x_align<A: Into<Align>>(self, x_align: A) -> Self {
+        Self {
+            x_align: x_align.into(),
+            ..self
+        }
+    }
+    /// Set the vertical alignment of the constraint.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn y_align<A: Into<Align>>(self, y_align: A) -> Self {
+        Self {
+            y_align: y_align.into(),
+            ..self
+        }
+    }
+    /// Set the margin of the constraint.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn margin<M: Into<XMargin>>(self, margin: M) -> Self {
+        Self {
+            margin: margin.into(),
+            ..self
+        }
+    }
+    /// Set the hint range of the constraint to modify the layout process.
+    /// See [`HintRange`] for details.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn hint(self, hint: HintRange) -> Self {
+        Self { hint, ..self }
+    }
+    /// Set the minimum hint for the constraint to ensure that the resulting segment
+    /// is at least this big, if possible.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn with_min<H: Into<Hint>>(self, hint: H) -> Self {
+        Self {
+            hint: self.hint.with_min(hint),
+            ..self
+        }
+    }
+    /// Set the preferred hint for the constraint to tell layout to aim for this size,
+    /// if possible.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn preferred<H: Into<Hint>>(self, hint: H) -> Self {
+        Self {
+            hint: self.hint.preferred(hint),
+            ..self
+        }
+    }
+    /// Set the maximum hint for the constraint to prevent the segment from growing
+    /// large than this, unless required to fill the area.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn with_max<H: Into<Hint>>(self, hint: H) -> Self {
+        Self {
+            hint: self.hint.with_max(hint),
+            ..self
+        }
+    }
+    /// Set the [`HintRange::fill_scale`] for this constraint.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn scale(self, scale: u16) -> Self {
+        Self {
+            hint: self.hint.scale(scale),
+            ..self
+        }
+    }
+    /// Set the [`HintRange::priority`] for this constraint.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn priority(self, priority: i16) -> Self {
+        Self {
+            hint: self.hint.priority(priority),
+            ..self
+        }
+    }
+    /// Set the [`SizeRange`] for this constraint.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn size<A: Into<SizeRange>>(self, range: A) -> Self {
+        Self {
+            size: range.into(),
+            ..self
+        }
+    }
+    /// Set the min value for the [`SizeRange`] of this constraint.
+    /// Use [`XConstraint::size`] to set all three range levels at once.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn size_min(self, size: Size) -> Self {
+        Self {
+            size: self.size.size_min(size),
+            ..self
+        }
+    }
+    /// Set the preferred value for the [`SizeRange`] of this constraint.
+    /// Use [`XConstraint::size`] to set all three range levels at once.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn size_preferred(self, size: Size) -> Self {
+        Self {
+            size: self.size.size_preferred(size),
+            ..self
+        }
+    }
+    /// Set the max value for the [`SizeRange`] of this constraint.
+    /// Use [`XConstraint::size`] to set all three range levels at once.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn size_max(self, size: Size) -> Self {
+        Self {
+            size: self.size.size_max(size),
+            ..self
+        }
+    }
+    /// Given an allocated area for this constraint, find the segment [`Rect`] within the allocated
+    /// `Rect`, based on margin, the [`Align`], and preferred size of this constraint.
+    /// This is used for the final step in the layout process.
+    pub fn inner_rect(&self, area: Rect) -> Rect {
+        let area = area - self.margin;
+        let x_align = self
+            .x_align
+            .align(self.size.horizontal.preferred, area.width);
+        let y_align = self
+            .y_align
+            .align(self.size.vertical.preferred, area.height);
+        Rect {
+            x: area.x.saturating_add(x_align.position),
+            y: area.y.saturating_add(y_align.position),
+            width: x_align.size,
+            height: y_align.size,
+        }
+    }
+}
+
+/// A margin specifies the empty space that should surround a layout segment.
+/// An extended margin includes separate values for each side of the [`Rect`],
+/// allowing the top margin to be different from the bottom margin, and the left
+/// to be different from the right.
+#[derive(Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct XMargin {
+    /// The amount of empty space above the segment.
+    pub top: u16,
+    /// The amount of empty space below the segment.
+    pub bottom: u16,
+    /// The amount of empty space left of the segment.
+    pub left: u16,
+    /// The amount of empty space right of the segment.
+    pub right: u16,
+}
+
+impl Debug for XMargin {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        if self.top == self.bottom && self.left == self.right {
+            if self.top == self.left {
+                write!(f, "XMargin::uniform({})", self.top)
+            } else {
+                write!(f, "XMargin::new({}, {})", self.left, self.top)
+            }
+        } else {
+            write!(
+                f,
+                "XMargin{{top:{}, bottom:{}, left:{}, right:{}}}",
+                self.top, self.bottom, self.left, self.right
+            )
+        }
+    }
+}
+
+impl From<u16> for XMargin {
+    fn from(value: u16) -> Self {
+        Self {
+            top: value,
+            bottom: value,
+            left: value,
+            right: value,
+        }
+    }
+}
+
+impl From<Margin> for XMargin {
+    fn from(value: Margin) -> Self {
+        Self::new(value.horizontal, value.vertical)
+    }
+}
+
+impl Sub<XMargin> for Rect {
+    type Output = Self;
+
+    fn sub(self, rhs: XMargin) -> Self::Output {
+        rhs.inner_rect(self)
+    }
+}
+
+impl SubAssign<XMargin> for Rect {
+    fn sub_assign(&mut self, rhs: XMargin) {
+        *self = rhs.inner_rect(*self);
+    }
+}
+
+impl Sub<Margin> for Rect {
+    type Output = Self;
+
+    fn sub(self, rhs: Margin) -> Self::Output {
+        self.inner(rhs)
+    }
+}
+
+impl SubAssign<Margin> for Rect {
+    fn sub_assign(&mut self, rhs: Margin) {
+        *self = self.inner(rhs);
+    }
+}
+
+impl XMargin {
+    /// A margin of zero size, specifying no empty space.
+    pub const ZERO: Self = Self::uniform(0);
+    /// Create a margin with the space horizontally and vertically,
+    /// with equal space left and right, and equal space top and bottom.
+    pub const fn new(horizontal: u16, vertical: u16) -> Self {
+        Self {
+            top: vertical,
+            bottom: vertical,
+            left: horizontal,
+            right: horizontal,
+        }
+    }
+    /// Create a margin with equal space on all sides.
+    pub const fn uniform(thickness: u16) -> Self {
+        Self {
+            top: thickness,
+            bottom: thickness,
+            left: thickness,
+            right: thickness,
+        }
+    }
+    /// Returns a new `Rect` inside the current one, with the given margin on each side.
+    ///
+    /// If the margin is larger than the given `Rect`, the [`Rect::ZERO`] will be returned.
+    #[must_use = "method returns the modified value"]
+    pub const fn inner_rect(self, rect: Rect) -> Rect {
+        let doubled_margin_horizontal = self.left.saturating_add(self.right);
+        let doubled_margin_vertical = self.top.saturating_add(self.bottom);
+
+        if rect.width < doubled_margin_horizontal || rect.height < doubled_margin_vertical {
+            Rect::ZERO
+        } else {
+            Rect {
+                x: rect.x.saturating_add(self.left),
+                y: rect.y.saturating_add(self.top),
+                width: rect.width.saturating_sub(doubled_margin_horizontal),
+                height: rect.height.saturating_sub(doubled_margin_vertical),
+            }
+        }
+    }
+    /// Set the empty space in this margin along the given axis.
+    pub fn set_linear<M: Into<LinearMargin>>(&mut self, direction: Direction, value: M) {
+        let margin = value.into();
+        match direction {
+            Direction::Horizontal => {
+                self.left = margin.start;
+                self.right = margin.end;
+            }
+            Direction::Vertical => {
+                self.top = margin.start;
+                self.bottom = margin.end;
+            }
+        }
+    }
+    /// The empty space in this margin along the given axis.
+    pub const fn linear(self, direction: Direction) -> LinearMargin {
+        match direction {
+            Direction::Horizontal => LinearMargin {
+                start: self.left,
+                end: self.right,
+            },
+            Direction::Vertical => LinearMargin {
+                start: self.top,
+                end: self.bottom,
+            },
+        }
+    }
+}
+
+/// A position and size of a segment within an allocated area along one axis.
+struct AlignmentPos {
+    /// The distance from the left side or the top of the allocated area, depending on axis.
+    pub position: u16,
+    /// The width or height of the segment, depending on axis.
+    pub size: u16,
+}
+
+impl AlignmentPos {
+    /// Construct an alignment position from the given position and size.
+    const fn new(position: u16, size: u16) -> Self {
+        Self { position, size }
+    }
+}
+
+/// The alignment of an `XConstraint`, much like [`HorizontalAlignment`] and [`VerticalAlignment`],
+/// but it also includes a [`Align::Full`] variant for stretching the segment to fill its allocated
+/// space. `Full` is the default value.
+#[derive(Debug, Display, Default, Clone, Copy, Eq, PartialEq, Hash, EnumIs, EnumString)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Align {
+    /// Causes the segment to fill the entire allocated area, and reduce the hint
+    /// for the max size of the allocated area to be no more than the max size of the segment.
+    /// If the allocated area still exceeds the max size of the segment despite the hint, then
+    /// the segment will still fill the entire allocated area.
+    #[default]
+    Full,
+    /// Causes the segment to be at the left side or the top of the allocated area, depending on
+    /// whether the alignment is horizontal or vertical.
+    Start,
+    /// Causes the segment to be centered in the allocated area.
+    Center,
+    /// Causes the segment to be at the right side or the bottom of the allocated area, depending on
+    /// whether the alignment is horizontal or vertical.
+    End,
+}
+
+impl From<HorizontalAlignment> for Align {
+    fn from(value: HorizontalAlignment) -> Self {
+        match value {
+            HorizontalAlignment::Left => Self::Start,
+            HorizontalAlignment::Center => Self::Center,
+            HorizontalAlignment::Right => Self::End,
+        }
+    }
+}
+
+impl From<VerticalAlignment> for Align {
+    fn from(value: VerticalAlignment) -> Self {
+        match value {
+            VerticalAlignment::Top => Self::Start,
+            VerticalAlignment::Center => Self::Center,
+            VerticalAlignment::Bottom => Self::End,
+        }
+    }
+}
+
+impl Align {
+    /// Determines the position of a segment with a given preferred size within an allocated area
+    /// with the given available space along one axis according to this alignment.
+    fn align(self, preferred_size: u16, available_space: u16) -> AlignmentPos {
+        let size = preferred_size.min(available_space);
+        match self {
+            Self::Full => AlignmentPos::new(0, available_space),
+            Self::Start => AlignmentPos::new(0, size),
+            Self::End => AlignmentPos::new(available_space.saturating_sub(size), size),
+            Self::Center => {
+                let x = available_space.saturating_sub(size) / 2;
+                AlignmentPos::new(x, size)
+            }
+        }
+    }
+}
+
+/// Specifies a range of sizes for a segment to control the behavior of an [`XConstraint`].
+/// along one axis. See [`SizeRange`] for details of how it is used in a constraint.
+/// The three values in this range can be indexed by [`RangeLevel`].
+///
+/// A `LinearSizeRange` can be converted from various types:
+/// * `u16`: `n` becomes `LinearSizeRange {min: n, preferred: n, max: u16::MAX}`
+/// * `(u16,u16)`: `(a, b)` becomes `LinearSizeRange {min: a, preferred: b, max: u16::MAX}`
+/// * `(u16,u16,u16)`: `(a,b,c)` becomes `LinearSizeRange {min: a, preferred: b, max: c}`
+/// * `a..=b` becomes `LinearSizeRange {min: a, preferred: b, max: b}`
+///
+/// In general if the max value is not specified then it is assumed to be `u16::MAX`,
+/// because usually things do not have a maximum size.
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LinearSizeRange {
+    /// The segment should be at least this large, if possible.
+    /// The `min` hint for the constraint will be increased at least this large.
+    pub min: u16,
+    /// Specifies the size of the segment if the allocated area is large
+    /// enough to allow it and the alignment is not set to [`Align::Full`] along this axis.
+    /// Regardless of how much larger an area is allocated to the segment, the segment will be this
+    /// size.
+    pub preferred: u16,
+    /// Specifies how large the segment should be at most. This has no effect
+    /// unless the constraint's alignment is set to [`Align::Full`], which forces the segment
+    /// to fill the entire allocated area, and reduces the `max` hint for the segment to be
+    /// no more than this large.
+    pub max: u16,
+}
+
+impl Debug for LinearSizeRange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        Debug::fmt(&self.min, f)?;
+        f.write_char('/')?;
+        if self.preferred == u16::MAX {
+            f.write_str("max")?;
+        } else {
+            Debug::fmt(&self.preferred, f)?;
+        }
+        if self.max < u16::MAX {
+            f.write_char('/')?;
+            Debug::fmt(&self.max, f)?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for LinearSizeRange {
+    fn default() -> Self {
+        Self::FULL
+    }
+}
+
+impl From<u16> for LinearSizeRange {
+    fn from(value: u16) -> Self {
+        Self::new(value, value, u16::MAX)
+    }
+}
+impl From<(u16, u16)> for LinearSizeRange {
+    fn from((min, pref): (u16, u16)) -> Self {
+        Self::new(min, pref, u16::MAX)
+    }
+}
+impl From<(u16, u16, u16)> for LinearSizeRange {
+    fn from((min, pref, max): (u16, u16, u16)) -> Self {
+        Self::new(min, pref, max)
+    }
+}
+impl From<i32> for LinearSizeRange {
+    fn from(value: i32) -> Self {
+        let value = u16::try_from(value).unwrap_or(0);
+        Self::new(value, value, u16::MAX)
+    }
+}
+impl From<(i32, i32)> for LinearSizeRange {
+    fn from((min, pref): (i32, i32)) -> Self {
+        let min = u16::try_from(min).unwrap_or(0);
+        let pref = u16::try_from(pref).unwrap_or(0);
+        Self::new(min, pref, u16::MAX)
+    }
+}
+impl From<(i32, i32, i32)> for LinearSizeRange {
+    fn from((min, pref, max): (i32, i32, i32)) -> Self {
+        let min = u16::try_from(min).unwrap_or(0);
+        let pref = u16::try_from(pref).unwrap_or(0);
+        let max = u16::try_from(max).unwrap_or(0);
+        Self::new(min, pref, max)
+    }
+}
+
+/// Generate `From` implementations for [`LinearSizeRange`] from types
+/// that implement `RangeBounds<u16>`.
+macro_rules! range_from_bounds {
+    ($($t:ty),*) => {
+        $(impl From<$t> for LinearSizeRange {
+            fn from(value: $t) -> Self {
+                Self::from_bounds(value)
+            }
+        })*
+    }
+}
+
+range_from_bounds!(
+    Range<u16>,
+    RangeFrom<u16>,
+    RangeTo<u16>,
+    RangeInclusive<u16>,
+    RangeToInclusive<u16>,
+    RangeFull
+);
+
+impl Index<RangeLevel> for LinearSizeRange {
+    type Output = u16;
+
+    fn index(&self, index: RangeLevel) -> &Self::Output {
+        match index {
+            RangeLevel::Min => &self.min,
+            RangeLevel::Preferred => &self.preferred,
+            RangeLevel::Max => &self.max,
+        }
+    }
+}
+
+impl IndexMut<RangeLevel> for LinearSizeRange {
+    fn index_mut(&mut self, index: RangeLevel) -> &mut Self::Output {
+        match index {
+            RangeLevel::Min => &mut self.min,
+            RangeLevel::Preferred => &mut self.preferred,
+            RangeLevel::Max => &mut self.max,
+        }
+    }
+}
+
+impl LinearSizeRange {
+    /// A default size range for segments where all sizes are acceptable.
+    /// It has a `min` of 0, a `preferred` of `MAX` and a `max` of `MAX` so that
+    /// the size range will not affect how much area is allocated to the segment
+    /// and the segment will fill whatever area is allocated to it.
+    pub const FULL: Self = Self {
+        min: 0,
+        preferred: u16::MAX,
+        max: u16::MAX,
+    };
+    /// Create a size range with the given min, preferred size, and max size.
+    pub const fn new(min: u16, preferred: u16, max: u16) -> Self {
+        Self {
+            min,
+            preferred,
+            max,
+        }
+    }
+    /// Creates a range from the given bounds, with the preferred size defaulting
+    /// to the maximum size.
+    pub fn from_bounds<B: RangeBounds<u16>>(bounds: B) -> Self {
+        let min = match bounds.start_bound() {
+            core::ops::Bound::Included(x) => *x,
+            core::ops::Bound::Excluded(x) => x.saturating_add(1),
+            core::ops::Bound::Unbounded => 0,
+        };
+        let max = match bounds.end_bound() {
+            core::ops::Bound::Included(x) => *x,
+            core::ops::Bound::Excluded(x) => x.saturating_sub(1),
+            core::ops::Bound::Unbounded => u16::MAX,
+        };
+        Self::new(min, max, max)
+    }
+    /// Modify the minimum value of the range.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn with_min(self, min: u16) -> Self {
+        Self { min, ..self }
+    }
+    /// Modify the preferred value of the range.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn preferred(self, preferred: u16) -> Self {
+        Self { preferred, ..self }
+    }
+    /// Modify the maximum value of the range.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn with_max(self, max: u16) -> Self {
+        Self { max, ..self }
+    }
+}
+
+/// An `SizeRange` represents a range of sizes for a layout segment,
+/// with `min`, `preferred`, and `max` sizes on both the horizontal and vertical
+/// axis.
+/// * `min`: says that the segment should be at least this large, if possible. If `min` is greater
+///   than zero, the min hint for the constraint will be increased at least this large.
+/// * `preferred`: specifies the size of the segment if the allocated area is large enough to allow
+///   it and the alignment is not set to [`Align::Full`]. Regardless of how much larger an area is
+///   allocated to the segment, the segment will be this size.
+/// * `max`: specifies how large the segment should be at most. This has no effect unless the
+///   constraint's alignment is set to [`Align::Full`], which forces the segment to fill the entire
+///   allocated area, and reduces the `max` hint for the segment to be no more than this large.
+#[derive(Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SizeRange {
+    /// The range of sizes along the horizontal axis.
+    pub horizontal: LinearSizeRange,
+    /// The range of sizes along the vertical axis.
+    pub vertical: LinearSizeRange,
+}
+
+impl Debug for SizeRange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "({:?}, {:?})", self.horizontal, self.vertical)
+    }
+}
+
+impl<R: Into<LinearSizeRange>, S: Into<LinearSizeRange>> From<(R, S)> for SizeRange {
+    fn from((width, height): (R, S)) -> Self {
+        Self::new(width, height)
+    }
+}
+
+impl From<Size> for SizeRange {
+    fn from(value: Size) -> Self {
+        Self::new(value.width, value.height)
+    }
+}
+
+impl From<&Size> for SizeRange {
+    fn from(value: &Size) -> Self {
+        Self::new(value.width, value.height)
+    }
+}
+
+impl SizeRange {
+    /// Size range that covers sizes from 0 x 0 to `u16::MAX` x `u16::MAX`.
+    /// The preferred size is set to `u16::MAX` x `u16::MAX`.
+    pub const FULL: Self = Self {
+        horizontal: LinearSizeRange::FULL,
+        vertical: LinearSizeRange::FULL,
+    };
+    /// Create a size range from the given horizontal and vertical ranges.
+    ///
+    /// # Example Usage
+    /// ```
+    /// use ratatui_core::layout::{SizeRange, XLayout};
+    /// // A layout that centers a 10x6 rect within its given area.
+    /// let layout = XLayout::from([SizeRange::new(10, 6)]);
+    /// // It can also be written as:
+    /// let layout = XLayout::from([(10, 6)]);
+    /// ```
+    pub fn new<R: Into<LinearSizeRange>, S: Into<LinearSizeRange>>(
+        horizontal: R,
+        vertical: S,
+    ) -> Self {
+        Self {
+            horizontal: horizontal.into(),
+            vertical: vertical.into(),
+        }
+    }
+    /// The size at the given range level.
+    pub fn get(&self, level: RangeLevel) -> Size {
+        Size::new(self.horizontal[level], self.vertical[level])
+    }
+    /// Modify the range to have the given horizontal dimension.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn horizontal<R: Into<LinearSizeRange>>(self, range: R) -> Self {
+        Self {
+            horizontal: range.into(),
+            ..self
+        }
+    }
+    /// Modify the range to have the given vertical dimension.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn vertical<R: Into<LinearSizeRange>>(self, range: R) -> Self {
+        Self {
+            vertical: range.into(),
+            ..self
+        }
+    }
+    /// Modify the range to have the given minimum size. Use [`Size::ZERO`] if there
+    /// should be no minimum size.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn size_min(self, size: Size) -> Self {
+        Self {
+            horizontal: self.horizontal.with_min(size.width),
+            vertical: self.vertical.with_min(size.height),
+        }
+    }
+    /// Modify the range to have the given preferred size.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn size_preferred(self, size: Size) -> Self {
+        Self {
+            horizontal: self.horizontal.preferred(size.width),
+            vertical: self.vertical.preferred(size.height),
+        }
+    }
+    /// Modify the range to have the given maximum size. Use [`Size::MAX`]
+    /// if there should be no maximum size.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn size_max(self, size: Size) -> Self {
+        Self {
+            horizontal: self.horizontal.with_max(size.width),
+            vertical: self.vertical.with_max(size.height),
+        }
+    }
+    /// The size range along the given axis.
+    pub const fn linear(&self, direction: Direction) -> LinearSizeRange {
+        match direction {
+            Direction::Horizontal => self.horizontal,
+            Direction::Vertical => self.vertical,
+        }
+    }
+    /// Create a constraint based on this size, with horizontal and vertical
+    /// alignment set to [`Align::Center`], no margin, and [`HintRange::SIZE`].
+    pub const fn into_constraint(self) -> XConstraint {
+        XConstraint {
+            margin: XMargin::ZERO,
+            x_align: Align::Center,
+            y_align: Align::Center,
+            size: self,
+            hint: HintRange::SIZE,
+            is_separator: false,
+        }
+    }
+}
+
+/// A list of constraints that can be used to help build an [`XLayout`].
+/// The `ConstraintList` can be extended using the + operator which allows
+/// values of multiple types to be combined into a single list and automatically
+/// converted into [`XConstraint`].
+#[derive(Default)]
+pub struct ConstraintList(Vec<XConstraint>);
+
+impl From<ConstraintList> for Vec<XConstraint> {
+    fn from(value: ConstraintList) -> Self {
+        value.0
+    }
+}
+
+impl IntoIterator for ConstraintList {
+    type Item = XConstraint;
+    type IntoIter = alloc::vec::IntoIter<XConstraint>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Deref for ConstraintList {
+    type Target = [XConstraint];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ConstraintList {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Generate `Add` implementations for types that can be added to the
+/// beginning of a [`ConstraintList`] and implement `Into<XConstraint>`.
+macro_rules! add_constraint_list_impl {
+    ($($t:ty),*) => {
+        $(impl Add<ConstraintList> for $t {
+            type Output = ConstraintList;
+            fn add(self, mut rhs: ConstraintList) -> ConstraintList {
+                rhs.insert(0, self);
+                rhs
+            }
+        })*
+    }
+}
+
+add_constraint_list_impl!(u16, Hint, HintRange, SizeRange, Size, Constraint);
+
+impl<C: Into<XConstraint>> Add<C> for ConstraintList {
+    type Output = Self;
+    fn add(mut self, rhs: C) -> Self {
+        self.push(rhs);
+        self
+    }
+}
+impl<C: Into<XConstraint>> AddAssign<C> for ConstraintList {
+    fn add_assign(&mut self, rhs: C) {
+        self.push(rhs);
+    }
+}
+
+impl<C: Into<XConstraint>> FromIterator<C> for ConstraintList {
+    fn from_iter<T: IntoIterator<Item = C>>(iter: T) -> Self {
+        Self(iter.into_iter().map(Into::into).collect())
+    }
+}
+
+impl Add for XConstraint {
+    type Output = ConstraintList;
+    fn add(self, rhs: Self) -> Self::Output {
+        [self, rhs].into_iter().collect()
+    }
+}
+
+impl Add for ConstraintList {
+    type Output = Self;
+    fn add(mut self, mut rhs: Self) -> Self::Output {
+        self.append(&mut rhs);
+        self
+    }
+}
+
+impl Add<XLayout> for ConstraintList {
+    type Output = XLayout;
+    fn add(mut self, mut rhs: XLayout) -> Self::Output {
+        core::mem::swap(&mut rhs.constraints, &mut self.0);
+        rhs.constraints.append(&mut self.0);
+        rhs
+    }
+}
+
+impl ConstraintList {
+    /// Create an empty list.
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+    /// Create a list from an iterable collection of values.
+    pub fn from<I>(constraints: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<XConstraint>,
+    {
+        Self(constraints.into_iter().map(Into::into).collect())
+    }
+    /// Create a list containing a single constraint.
+    pub fn single<C: Into<XConstraint>>(constraint: C) -> Self {
+        let mut list = Self::new();
+        list.push(constraint.into());
+        list
+    }
+    /// Add a constraint to the end of the list.
+    pub fn push<C: Into<XConstraint>>(&mut self, constraint: C) {
+        self.0.push(constraint.into());
+    }
+    /// Insert a constraint into the list at the given position.
+    pub fn insert<C: Into<XConstraint>>(&mut self, index: usize, constraint: C) {
+        self.0.insert(index, constraint.into());
+    }
+    /// Add multiple constraints to the end of the list.
+    pub fn extend<I>(&mut self, constraints: I)
+    where
+        I: IntoIterator,
+        I::Item: Into<XConstraint>,
+    {
+        self.0.extend(constraints.into_iter().map(Into::into));
+    }
+    /// Combine two constraint lists together. This constraint list is extended,
+    /// and the given constraint list is drained and left empty.
+    pub fn append(&mut self, other: &mut Self) {
+        self.0.append(&mut other.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversions() {
+        assert_eq!(
+            LinearSizeRange::from(1),
+            LinearSizeRange::new(1, 1, u16::MAX)
+        );
+        assert_eq!(LinearSizeRange::from(1..=1), LinearSizeRange::new(1, 1, 1));
+        assert_eq!(LinearSizeRange::from(1..2), LinearSizeRange::new(1, 1, 1));
+        assert_eq!(
+            LinearSizeRange::from((3, 14)),
+            LinearSizeRange::new(3, 14, u16::MAX)
+        );
+        assert_eq!(
+            LinearSizeRange::from((3, 14, 17)),
+            LinearSizeRange::new(3, 14, 17)
+        );
+        assert_eq!(
+            SizeRange::from((1, 2)),
+            SizeRange::new(
+                LinearSizeRange::new(1, 1, u16::MAX),
+                LinearSizeRange::new(2, 2, u16::MAX)
+            )
+        );
+        assert_eq!(
+            SizeRange::from(Size::new(1, 2)),
+            SizeRange::new(
+                LinearSizeRange::new(1, 1, u16::MAX),
+                LinearSizeRange::new(2, 2, u16::MAX)
+            )
+        );
+        assert_eq!(
+            SizeRange::from((1..=3, 2..=5)),
+            SizeRange::new(LinearSizeRange::new(1, 3, 3), LinearSizeRange::new(2, 5, 5))
+        );
+    }
+}

--- a/ratatui-core/src/layout/xlayout/hint.rs
+++ b/ratatui-core/src/layout/xlayout/hint.rs
@@ -1,0 +1,479 @@
+//! The [`Hint`] and [`HintRange`] types which are used to control how an [`XConstraint`] is
+//! used to allocate space for a segment.
+
+use core::ops::{
+    Index, IndexMut, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo,
+    RangeToInclusive,
+};
+
+use super::{Constraint, Debug, Display, EnumIs, Formatter, RangeLevel, Spacing, div_round};
+use crate::layout::{Direction, XConstraint};
+
+/// A hint represents a suggestion to the layout algorithm for how large some segment should be.
+/// There are various ways to represent the suggested size of a segment, either in an absolute
+/// measurement or relative to the size of the area that is to be split.
+/// The default hint is `Hint::Percentage(100)`, meaning that the segment should fill the
+/// entire area, 100%.
+#[derive(Clone, Copy, Eq, PartialEq, Hash, EnumIs)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Hint {
+    /// The absolute size of the segment, regardless of the size of the area to be split.
+    Length(u16),
+    /// The size of the segment as a percentage of the total size of the area to be split.
+    Percentage(u16),
+    /// The size of the segment as a ratio of the total size of the area to be split.
+    /// For example, `Ratio(1,2)` means that the segment should be allocated one third of the
+    /// total size of the area.
+    Ratio(u32, u32),
+    /// The size of the segment should be negative by the given absolute amount.
+    /// If a segment is allocated a negative area, then its rectangle will have zero size
+    /// and its neighboring segments will overlap each other, or even leave the bounds of
+    /// the area that is being split.
+    Overlap(u16),
+    /// The size of the segment should be determed by the [`SizeRange`](super::SizeRange) of the
+    /// constraint. It is as if it were `Hint::Length(x)` where `x` is the size of the
+    /// constraint's area range at the given level along the layout axis.
+    Size(RangeLevel),
+}
+
+impl Display for Hint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+impl Debug for Hint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Length(v) => Debug::fmt(v, f),
+            Self::Percentage(v) => write!(f, "{v}%"),
+            Self::Ratio(a, b) => write!(f, "{a}:{b}"),
+            Self::Overlap(v) => write!(f, "-{v}"),
+            Self::Size(level) => write!(f, "Area({level:?})"),
+        }
+    }
+}
+
+impl Hint {
+    /// A hint indicating that a segment should have zero size.
+    pub const ZERO: Self = Self::Length(0);
+    /// A hint indicating that a segment should fill the entire area.
+    pub const FULL: Self = Self::Percentage(100);
+    /// Find the absolute size of the hint when splitting an area of the given size.
+    /// For example, `Percentage(50).absolute_for(8)` would be 4, because 4 is 50% of 8.
+    /// `Ratio(2,3).absolute_for(12)` would be 8, because 8 is 2/3 of 12.
+    pub(super) fn absolute_for(
+        self,
+        constraint: &XConstraint,
+        direction: Direction,
+        area_size: u16,
+    ) -> i32 {
+        let size = u64::from(area_size);
+        match self {
+            Self::Length(v) => v.into(),
+            Self::Percentage(100) => area_size.into(),
+            Self::Percentage(v) => {
+                i32::try_from(div_round(u64::from(v).saturating_mul(size), 100)).unwrap_or(i32::MAX)
+            }
+            //.max(1),
+            Self::Ratio(a, 0) => i32::try_from(a).unwrap_or(i32::MAX),
+            Self::Ratio(0, _) => 0,
+            Self::Ratio(a, b) => {
+                i32::try_from(div_round(u64::from(a).saturating_mul(size), u64::from(b)))
+                    .unwrap_or(i32::MAX)
+                //.max(1)
+            }
+            Self::Overlap(v) => -i32::from(v),
+            Self::Size(level) => constraint.size.linear(direction)[level].into(),
+        }
+    }
+}
+
+impl Default for Hint {
+    fn default() -> Self {
+        Self::Percentage(100)
+    }
+}
+
+impl From<Spacing> for Hint {
+    fn from(value: Spacing) -> Self {
+        match value {
+            Spacing::Space(v) => Self::Length(v),
+            Spacing::Overlap(v) => Self::Overlap(v),
+        }
+    }
+}
+
+impl From<u16> for Hint {
+    fn from(value: u16) -> Self {
+        Self::Length(value)
+    }
+}
+
+impl From<(u32, u32)> for Hint {
+    fn from((a, b): (u32, u32)) -> Self {
+        Self::Ratio(a, b)
+    }
+}
+
+/// A range of layout hints including min, preferred, and max, along with other
+/// modifiers to how the segment should be allocated space within an area.
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HintRange {
+    /// A hint for the minimum amount to allocate. During layout this may be increased
+    /// if constraint has an [`XConstraint::size`] that requires a certain minimum size.
+    /// During layout, segments with lower `priority` are allocated their minimum size before
+    /// segments with greater `priority`.
+    pub min: Hint,
+    /// A hint for the preferred amount to allocate to the segment.
+    /// During layout, segments with lower `priority` are allocated their preferred size before
+    /// segments with greater `priority`.
+    pub preferred: Hint,
+    /// A hint for the maximum acceptable size for the segment's allocated area. This hint may be
+    /// exceeded if all segments reach their maximum and yet there is still area to be filled.
+    /// Segments with greater `priority` are allocated their preferred size before segments with
+    /// lower `priority`. This is reversed from how priority is handled for `min` and
+    /// `preferred`, meaning that low `priority` values give a segment greater chance to get to
+    /// its preferred size and stay there during the layout process.
+    pub max: Hint,
+    /// During layout, the amount allocated to the segment will be multiplied by its `fill_scale`,
+    /// causing some segments to grow faster than others. This has no effect if all segments
+    /// reach the sizes they are growing toward, but if the area is not large enough to give
+    /// every segment its desired size, then `fill_scale` allows some segments to get an
+    /// unequal share of what is available.
+    ///
+    /// This is akin to `priority` in that it allows some segments to have a better chance to be
+    /// allocated space, but priority causes segments to take turns in allocation, so for
+    /// example a segment with a low priority value would be allocated its full minimum size
+    /// before any other segments even start allocating their minimum sizes. While `fill_scale`
+    /// causes segments to share the allocation unequally, `priority` causes segments to not share
+    /// at all.
+    ///
+    /// If `fill_scale` is zero, then the segment cannot ever grow, bypassing the layout process.
+    /// The segment is given its minimum hint size indiscriminantly, even if that is larger
+    /// than the `Rect` that is being split.
+    pub fill_scale: u16,
+    /// After the stage where all segments grow to their `max` hint size, if there is still space
+    /// in the area to be filled, that space is required to be filled. If `overfill` is true,
+    /// then this segment is offering to be among the segments that will be filled beyond its
+    /// maximum. Any segment with `overfill` set to false will be ignored for the remainder of
+    /// the layout process, unless all segments have `overfill` set to false, in which case all
+    /// segments will grow. The default value is false.
+    pub overfill: bool,
+    /// By default all segments will simultaneously allocate space within the area for each stage
+    /// of their growth, first growing to their minimum size, then all growing to their
+    /// preferred size, then all to their maximum size, but `priority` makes it possible to
+    /// choose the order in which allocation happens, so some segments take their share
+    /// before other segments, leaving the other segments to allocate only what is left over.
+    ///
+    /// During the min stage and the preferred stage, lower priority segments allocate first to
+    /// give them a better chance of reaching their min/preferred size. During later stages the
+    /// priority is reversed, so that lower priority segments allocate last, giving them the
+    /// best chance to remain at their preferred size and not be forced to grow.
+    ///
+    /// This is akin to `fill_scale` in that it allows some segments to have a better chance to be
+    /// allocated space, but fill scale causes segments to allocate faster within their turn,
+    /// thereby taking more of the available space even among other segments of the same
+    /// priority. Neither `fill_scale` nor `priority` has any effect if all the segments are
+    /// able to reach their preferred size and none are force to grow to fill the area.
+    pub priority: i16,
+}
+
+impl Debug for HintRange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{:?}/{:?}/{:?} scale:{}",
+            self.min, self.preferred, self.max, self.fill_scale
+        )?;
+        if self.overfill {
+            f.write_str(" overfill")?;
+        }
+        write!(f, " priority:{}", self.priority)
+    }
+}
+
+impl Index<RangeLevel> for HintRange {
+    type Output = Hint;
+
+    fn index(&self, index: RangeLevel) -> &Self::Output {
+        match index {
+            RangeLevel::Min => &self.min,
+            RangeLevel::Preferred => &self.preferred,
+            RangeLevel::Max => &self.max,
+        }
+    }
+}
+
+impl IndexMut<RangeLevel> for HintRange {
+    fn index_mut(&mut self, index: RangeLevel) -> &mut Self::Output {
+        match index {
+            RangeLevel::Min => &mut self.min,
+            RangeLevel::Preferred => &mut self.preferred,
+            RangeLevel::Max => &mut self.max,
+        }
+    }
+}
+
+impl Default for HintRange {
+    fn default() -> Self {
+        Self::FULL
+    }
+}
+
+/// Generate `From` implementations for [`HintRange`] from types that
+/// implement [`RangeBounds<u16>`].
+macro_rules! hint_from_bounds {
+    ($($t:ty),*) => {
+        $(impl From<$t> for HintRange {
+            fn from(value: $t) -> Self {
+                Self::from_bounds(value)
+            }
+        })*
+    }
+}
+
+hint_from_bounds!(
+    Range<u16>,
+    RangeFrom<u16>,
+    RangeTo<u16>,
+    RangeInclusive<u16>,
+    RangeToInclusive<u16>,
+    RangeFull
+);
+
+impl HintRange {
+    /// The default hint range that allows the segment to have zero size,
+    /// or grow to fill the entire area. `preferred` is `Hint::FULL`,
+    /// `fill_scale` is 1, `overfill` is false, and `priority` is 0.
+    pub const FULL: Self = Self {
+        min: Hint::ZERO,
+        preferred: Hint::FULL,
+        max: Hint::FULL,
+        fill_scale: 1,
+        overfill: false,
+        priority: 0,
+    };
+    /// A hint range that has zero for min, preferred, and max.
+    /// All the rest is the same as [`HintRange::FULL`].
+    pub const ZERO: Self = Self {
+        min: Hint::ZERO,
+        preferred: Hint::ZERO,
+        max: Hint::ZERO,
+        ..Self::FULL
+    };
+    /// The default hint range for constraints that converted from sizes,
+    /// using [`Hint::Size`] to constrain the segment based on the size along the layout axis.
+    /// `min`, `preferred`, `max` come from the size.
+    /// `fill_scale` is 1, `overfill` is false, and `priority` is 0.
+    pub const SIZE: Self = Self {
+        min: Hint::Size(RangeLevel::Min),
+        preferred: Hint::Size(RangeLevel::Preferred),
+        max: Hint::Size(RangeLevel::Max),
+        ..Self::FULL
+    };
+    /// Create an [`XConstraint`] from this hint range by taking
+    /// [`XConstraint::FULL`] and replacing its hint range with this hint range.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn into_constraint(self) -> XConstraint {
+        XConstraint {
+            hint: self,
+            ..XConstraint::FULL
+        }
+    }
+    /// Create a [`HintRange::FULL`] except min, preferred, and max are set to the given hint.
+    pub const fn from_hint(hint: Hint) -> Self {
+        Self {
+            min: hint,
+            preferred: hint,
+            max: hint,
+            ..Self::FULL
+        }
+    }
+    /// Construct a hint range from the given bounds.
+    /// The low end of the bounds become a [`Hint::Length`] value for min.
+    /// The high end of the bounds become a [`Hint::Length`] value for both
+    /// preferred and max.
+    pub fn from_bounds<B: RangeBounds<u16>>(bounds: B) -> Self {
+        let min = match bounds.start_bound() {
+            core::ops::Bound::Included(x) => *x,
+            core::ops::Bound::Excluded(x) => x.saturating_add(1),
+            core::ops::Bound::Unbounded => 0,
+        };
+        let max = match bounds.end_bound() {
+            core::ops::Bound::Included(x) => *x,
+            core::ops::Bound::Excluded(x) => x.saturating_sub(1),
+            core::ops::Bound::Unbounded => u16::MAX,
+        };
+        Self {
+            min: Hint::Length(min),
+            preferred: Hint::Length(max),
+            max: Hint::Length(max),
+            ..Self::FULL
+        }
+    }
+    /// Create a `HintRange` that directs the constraint to fill whatever space
+    /// is leftover after other segments have reached their preferred sizes.
+    /// Its `fill_scale` is set to the given value to determine how large it will grow
+    /// relative to other filler constraints.
+    /// The min, preferred, are set to [`Hint::ZERO`] so that it will
+    /// not grow until max phase of layout, and max is set to [`Hint::FULL`] so it will
+    /// keep growing until no space is left. `priority` is set to 100 to encourage it to
+    /// grow before any other segments are stretched toward their own max.
+    pub const fn filler(fill_scale: u16) -> Self {
+        Self::from_hint(Hint::ZERO)
+            .without_max()
+            .scale(fill_scale)
+            .priority(100)
+    }
+    /// Set the `min`, `preferred`, and `max` to be `Hint::Area(RangeLevel::Min)`,
+    /// `Hint::Area(RangeLevel::Preferred)` and `Hint::Area(RangeLevel::Max)`, so that
+    /// this hint range directs its constraint to try to satisfy the requirements of its
+    /// area. These are the default values when an [`SizeRange`](super::SizeRange) is converted
+    /// into an [`XConstraint`].
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn hint_size(self) -> Self {
+        self.with_min(Hint::Size(RangeLevel::Min))
+            .preferred(Hint::Size(RangeLevel::Preferred))
+            .with_max(Hint::Size(RangeLevel::Max))
+    }
+    /// Set the hint for the minimum amount to allocate. During layout this may be increased
+    /// if constraint has an [`XConstraint::size`] that requires a certain minimum size.
+    /// During layout, segments with lower `priority` are allocated their minimum size before
+    /// segments with greater `priority`.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn with_min<H: Into<Hint>>(self, hint: H) -> Self {
+        Self {
+            min: hint.into(),
+            ..self
+        }
+    }
+    /// Set the hint for the preferred amount to allocate to the segment.
+    /// During layout, segments with lower `priority` are allocated their preferred size before
+    /// segments with greater `priority`.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn preferred<H: Into<Hint>>(self, hint: H) -> Self {
+        Self {
+            preferred: hint.into(),
+            ..self
+        }
+    }
+    /// Set the hint for the maximum acceptable size for the segment's allocated area. This hint may
+    /// be exceeded if all segments reach their maximum and yet there is still area to be
+    /// filled. Segments with greater `priority` are allocated their preferred size before
+    /// segments with lower `priority`. This is reversed from how priority is handled for `min`
+    /// and `preferred`, meaning that low `priority` values give a segment greater chance to get
+    /// to its preferred size and stay there during the layout process.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn with_max<H: Into<Hint>>(self, hint: H) -> Self {
+        Self {
+            max: hint.into(),
+            ..self
+        }
+    }
+    /// Set the `max` hint to [`Hint::FULL`] which is the full size of the area to be split,
+    /// which effectively means that there is no maximum.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn without_max(self) -> Self {
+        Self {
+            max: Hint::FULL,
+            ..self
+        }
+    }
+    /// During layout, the amount allocated to the segment will be multiplied by its `fill_scale`,
+    /// causing some segments to grow faster than others. This has no effect if all segments
+    /// reach the sizes they are growing toward, but if the area is not large enough to give
+    /// every segment its desired size, then `fill_scale` allows some segments to get an unequal
+    /// share of what is available.
+    ///
+    /// This is akin to `priority` in that it allows some segments to have a better chance to be
+    /// allocated space, but priority causes segments to take turns in allocation, so for
+    /// example a segment with a low priority value would be allocated its full minimum size
+    /// before any other segments even start allocating their minimum sizes. While `fill_scale`
+    /// causes segments to share the allocation unequally, `priority` causes segments to not share
+    /// at all.
+    ///
+    /// If `fill_scale` is zero, then the segment cannot ever grow, bypassing the layout process.
+    /// The segment is given its minimum hint size indiscriminantly, even if that is larger than
+    /// the `Rect` that is being split.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn scale(self, fill_scale: u16) -> Self {
+        Self { fill_scale, ..self }
+    }
+    /// By default all segments will simultaneously allocate space within the area for each stage of
+    /// their growth, first growing to their minimum size, then all growing to their preferred
+    /// size, then all to their maximum size, but `priority` makes it possible to choose the
+    /// order in which allocation happens, so some segments take their share before other
+    /// segments, leaving the other segments to allocate only what is left over.
+    ///
+    /// During the min stage and the preferred stage, lower priority segments allocate first to give
+    /// them a better chance of reaching their min/preferred size. During later stages the
+    /// priority is reversed, so that lower priority segments allocate last, giving them the
+    /// best chance to remain at their preferred size and not be forced to grow.
+    ///
+    /// This is akin to `fill_scale` in that it allows some segments to have a better chance to be
+    /// allocated space, but fill scale causes segments to allocate faster within their turn,
+    /// thereby taking more of the available space even among other segments of the same
+    /// priority. Neither `fill_scale` nor `priority` has any effect if all the segments are
+    /// able to reach their preferred size and none are force to grow to fill the area.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn priority(self, priority: i16) -> Self {
+        Self { priority, ..self }
+    }
+    /// After the stage where all segments grow to their `max` hint size, if there is still space in
+    /// the area to be filled, that space is required to be filled. If `overfill` is true, then
+    /// this segment is offering to be among the segments that will be filled beyond its
+    /// maximum. Any segment with `overfill` set to false will be ignored for the remainder of
+    /// the layout process, unless all segments have `overfill` set to false, in which case all
+    /// segments will grow. The default value is false.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn overfill(self, overfill: bool) -> Self {
+        Self { overfill, ..self }
+    }
+}
+
+impl<V: Into<Hint>> From<V> for HintRange {
+    fn from(value: V) -> Self {
+        Self::from_hint(value.into())
+    }
+}
+
+impl From<Constraint> for HintRange {
+    fn from(value: Constraint) -> Self {
+        match value {
+            Constraint::Min(v) => Self {
+                min: v.into(),
+                //preferred: v.into(),
+                priority: 100,
+                ..Self::FULL
+            },
+            Constraint::Max(v) => Self {
+                preferred: v.into(),
+                max: v.into(),
+                priority: 100,
+                ..Self::FULL
+            },
+            Constraint::Length(v) => Self {
+                preferred: v.into(),
+                max: v.into(),
+                ..Self::FULL
+            },
+            Constraint::Percentage(v) => Self {
+                preferred: Hint::Percentage(v),
+                max: Hint::Percentage(v),
+                ..Self::FULL
+            },
+            Constraint::Ratio(a, b) => Self {
+                preferred: Hint::Ratio(a, b),
+                max: Hint::Ratio(a, b),
+                ..Self::FULL
+            },
+            Constraint::Fill(v) => Self {
+                fill_scale: v,
+                priority: i16::MAX,
+                ..Self::FULL
+            },
+        }
+    }
+}

--- a/ratatui-core/src/layout/xlayout/record.rs
+++ b/ratatui-core/src/layout/xlayout/record.rs
@@ -1,0 +1,336 @@
+//! This is a debugging tool for [`XLayout`](super::XLayout) that provides a record of
+//! how an area was split into segments.
+use super::{Debug, Display, Formatter, STEP_FACTOR, SegmentRule, SegmentTarget, Vec};
+
+/// An optional [`FillRecord`] that may record the steps taken in the layout algorithm,
+/// if the algorithm is being run for debugging. Otherwise this will be `None` and
+/// nothing will be recorded.
+pub struct OptionFillRecord(pub Option<FillRecord>);
+
+impl OptionFillRecord {
+    /// Populate the list of segments in the record from a [`SegmentRule`] array.
+    pub fn set_segments(&mut self, area_size: i32, segments: &[SegmentRule]) {
+        if let Some(r) = &mut self.0 {
+            r.area_size = area_size;
+            r.segments = segments.iter().map(SegmentRule::record).collect();
+        }
+    }
+    /// Reset the record so that the layout process can restart with the same
+    /// segments and an empty list of steps.
+    pub fn reset(&mut self) {
+        if let Some(r) = &mut self.0 {
+            r.steps.clear();
+        }
+    }
+    /// Add a step to the record.
+    pub fn add_step(
+        &mut self,
+        index: usize,
+        before: i32,
+        after: i32,
+        size: u64,
+        target: SegmentTarget,
+    ) {
+        if let Some(r) = &mut self.0 {
+            r.steps.push(FillRecordStep {
+                index,
+                before,
+                after,
+                size,
+                target,
+            });
+        }
+    }
+}
+
+#[allow(clippy::doc_markdown)]
+/// A record of the steps used by a `XLayout` to split an area into segments. It contains a list of
+/// segments, one for each constraint in order, even including the constraints with the
+/// [`is_separator`](super::XConstraint::is_separator) flag. The `Display` implementation concisely
+/// formats the data to visualize the layout process.
+///
+/// For example, this layout operation would produce something like the following result.
+///
+/// ```
+/// use ratatui_core::layout::{IntoConstraint, Rect, XConstraint, XLayout};
+/// let layout = XLayout::vertical(
+///     (3..=10).scale(1).list() + XConstraint::overlap(8).scale(0) + (5..=12).scale(2),
+/// );
+/// let area = Rect::new(0, 0, 20, 15);
+/// println!("{}", layout.split_for_debug(area));
+/// ```
+///
+/// Output:
+///
+/// ```text
+/// area size: 15 (min/pref/max)
+/// [0: 0/3/10 scale:1 priority:0, 1: -8/-8/0 scale:0 priority:100, 2: 0/5/12 scale:2 priority:0]
+/// step  0: [  0]  0 -> 3   +3 7+22/32 Preferred (1 * 3 + 0) 0/3/10 scale:1 priority:0
+/// step  1: [  2]  0 -> 5   +5 7+22/32 Preferred (2 * 2 + 1) 0/5/12 scale:2 priority:0
+/// step  2: [  0]  3 -> 8   +5 5+0/32 Max (1 * 5 + 0) 0/3/10 scale:1 priority:0
+/// step  3: [  2]  5 -> 12  +7 5+0/32 Max (2 * 3 + 1) 0/5/12 scale:2 priority:0
+/// step  4: [  0]  8 -> 10  +2 3+0/32 Max (1 * 2 + 0) 0/3/10 scale:1 priority:0
+/// step  5: [  0] 10 -> 11  +1 0+11/32 Forced (1 * 1 + 0) 0/3/10 scale:1 priority:0
+/// final: [11, -8, 12]
+/// ```
+///
+/// The first line tells us length of the area in the layout direction: 15, and it reminds us of the
+/// format in which ranges are expressed, first min, then preferred, then max, separated by `/`.
+///
+/// Next we get a list of the segments that will be allocating. In this case there are three
+/// segments, one for each constraint. In this case
+/// [`XConstraint::overlap`](super::XConstraint::overlap) returns a separator constraint, so its
+/// segment would not be returned from a call to [`XLayout::split`](super::XLayout::split)
+/// but the layout algorithm does not care about that at this stage.
+///
+/// Next we have a list of 6 steps that were require to split this area. Each line is one step, and
+/// they are formatted like this:
+///
+/// ```text
+/// {step #}{index}{before}{after}{change}{step size}{phase}{amount used}{targets}{scale}{priority}
+/// step  0: [  0]     0  ->   3     +3    7+22/32 Preferred (1 * 3 + 0) 0/3/10 scale:1 priority:0
+/// ```
+///
+/// 1. `step #`: The number of steps that came before this step.
+/// 2. `index`: The index of the constraint that controls this segment in the constraint's array,
+///    and the index of the segment in the above list of segments.
+/// 3. `before`: The amount allocated to this segment before this step.
+/// 4. `after`: The amount allocated to this segment after this step.
+/// 5. `change`: `after - before`
+/// 6. `step size`: See [`FillRecordStep::size`]. This represents how much the constraint is
+///    permitted to allocate in this step. Here the number is divided by 32 to make it easier to
+///    read. Multiply that by the segment's scale to get the maximum possible allocation. Every
+///    active constraint is given the same step size for one step, so having a larger scale means a
+///    larger potential for allocation each step.
+/// 7. `phase`: This indicates which target the segment is growing toward. In this case, it is
+///    growing toward its preferred size, which is 3.
+/// 8. `amount used`: This indicates how much of the step size was actually used. `1 * 3 + 0` means
+///    that the scale was 1, and that was multiplied by 3 (out of a maximum of 7) from the step
+///    size, plus 0 additional size from using less than a full scale. If the segment had used its
+///    full step size, this would have said `1 * 7 + 1`. The + 1 comes from 22/32 rounded up. It
+///    could not do that because 3 reached the target for this step.
+/// 9. `targets`: `0/3/10`. These are the three targets, the minimum, the preferred, and the
+///    maximum. In this case the phase is `Preferred` so the allocation target is 3. The target for
+///    the next phase will be 10.
+/// 10. `scale`: This is the factor that gets multiplied by the step size to determine how much the
+///     segment is allowed to allocate on this step. See
+///     [`HintRange::fill_scale`](super::HintRange::fill_scale).
+/// 11. `priority`: In this example all the segments have the same priority, so all of them are
+///     immediately active and stay active until they reach their target. If there were multiple
+///     priorities, then segments with earlier priority would activate first and take steps until
+///     they reach their current target, and only after all the active segments are satisfied would
+///     segments from the next priority become active.
+///
+/// In step 0 and 1, segments 0 and 2 are each allowed a step size of 7+22/32, and they both
+/// immediately use that to reach their preferred targets. Segment 1 does not get a step because its
+/// scale is 0. The reason the step size is 7+22/32 is because the layout has 23 space to fill,
+/// 15 from the width of the area, +8 due to segment 1 having negative size and causing the other
+/// segments to overlap. If both segments 0 and 2 used their full 7+22/32, then segment 0 would
+/// allocate 8 and segment 2 would allocate 15 (2 * 7+22/32), which is a total of 23. They are being
+/// given the maximum step size that is safe to take without a chance of overflowing the area.
+///
+/// In step 2 and 3, segments 0 and 2 get a step size of 5. The step size is smaller because less of
+/// the area is available after the first round. Segment 2 uses 3 of that 5 to immediately bring
+/// itself to its target preferred size of 12 by multiplying 3 by its scale of 2. Unfortunately, the
+/// step size is insufficient for segment 0, so it uses the full step size and only reaches 8, which
+/// is less than its target of 10.
+///
+/// In step 4, the only remaining active segment is segment 0, so it is given a step size of 3,
+/// which authorizes it to allocate the entire remaining area. In order to reach its target, it only
+/// uses 2. This leaves 1 space remaining in the area that has not been allocated.
+///
+/// The max phase and the overfill phase are skipped, because segments 0 and 2 have both already
+/// reached their max target, and neither has the
+/// [`HintRange::overfill`](super::HintRange::overfill) flag set. Therefore step 5 skips straight to
+/// the forced phase where all segments must grow regardless of targets until the entire area is
+/// allocated. Segment 1 is exempt because having a scale of 0 means it still cannot grow. Segment 0
+/// takes the first step and is given a step size of 11/32 because there is only 1 unit of space to
+/// fill. In this case the small step size does not matter, because every segment is always allowed
+/// to allocate at least one unit on each step, so segment 0 takes that unit and the layout is
+/// complete.
+///
+/// The final line shows the result: `[11, -8, 12]`. Segment 0 was forced to exceed its maximum by 1
+/// to reach 11, segment 1 started at -8 and remained there to the end because its scale was 0, and
+/// segment 2 reached its preferred size of 12.
+#[derive(Debug, Default, Clone)]
+pub struct FillRecord {
+    /// The size of the area to layout along the layout axis.
+    pub area_size: i32,
+    /// The list of segments, each one controlled by a constraint.
+    pub segments: Vec<FillRecordSegment>,
+    /// The list of steps in the layout process, each one allocating a certain amount of space
+    /// to a certain segment.
+    pub steps: Vec<FillRecordStep>,
+}
+
+impl Display for FillRecord {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "area size: {} (min/pref/max)\n[", self.area_size)?;
+        let mut iter = self.segments.iter().enumerate();
+        if let Some((i, seg)) = iter.next() {
+            write!(f, "{i}: {seg}")?;
+        }
+        for (i, seg) in iter {
+            write!(f, ", {i}: {seg}")?;
+        }
+        f.write_str("]\n")?;
+        let mut results = self
+            .segments
+            .iter()
+            .map(FillRecordSegment::initial_size)
+            .collect::<Vec<_>>();
+        for (i, step) in self.steps.iter().enumerate() {
+            let amount = step.after.saturating_sub(step.before);
+            let Some(segment) = self.segments.get(step.index) else {
+                writeln!(f, "step{i:3}: [{:3}] Invalid index", step.index)?;
+                continue;
+            };
+            let scale = segment.fill_scale;
+            let steps = amount.checked_div(scale).unwrap_or(0);
+            let rem = amount.checked_rem(scale).unwrap_or(amount);
+            writeln!(f, "step{i:3}: {step} ({scale} * {steps} + {rem}) {segment}")?;
+            if let Some(v) = results.get_mut(step.index) {
+                *v = step.after;
+            } else {
+                f.write_str("Invalid index\n")?;
+            }
+        }
+        write!(f, "final: {results:?}")
+    }
+}
+
+/// The values that are used to allocate space to a segment during layout, after the constraints
+/// have calculated absolute values given the area that needs to be filled.
+#[derive(Debug, Clone)]
+pub struct FillRecordSegment {
+    /// The target size for this segment during the min phase of layout.
+    /// See [`HintRange::min`](super::HintRange::min).
+    pub min: i32,
+    /// The target size for this segment during the preferred phase of layout.
+    /// See [`HintRange::preferred`](super::HintRange::preferred).
+    pub preferred: i32,
+    /// The target size for this segment during the max phase of layout.
+    /// See [`HintRange::max`](super::HintRange::max).
+    pub max: i32,
+    /// The speed at which this segment grows relative to other segments.
+    /// See [`HintRange::fill_scale`](super::HintRange::fill_scale).
+    pub fill_scale: i32,
+    /// True if this segment will allocate during the [`SegmentTarget::Overfill`] phase.
+    pub overfill: bool,
+    /// The order in which segments are allowed to allocate size.
+    /// Lower values allocate first during the min and preferred phase,
+    /// then higher values allocate first during later phases.
+    /// See [`HintRange::priority`](super::HintRange::priority).
+    pub priority: i16,
+}
+
+impl Display for FillRecordSegment {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{}/{}/{} scale:{}",
+            self.min, self.preferred, self.max, self.fill_scale
+        )?;
+        if self.overfill {
+            f.write_str(" overfill")?;
+        }
+        write!(f, " priority:{}", self.priority)
+    }
+}
+
+impl FillRecordSegment {
+    /// The size of the segment when layout begins, based upon its
+    /// min size and fill scale. Most segments begin at zero size, but
+    /// a negative min size or a fill scale of zero will cause the min size
+    /// to be used instead of zero.
+    pub fn initial_size(&self) -> i32 {
+        if self.fill_scale == 0 {
+            self.min
+        } else {
+            self.min.min(0)
+        }
+    }
+}
+
+/// A step in the layout process, allocating a certain amouht of space to a certain segment.
+#[derive(Debug, Clone)]
+pub struct FillRecordStep {
+    /// The index of the segment in the segment list, and also the index of the constraint
+    /// in the constraint list.
+    pub index: usize,
+    /// The size of the segment before space was allocated to it in this step.
+    pub before: i32,
+    /// The size of the segment after the step.
+    pub after: i32,
+    /// The size of the step. Each time the layout takes a step, it looks through
+    /// all the active constraints and how fast each one wants to allocate based on its
+    /// [`HintRange::fill_scale`](super::HintRange::fill_scale), and then checks the remaining
+    /// available space to determine how large a step each constraint should make in allocating
+    /// space while still giving all the other active constraints their chance.
+    ///
+    /// The amount that a constraint is allowed to allocate for itself in this step is
+    /// `fill_scale * size / 32`
+    ///
+    /// If the amount allocated is less than this, it is because the constraint reached its target
+    /// and has become inactive.
+    pub size: u64,
+    /// The target of the current step, indicating whether the constraints are trying to reach
+    /// their min, preferred, or max sizes.
+    pub target: SegmentTarget,
+}
+
+impl Display for FillRecordStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let index = self.index;
+        let before = self.before;
+        let after = self.after;
+        let amount = after.saturating_sub(before);
+        let whole_steps = self.size / STEP_FACTOR;
+        let part_steps = self.size % STEP_FACTOR;
+        let target = self.target;
+        write!(
+            f,
+            "[{index:3}]{before:3} -> {after:<3}{amount:+3} {whole_steps}+{part_steps}/{STEP_FACTOR} {target}",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+
+    use crate::layout::{IntoConstraint, Rect, XConstraint, XLayout};
+
+    #[test]
+    fn layout_debug1() {
+        const EXPECTED: &str = "area size: 8 (min/pref/max)\n\
+        [0: 8/8/65535 scale:1 priority:0, 1: 2/2/65535 scale:0 priority:0, 2: 8/8/65535 scale:2 priority:0]\n\
+        step  0: [  0]  0 -> 2   +2 2+0/32 Min (1 * 2 + 0) 8/8/65535 scale:1 priority:0\n\
+        step  1: [  2]  0 -> 4   +4 2+0/32 Min (2 * 2 + 0) 8/8/65535 scale:2 priority:0\n\
+        final: [2, 2, 4]";
+        let layout = XLayout::vertical(
+            (.., 8).scale(1).list() + (.., 2).separator().scale(0) + (.., 8).scale(2),
+        );
+        let area = Rect::new(0, 0, 20, 8);
+        assert_eq!(&layout.split_for_debug(area).to_string(), EXPECTED);
+    }
+    #[test]
+    fn layout_debug2() {
+        const EXPECTED: &str = "area size: 15 (min/pref/max)\n\
+        [0: 0/3/10 scale:1 priority:0, 1: -8/-8/0 scale:0 priority:100, 2: 0/5/12 scale:2 priority:0]\n\
+        step  0: [  0]  0 -> 3   +3 7+22/32 Preferred (1 * 3 + 0) 0/3/10 scale:1 priority:0\n\
+        step  1: [  2]  0 -> 5   +5 7+22/32 Preferred (2 * 2 + 1) 0/5/12 scale:2 priority:0\n\
+        step  2: [  0]  3 -> 8   +5 5+0/32 Max (1 * 5 + 0) 0/3/10 scale:1 priority:0\n\
+        step  3: [  2]  5 -> 12  +7 5+0/32 Max (2 * 3 + 1) 0/5/12 scale:2 priority:0\n\
+        step  4: [  0]  8 -> 10  +2 3+0/32 Max (1 * 2 + 0) 0/3/10 scale:1 priority:0\n\
+        step  5: [  0] 10 -> 11  +1 0+11/32 Forced (1 * 1 + 0) 0/3/10 scale:1 priority:0\n\
+        final: [11, -8, 12]";
+        let layout = XLayout::vertical(
+            (0..=10).preferred(3).scale(1).list()
+                + XConstraint::overlap(8).scale(0)
+                + (0..=12).preferred(5).scale(2),
+        );
+        let area = Rect::new(0, 0, 20, 15);
+        assert_eq!(&layout.split_for_debug(area).to_string(), EXPECTED);
+    }
+}

--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -10,7 +10,7 @@ use unicode_truncate::UnicodeTruncateStr;
 use unicode_width::UnicodeWidthStr;
 
 use crate::buffer::Buffer;
-use crate::layout::{Alignment, Rect};
+use crate::layout::{Alignment, Rect, Size};
 use crate::style::{Style, Styled};
 use crate::text::{Span, StyledGrapheme, Text};
 use crate::widgets::Widget;
@@ -441,6 +441,23 @@ impl<'a> Line<'a> {
         UnicodeWidthStr::width(self)
     }
 
+    /// Returns the width and height of the underlying string.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Size;
+    /// use ratatui_core::style::Stylize;
+    /// use ratatui_core::text::Line;
+    ///
+    /// let line = Line::from(vec!["Hello".blue(), " world!".green()]);
+    /// assert_eq!(Size::new(12, 1), line.size());
+    /// ```
+    #[must_use]
+    pub fn size(&self) -> Size {
+        Size::new(u16::try_from(self.width()).unwrap_or(u16::MAX), 1)
+    }
+
     /// Returns an iterator over the graphemes held by this line.
     ///
     /// `base_style` is the [`Style`] that will be patched with each grapheme [`Style`] to get
@@ -846,6 +863,7 @@ impl Styled for Line<'_> {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
     use alloc::format;
     use core::iter;
     use std::dbg;
@@ -948,6 +966,18 @@ mod tests {
 
         let empty_line = Line::default();
         assert_eq!(0, empty_line.width());
+    }
+
+    #[test]
+    fn size() {
+        let line = Line::from(vec![
+            Span::styled("My", Style::default().fg(Color::Yellow)),
+            Span::raw(" text"),
+        ]);
+        assert_eq!(Size::new(7, 1), line.size());
+
+        let empty_line = Line::default();
+        assert_eq!(Size::new(0, 1), empty_line.size());
     }
 
     #[test]

--- a/ratatui-core/src/text/span.rs
+++ b/ratatui-core/src/text/span.rs
@@ -6,7 +6,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use crate::buffer::Buffer;
-use crate::layout::Rect;
+use crate::layout::{Rect, Size};
 use crate::style::{Style, Styled};
 use crate::text::{Line, StyledGrapheme};
 use crate::widgets::Widget;
@@ -270,6 +270,14 @@ impl<'a> Span<'a> {
     /// Returns the unicode width of the content held by this span.
     pub fn width(&self) -> usize {
         UnicodeWidthStr::width(self)
+    }
+
+    /// Returns the size of the content held by this span.
+    pub fn size(&self) -> Size {
+        Size::new(
+            u16::try_from(UnicodeWidthStr::width(self)).unwrap_or(u16::MAX),
+            1,
+        )
     }
 
     /// Returns an iterator over the graphemes held by this span.
@@ -629,6 +637,13 @@ mod tests {
         assert_eq!(Span::raw("test content").width(), 12);
         // Needs reconsideration: https://github.com/ratatui/ratatui/issues/1271
         assert_eq!(Span::raw("test\ncontent").width(), 12);
+    }
+
+    #[test]
+    fn size() {
+        assert_eq!(Span::raw("").size(), Size::new(0, 1));
+        assert_eq!(Span::raw("test").size(), Size::new(4, 1));
+        assert_eq!(Span::raw("test content").size(), Size::new(12, 1));
     }
 
     #[test]

--- a/ratatui-core/src/text/text.rs
+++ b/ratatui-core/src/text/text.rs
@@ -8,7 +8,7 @@ use core::fmt;
 use unicode_width::UnicodeWidthStr;
 
 use crate::buffer::Buffer;
-use crate::layout::{Alignment, Rect};
+use crate::layout::{Alignment, Rect, Size};
 use crate::style::{Style, Styled};
 use crate::text::{Line, Span};
 use crate::widgets::Widget;
@@ -301,6 +301,24 @@ impl<'a> Text<'a> {
     /// ```
     pub fn height(&self) -> usize {
         self.lines.len()
+    }
+
+    /// Returns the width and height.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Size;
+    /// use ratatui_core::text::Text;
+    ///
+    /// let text = Text::from("The first line\nThe second line");
+    /// assert_eq!(Size::new(15, 2), text.size());
+    /// ```
+    pub fn size(&self) -> Size {
+        Size::new(
+            u16::try_from(self.width()).unwrap_or(u16::MAX),
+            u16::try_from(self.height()).unwrap_or(u16::MAX),
+        )
     }
 
     /// Sets the style of this text.
@@ -819,6 +837,12 @@ mod tests {
     fn height() {
         let text = Text::from("The first line\nThe second line");
         assert_eq!(2, text.height());
+    }
+
+    #[test]
+    fn size() {
+        let text = Text::from("The first line\nThe second line");
+        assert_eq!(Size::new(15, 2), text.size());
     }
 
     #[test]

--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -49,6 +49,8 @@ unstable = ["unstable-rendered-line-info"]
 ## See [Issue 293](https://github.com/ratatui/ratatui/issues/293) for more details.
 unstable-rendered-line-info = []
 
+xlayout = ["ratatui-core/xlayout"]
+
 [dependencies]
 bitflags.workspace = true
 document-features = { workspace = true, optional = true }

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -1766,22 +1766,34 @@ mod tests {
             // without selection, more than needed width
             // rounds from positions: [0.00, 0.00, 6.67, 7.67, 14.33]
             let table = Table::default().widths([Ratio(1, 3), Ratio(1, 3)]);
+            #[cfg(not(feature = "xlayout"))]
             assert_eq!(table.get_column_widths(20, 0, 0), [(0, 7), (8, 6)]);
+            #[cfg(feature = "xlayout")]
+            assert_eq!(table.get_column_widths(20, 0, 0), [(0, 7), (8, 7)]);
 
             // with selection, more than needed width
             // rounds from positions: [0.00, 3.00, 10.67, 17.33, 20.00]
             let table = Table::default().widths([Ratio(1, 3), Ratio(1, 3)]);
-            assert_eq!(table.get_column_widths(20, 3, 0), [(3, 6), (10, 5)]);
+            #[cfg(not(feature = "xlayout"))]
+            assert_eq!(table.get_column_widths(20, 3, 0), [(3, 6), (10, 5)],);
+            #[cfg(feature = "xlayout")]
+            assert_eq!(table.get_column_widths(20, 3, 0), [(3, 6), (10, 6)],);
 
             // without selection, less than needed width
             // rounds from positions: [0.00, 2.33, 3.33, 5.66, 7.00]
             let table = Table::default().widths([Ratio(1, 3), Ratio(1, 3)]);
+            #[cfg(not(feature = "xlayout"))]
             assert_eq!(table.get_column_widths(7, 0, 0), [(0, 2), (3, 3)]);
+            #[cfg(feature = "xlayout")]
+            assert_eq!(table.get_column_widths(7, 0, 0), [(0, 2), (3, 2)]);
 
             // with selection, less than needed width
             // rounds from positions: [0.00, 3.00, 5.33, 6.33, 7.00, 7.00]
             let table = Table::default().widths([Ratio(1, 3), Ratio(1, 3)]);
+            #[cfg(not(feature = "xlayout"))]
             assert_eq!(table.get_column_widths(7, 3, 0), [(3, 1), (5, 2)]);
+            #[cfg(feature = "xlayout")]
+            assert_eq!(table.get_column_widths(7, 3, 0), [(3, 1), (5, 1)]);
         }
 
         /// When more width is available than requested, the behavior is controlled by flex

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -71,6 +71,8 @@ scrolling-regions = [
   "ratatui-termwiz?/scrolling-regions",
 ]
 
+xlayout = ["ratatui-core/xlayout", "ratatui-widgets/xlayout"]
+
 ## enables the [`macros`](macros) module which provides some useful macros for creating spans,
 ## lines, text, and layouts
 macros = ["dep:ratatui-macros"]

--- a/ratatui/tests/widgets_table.rs
+++ b/ratatui/tests/widgets_table.rs
@@ -291,7 +291,7 @@ fn widgets_table_columns_widths_can_use_percentage_constraints<'line, Lines>(
     "│                            │",
     "└────────────────────────────┘",
 ])]
-#[case::large_width_just_before_pushing_a_column_off(&[
+#[cfg_attr(not(feature="xlayout"), case::large_width_just_before_pushing_a_column_off(&[
     Constraint::Percentage(33),
     Constraint::Length(10),
     Constraint::Percentage(33),
@@ -306,8 +306,8 @@ fn widgets_table_columns_widths_can_use_percentage_constraints<'line, Lines>(
     "│                            │",
     "│                            │",
     "└────────────────────────────┘",
-])]
-#[case::more_than_100(&[
+]))]
+#[cfg_attr(not(feature="xlayout"), case::more_than_100(&[
     Constraint::Percentage(60),
     Constraint::Length(10),
     Constraint::Percentage(60),
@@ -322,7 +322,39 @@ fn widgets_table_columns_widths_can_use_percentage_constraints<'line, Lines>(
     "│                            │",
     "│                            │",
     "└────────────────────────────┘",
-])]
+]))]
+#[cfg_attr(feature="xlayout", case::large_width_just_before_pushing_a_column_off(&[
+    Constraint::Percentage(33),
+    Constraint::Length(10),
+    Constraint::Percentage(33),
+], [
+    "┌────────────────────────────┐",
+    "│Head1     Head2    Head3    │",
+    "│                            │",
+    "│Row11     Row12    Row13    │",
+    "│Row21     Row22    Row23    │",
+    "│Row31     Row32    Row33    │",
+    "│Row41     Row42    Row43    │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+]))]
+#[cfg_attr(feature="xlayout", case::more_than_100(&[
+    Constraint::Percentage(60),
+    Constraint::Length(10),
+    Constraint::Percentage(60),
+], [
+    "┌────────────────────────────┐",
+    "│Head1     Head2    Head3    │",
+    "│                            │",
+    "│Row11     Row12    Row13    │",
+    "│Row21     Row22    Row23    │",
+    "│Row31     Row32    Row33    │",
+    "│Row41     Row42    Row43    │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+]))]
 fn widgets_table_columns_widths_can_use_mixed_constraints<'line, Lines>(
     #[case] widths: &[Constraint],
     #[case] expected: Lines,
@@ -384,7 +416,7 @@ fn widgets_table_columns_widths_can_use_mixed_constraints<'line, Lines>(
     "│                            │",
     "└────────────────────────────┘",
 ])]
-#[case::three(&[Constraint::Ratio(1, 3), Constraint::Ratio(1, 3), Constraint::Ratio(1, 3)], [
+#[cfg_attr(not(feature="xlayout"), case::three(&[Constraint::Ratio(1, 3), Constraint::Ratio(1, 3), Constraint::Ratio(1, 3)], [
     "┌────────────────────────────┐",
     "│Head1    Head2     Head3    │",
     "│                            │",
@@ -395,7 +427,19 @@ fn widgets_table_columns_widths_can_use_mixed_constraints<'line, Lines>(
     "│                            │",
     "│                            │",
     "└────────────────────────────┘",
-])]
+]))]
+#[cfg_attr(feature="xlayout", case::three(&[Constraint::Ratio(1, 3), Constraint::Ratio(1, 3), Constraint::Ratio(1, 3)], [
+    "┌────────────────────────────┐",
+    "│Head1    Head2    Head3     │",
+    "│                            │",
+    "│Row11    Row12    Row13     │",
+    "│Row21    Row22    Row23     │",
+    "│Row31    Row32    Row33     │",
+    "│Row41    Row42    Row43     │",
+    "│                            │",
+    "│                            │",
+    "└────────────────────────────┘",
+]))]
 #[case::two(&[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)], [
     "┌────────────────────────────┐",
     "│Head1         Head2         │",


### PR DESCRIPTION
This PR implements an alternative constraint solver algorithm to replace kasuari as the engine behind `Layout`. It is vastly more efficient since it solves the layout directly instead of converting it into a more general constraint solving problem, and it uses a relatively simple algorithm that is explained in detail in the comments of the `ratatui_core::layout::xlayout` module.

In addition to making `Layout` faster, this algorithm offers an extended interface that gives users access to more options for fine-tuning the layout. This is called `XLayout` and it works much like `Layout` and can be smoothly used alongside `Layout`.

The vast majority of tests pass after replacing kasuari with `XLayout`, meaning that most apps should see no difference at all, but there are a few tests that needed to be slightly modified in order to pass. These modifications were made because the output of `XLayout` was either different from kasuari in only trivial ways, or else `XLayout` produced superior output.

An "xlayout" feature was added for the purpose of switching between kasuari and `XLayout` as the solver behind `Layout`. This is merely for demonstration purposes, so that it is easy to compare the difference between the two solvers in apps and through profiling. I would expect that if `XLayout` is superior to kasuari then there would be no need for a feature and `XLayout` could simply permanently replace kasuari.

I hope to start a discussion about whether this or something like this might replace kasuari.
