### PR TITLE
feat(symbols)!: Make `Marker` non-exhaustive

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -27,6 +27,7 @@ This is a quick summary of the sections below:
   - Disabling `default-features` suppresses the error message if `show_cursor()` fails when dropping
     `Terminal`
   - Support a broader range for `unicode-width` version
+  - `Marker` is now non-exhaustive
 - [v0.29.0](#v0290)
   - `Sparkline::data` takes `IntoIterator<Item = SparklineBar>` instead of `&[u64]` and is no longer
     const
@@ -91,6 +92,24 @@ This is a quick summary of the sections below:
   - `List` no longer ignores empty strings
 
 ## v0.30.0 Unreleased
+
+### `Marker` is now non-exhaustive ([#2236])
+
+[#2236]: https://github.com/ratatui/ratatui/pull/2236
+
+The `Marker` enum is now marked as `#[non_exhaustive]`, if you were matching on `Marker` exhaustively,
+you will need to add a wildcard arm:
+
+```diff
+  match marker {
+      Marker::Dot => { /* ... */ }
+      Marker::Block => { /* ... */ }
+      Marker::Bar => { /* ... */ }
+      Marker::Braille => { /* ... */ }
+      Marker::HalfBlock => { /* ... */ }
++     _ => { /* ... */ }
+  }
+```
 
 ### `Flex::SpaceAround` now mirrors flexbox: space between items is twice the size of the outer gaps ([#1952])
 

--- a/examples/apps/canvas/src/main.rs
+++ b/examples/apps/canvas/src/main.rs
@@ -124,6 +124,7 @@ impl App {
             Marker::Block => Marker::HalfBlock,
             Marker::HalfBlock => Marker::Bar,
             Marker::Bar => Marker::Dot,
+            _ => unreachable!(),
         };
     }
 

--- a/ratatui-core/src/symbols/marker.rs
+++ b/ratatui-core/src/symbols/marker.rs
@@ -4,6 +4,7 @@ pub const DOT: &str = "•";
 
 /// Marker to use when plotting data points
 #[derive(Debug, Default, Display, EnumString, Clone, Copy, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub enum Marker {
     /// One point per cell in shape of dot (`•`)
     #[default]

--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -559,11 +559,11 @@ impl<'a> Context<'a> {
         let block = symbols::block::FULL.chars().next().unwrap();
         let bar = symbols::bar::HALF.chars().next().unwrap();
         match marker {
-            Marker::Dot => Box::new(CharGrid::new(width, height, dot)),
             Marker::Block => Box::new(CharGrid::new(width, height, block).apply_color_to_bg()),
             Marker::Bar => Box::new(CharGrid::new(width, height, bar)),
             Marker::Braille => Box::new(BrailleGrid::new(width, height)),
             Marker::HalfBlock => Box::new(HalfBlockGrid::new(width, height)),
+            Marker::Dot | _ => Box::new(CharGrid::new(width, height, dot)),
         }
     }
 


### PR DESCRIPTION
This will allow us to add new markers without causing further breaking changes.

BREAKING CHANGE: `Marker` is now non-exhaustive

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
