### PR TITLE
refactor: `Buffer::pos_of` to call `Rect::pos_of`

### DIFF
--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -269,21 +269,8 @@ impl Buffer {
         Some(y * width + x)
     }
 
-    /// Returns the (global) coordinates of a cell given its index
-    ///
-    /// Global coordinates are offset by the Buffer's area offset (`x`/`y`).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ratatui_core::buffer::Buffer;
-    /// use ratatui_core::layout::Rect;
-    ///
-    /// let rect = Rect::new(200, 100, 10, 10);
-    /// let buffer = Buffer::empty(rect);
-    /// assert_eq!(buffer.pos_of(0), (200, 100));
-    /// assert_eq!(buffer.pos_of(14), (204, 101));
-    /// ```
+    /// Returns the (global) coordinates of a cell given its index. It
+    /// runs [`Rect::pos_of`] under the hood on `self.area`.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
## Summary
Proposed change in [issue 2217](https://github.com/ratatui/ratatui/issues/2217):

> Function `Buffer::pos_of` returns a coordinate pair of a cell in `self.area: Rect` given an index parameter. It looks like this functionality only touches the `area` and it could be pulled into a function: `Rect::pos_of`. I imagine this functionality is useful in other places than just `Buffer`.

Also included: modification to docstring in `Buffer::symbol` example (bad char).