### PR TITLE
fix: change flex example colors for MacOS default terminal

### DIFF
--- a/examples/apps/flex/src/main.rs
+++ b/examples/apps/flex/src/main.rs
@@ -561,7 +561,6 @@ struct Theme {
     space_around_tab: Color,
     description_fg: Color,
 }
-}
 
 impl Theme {
     pub fn new() -> Self {


### PR DESCRIPTION
Part of the fix for #1972 

### Summary
This fix introduces a function to check if we are in a terminal without truecolor(24-bit) and changes the default colors to appear fine of the flex example.

### Notes
The function "is_true_color_supported” is an old problem and there is no common way to determine if a terminal supports or not the truecolor. 

This is the main reason why the function detects specifically the Terminal.app version before the Tahoe. If there are other known terminals with this problem, we can add it to this function.
