### PR TITLE
chore: expose crossterm 0.28/0.29 feature flags in Ratatui

### DIFF
--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -28,7 +28,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 ## which allows you to set the underline color of text, the `macros` feature which provides
 ## some useful macros and `layout-cache` which speeds up layout cache calculations
 ## in `std`-enabled environments.
-default = ["crossterm_0_29", "underline-color", "all-widgets", "macros", "layout-cache"]
+default = ["crossterm", "underline-color", "all-widgets", "macros", "layout-cache"]
 #! Generally an application will only use one backend, so you should only enable one of the following features:
 ## enables the [`CrosstermBackend`](backend::CrosstermBackend) backend and adds a dependency on [`crossterm`].
 crossterm = ["std", "dep:ratatui-crossterm"]


### PR DESCRIPTION
In docs we currently say that individual versions of crossterm could be enabled like this:

```toml
ratatui = { version = "0.30.0-beta", features = ["crossterm_0_28"] }
```

However this wasn't actually possible:

```
package `x` depends on `ratatui` with feature `crossterm_0_28` but `ratatui` does not have that feature.

failed to select a version for `ratatui` which could resolve this conflict
```

This PR fixes that by exposing respective feature flags.
(Tested locally)