### PR TITLE
fix: import path for crossterm event module

### DIFF
--- a/ratatui-widgets/examples/paragraph.rs
+++ b/ratatui-widgets/examples/paragraph.rs
@@ -15,7 +15,7 @@
 //! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use color_eyre::Result;
-use crossterm::event;
+use ratatui::crossterm::event;
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Stylize};


### PR DESCRIPTION
I was trying to look at the examples and noticed an error, this was cause instead of using crossterm 0.29 I was just using ratatui::crossterm. and you can use this instead of having to include a whole new dependency this just make the whole thing more user friendly and work with two dependencies instead of three!