### PR TITLE
style(rect): use plus operator for offset

### DIFF
--- a/ratatui-core/tests/rect.rs
+++ b/ratatui-core/tests/rect.rs
@@ -72,7 +72,7 @@ fn outer() {
 #[test]
 fn offset() {
     let base = Rect::new(2, 2, 5, 3);
-    let moved = base.offset(Offset { x: 4, y: 2 });
+    let moved = base + Offset::new(4, 2);
 
     let mut buf = Buffer::empty(Rect::new(0, 0, 15, 10));
     Filled { symbol: "░" }.render(base, &mut buf);

--- a/ratatui-widgets/src/block.rs
+++ b/ratatui-widgets/src/block.rs
@@ -1951,18 +1951,18 @@ mod tests {
         let mut offset = Offset::ZERO;
         for (border_type_1, border_type_2) in iproduct!(border_types, border_types) {
             let title = format!("{border_type_1} + {border_type_2}");
-            let title_area = Rect::new(0, 0, 43, 1).offset(offset);
+            let title_area = Rect::new(0, 0, 43, 1) + offset;
             title.render(title_area, &mut buffer);
             offset.y += 1;
             for (rect_1, rect_2) in rects {
                 Block::bordered()
                     .border_type(border_type_1)
                     .merge_borders(strategy)
-                    .render(rect_1.offset(offset), &mut buffer);
+                    .render(rect_1 + offset, &mut buffer);
                 Block::bordered()
                     .border_type(border_type_2)
                     .merge_borders(strategy)
-                    .render(rect_2.offset(offset), &mut buffer);
+                    .render(rect_2 + offset, &mut buffer);
             }
             offset.y += 9;
         }


### PR DESCRIPTION
## Summary
Use `+` operator to move `Rect` by an `Offset` as added [here](https://github.com/ratatui/ratatui/pull/1596).

Includes change to use `Offset::new()` in place of `Offset { ... }`