### PR TITLE
feat(layout): support per-side insets via Rect::inner

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -20,6 +20,7 @@ This is a quick summary of the sections below:
   - 'layout::Alignment' is renamed to 'layout::HorizontalAlignment'
   - MSRV is now 1.86.0
   - `Backend` now requires an associated `Error` type and `clear_region` method
+  - `Rect::inner` now takes `Into<Inset>` instead of `Margin`
   - `TestBackend` now uses `core::convert::Infallible` for error handling instead of `std::io::Error`
   - Disabling `default-features` will now disable layout cache, which can have a negative impact on performance
   - `Layout::init_cache` and `Layout::DEFAULT_CACHE_SIZE` are now only available if `layout-cache`
@@ -125,6 +126,13 @@ behavior can be achieved by using `Flex::SpaceEvenly` instead.
 - let rects = Layout::horizontal([Length(1), Length(2)]).flex(Flex::SpaceAround).split(area);
 + let rects = Layout::horizontal([Length(1), Length(2)]).flex(Flex::SpaceEvenly).split(area);
 ```
+
+### `Rect::inner` now takes `Into<Inset>` instead of `Margin`
+
+`Rect::inner` accepts any type that converts into `Inset` (for example `Inset` or `Margin`). Calls
+that relied on inference for a `Margin` conversion may now need an explicit `Margin::new` (or
+`Inset::trbl`) to make type inference succeed. This change also removes `const` support for
+`Rect::inner`, so calls in const contexts need to move to runtime code.
 
 ### `block::Title` no longer exists ([#1926])
 

--- a/ratatui-core/src/layout.rs
+++ b/ratatui-core/src/layout.rs
@@ -62,6 +62,7 @@
 //! - [`Position`] - Represents a point in the terminal coordinate system
 //! - [`Size`] - Represents dimensions (width and height)
 //! - [`Margin`] - Defines spacing around rectangular areas
+//! - [`Inset`] - Defines side-specific spacing inside a rectangle
 //! - [`Offset`] - Represents relative movement in the coordinate system
 //! - [`Spacing`] - Controls spacing or overlap between layout segments
 //!
@@ -314,6 +315,7 @@ mod alignment;
 mod constraint;
 mod direction;
 mod flex;
+mod inset;
 mod layout;
 mod margin;
 mod offset;
@@ -325,6 +327,7 @@ pub use alignment::{Alignment, HorizontalAlignment, VerticalAlignment};
 pub use constraint::Constraint;
 pub use direction::Direction;
 pub use flex::Flex;
+pub use inset::Inset;
 pub use layout::{Layout, Spacing};
 pub use margin::Margin;
 pub use offset::Offset;

--- a/ratatui-core/src/layout/inset.rs
+++ b/ratatui-core/src/layout/inset.rs
@@ -1,0 +1,189 @@
+#![warn(missing_docs)]
+use core::fmt;
+
+use crate::layout::Margin;
+
+/// Represents side-specific spacing inside rectangular areas.
+///
+/// `Inset` defines how much space to remove from each side of a rectangle. Unlike [`Margin`], which
+/// applies uniform spacing horizontally and vertically, `Inset` lets you specify independent
+/// amounts for the top, right, bottom, and left edges. The default constructor order is
+/// top-right-bottom-left (often remembered as “trbl” or “trouble”), matching the CSS spec and
+/// offering an easy clockwise mnemonic.
+///
+/// Use `Inset` when you need per-side control; choose [`Margin`](crate::layout::Margin) for the
+/// common symmetric case.
+///
+/// # Construction
+///
+/// - [`trbl`](Self::trbl) - Create a new inset with top/right/bottom/left values
+/// - [`default`](Default::default) - Create with zero inset on all sides
+/// - [`symmetric`](Self::symmetric) - Create with shared horizontal and vertical values
+/// - [`horizontal`](Self::horizontal) - Create with equal left and right values
+/// - [`vertical`](Self::vertical) - Create with equal top and bottom values
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::{Inset, Rect};
+///
+/// let inset = Inset::trbl(1, 2, 3, 4);
+/// let rect = Rect::new(0, 0, 10, 10).inner(inset);
+/// assert_eq!(rect, Rect::new(4, 1, 4, 6));
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Inset {
+    /// Space to remove from the top edge
+    pub top: u16,
+    /// Space to remove from the right edge
+    pub right: u16,
+    /// Space to remove from the bottom edge
+    pub bottom: u16,
+    /// Space to remove from the left edge
+    pub left: u16,
+}
+
+impl Inset {
+    /// Creates a new inset with explicit top/right/bottom/left values.
+    pub const fn trbl(top: u16, right: u16, bottom: u16, left: u16) -> Self {
+        Self {
+            top,
+            right,
+            bottom,
+            left,
+        }
+    }
+
+    /// Creates a new inset with shared horizontal and vertical values.
+    ///
+    /// The `horizontal` value is applied to `left` and `right`; the `vertical` value is applied to
+    /// `top` and `bottom`. Note the order is `horizontal, vertical` (x then y), opposite of the CSS
+    /// ordering; we keep a single ordering across helpers to avoid mixing patterns in code.
+    pub const fn symmetric(horizontal: u16, vertical: u16) -> Self {
+        Self {
+            right: horizontal,
+            left: horizontal,
+            top: vertical,
+            bottom: vertical,
+        }
+    }
+
+    /// Creates a new inset with equal left and right values.
+    pub const fn horizontal(horizontal: u16) -> Self {
+        Self {
+            top: 0,
+            right: horizontal,
+            bottom: 0,
+            left: horizontal,
+        }
+    }
+
+    /// Creates a new inset with equal top and bottom values.
+    pub const fn vertical(vertical: u16) -> Self {
+        Self {
+            top: vertical,
+            right: 0,
+            bottom: vertical,
+            left: 0,
+        }
+    }
+}
+
+impl fmt::Display for Inset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "t{} r{} b{} l{}",
+            self.top, self.right, self.bottom, self.left
+        )
+    }
+}
+
+impl From<Margin> for Inset {
+    fn from(margin: Margin) -> Self {
+        Self {
+            top: margin.vertical,
+            right: margin.horizontal,
+            bottom: margin.vertical,
+            left: margin.horizontal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+
+    use super::*;
+
+    #[test]
+    fn new() {
+        assert_eq!(
+            Inset::trbl(1, 2, 3, 4),
+            Inset {
+                top: 1,
+                right: 2,
+                bottom: 3,
+                left: 4
+            }
+        );
+    }
+
+    #[test]
+    fn display() {
+        assert_eq!(Inset::trbl(1, 2, 3, 4).to_string(), "t1 r2 b3 l4");
+    }
+
+    #[test]
+    fn symmetric() {
+        assert_eq!(
+            Inset::symmetric(2, 3),
+            Inset {
+                top: 3,
+                right: 2,
+                bottom: 3,
+                left: 2
+            }
+        );
+    }
+
+    #[test]
+    fn horizontal() {
+        assert_eq!(
+            Inset::horizontal(2),
+            Inset {
+                top: 0,
+                right: 2,
+                bottom: 0,
+                left: 2
+            }
+        );
+    }
+
+    #[test]
+    fn vertical() {
+        assert_eq!(
+            Inset::vertical(3),
+            Inset {
+                top: 3,
+                right: 0,
+                bottom: 3,
+                left: 0
+            }
+        );
+    }
+
+    #[test]
+    fn from_margin() {
+        assert_eq!(
+            Inset::from(Margin::new(2, 3)),
+            Inset {
+                top: 3,
+                right: 2,
+                bottom: 3,
+                left: 2
+            }
+        );
+    }
+}

--- a/ratatui-core/src/layout/margin.rs
+++ b/ratatui-core/src/layout/margin.rs
@@ -11,6 +11,9 @@ use core::fmt;
 /// margin, the space is applied to both the left and right sides. For vertical margin, the space
 /// is applied to both the top and bottom sides.
 ///
+/// Use [`Inset`](crate::layout::Inset) when you need different values for each side; `Margin`
+/// provides the symmetric case.
+///
 /// # Construction
 ///
 /// - [`new`](Self::new) - Create a new margin with horizontal and vertical spacing


### PR DESCRIPTION
- Introduce Inset for side-specific shrinking with symmetric/horizontal/vertical helpers and Margin conversion
- update Rect::inner to accept Into<Inset>

---

This is inspired by (but not a copy of) the Insets in Codex:
https://github.com/openai/codex/blob/6eeaf46ac136f6ea0352641a5daea5006195e09f/codex-rs/tui/src/render/mod.rs#L8

The differences in the implementation here are:
- Top Right Bottom Left order to match CSS order
- Changes the inner() method instead of adding a new insets() method
- Singular vs plural naming
- horizontal/vertical order to match most of Ratatui's ordering of values (usually x then y)