### PR TITLE
fix: Fix the dependency on time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ strum = { version = "0.27", default-features = false, features = ["derive"] }
 termion = "4"
 termwiz = "0.23"
 thiserror = { version = "2", default-features = false }
-time = { version = "0.3", default-features = false }
+time = { version = "0.3.37", default-features = false }
 tokio = "1"
 tokio-stream = "0.1"
 tracing = "0.1"


### PR DESCRIPTION
ratatui-widgets uses time's Month::length(), which requires time-0.3.37 or later.
