### PR TITLE
refactor: Exchange overflow check with saturating_add

### DIFF
--- a/ratatui-core/src/layout/rect.rs
+++ b/ratatui-core/src/layout/rect.rs
@@ -147,15 +147,8 @@ impl Rect {
     /// let rect = Rect::new(1, 2, 3, 4);
     /// ```
     pub const fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
-        // these calculations avoid using min so that this function can be const
-        let max_width = u16::MAX - x;
-        let max_height = u16::MAX - y;
-        let width = if width > max_width { max_width } else { width };
-        let height = if height > max_height {
-            max_height
-        } else {
-            height
-        };
+        let width = x.saturating_add(width) - x;
+        let height = y.saturating_add(height) - y;
         Self {
             x,
             y,


### PR DESCRIPTION
### Summary
Factory `Rect::new` contains out-of-bound conditions to ensure `x + width` and `y + height` do not overflow `u16`. I believe these can be exchanged with [`saturating_add`](https://doc.rust-lang.org/std/primitive.u16.html#method.saturating_add).

### Testing
Tests `size_truncation` and `size_preservation` appear to be the only candidates for concern regarding this change.