### PR TITLE
docs: Discourage use of `Buffer`'s `pos_of`, `index_of`

### DIFF
--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -216,9 +216,8 @@ impl Buffer {
     ///
     /// Global coordinates are offset by the Buffer's area offset (`x`/`y`).
     ///
-    /// Usage discouraged, as it exposes `self.content` as a linearly
-    /// indexable array, which limits potential future abstractions. See
-    /// <https://github.com/ratatui/ratatui/issues/1122>.
+    /// Usage discouraged, as it exposes `self.content` as a linearly indexable array, which limits
+    /// potential future abstractions. See <https://github.com/ratatui/ratatui/issues/1122>.
     ///
     /// # Examples
     ///
@@ -277,9 +276,8 @@ impl Buffer {
     ///
     /// Global coordinates are offset by the Buffer's area offset (`x`/`y`).
     ///
-    /// Usage discouraged, as it exposes `self.content` as a linearly
-    /// indexable array, which limits potential future abstractions. See
-    /// <https://github.com/ratatui/ratatui/issues/1122>.
+    /// Usage discouraged, as it exposes `self.content` as a linearly indexable array, which limits
+    /// potential future abstractions. See <https://github.com/ratatui/ratatui/issues/1122>.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Summary

Per @joshka 's [comment](https://github.com/ratatui/ratatui/pull/2220#issuecomment-3567065394):
> Document the above in pos_of() ("Don't use this because...")

"Usage discouraged" documentation added to `Buffer::pos_of` and `Buffer::index_of`. Does __not__ deprecate functions.

Doc now contains reference to [issue of making methods private](https://github.com/ratatui/ratatui/issues/1122).