### PR TITLE
ci: don't fail on cargo-deny advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           rust-toolchain: stable
           log-level: info
+          arguments: --all-features --exclude-unpublished
           command: check ${{ matrix.checks }}
 
   # Check for any unused dependencies in the codebase.


### PR DESCRIPTION
Instead of failing on advisories, run the cargo-deny check, and report the failure.

Uses the cargo-deny-action instead of installing this manually.

https://github.com/EmbarkStudios/cargo-deny-action/tree/v2?tab=readme-ov-file#recommended-pipeline-if-using-advisories-to-avoid-sudden-breakages
(bumped to use rust stable, and log level info)