### PR TITLE
fix(buffer): diff for trailing cells when only style changes

### DIFF
--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -539,7 +539,13 @@ impl Buffer {
                                 }
                                 let prev_trailing = &previous_buffer[j];
                                 let next_trailing = &next_buffer[j];
-                                if prev_trailing != next_trailing {
+                                // Only emit update if the symbol has changed.
+                                // The style of hidden trailing cells is not visible, so style
+                                // differences alone should not trigger updates that can cause
+                                // cursor positioning issues on some terminals.
+                                if next_trailing.diff_option != CellDiffOption::Skip
+                                    && prev_trailing.symbol() != next_trailing.symbol()
+                                {
                                     let (tx, ty) = self.pos_of(j);
                                     // Push an explicit update for the trailing cell.
                                     // This is expected to be a blank cell, but we use the actual
@@ -1499,6 +1505,58 @@ mod tests {
         assert!(
             diff.iter()
                 .any(|(x, y, c)| *x == 1 && *y == 0 && c.symbol() == " ")
+        );
+    }
+
+    /// Regression test for a bug where trailing cells of wide VS16 emojis would generate
+    /// unnecessary diff updates when only the style (not the symbol) changed.
+    ///
+    /// This caused visual artifacts when:
+    /// 1. A previous widget applied a foreground color to the entire area
+    /// 2. A border with VS16 emojis (like ⚠️) was rendered on top
+    /// 3. The trailing cells had different styles but the same symbol (space)
+    ///
+    /// The fix ensures that only symbol changes trigger trailing cell updates,
+    /// not style-only changes, since the style of hidden trailing cells is not visible.
+    #[test]
+    fn diff_ignores_style_only_changes_in_trailing_cells() {
+        use crate::style::Color;
+
+        // Previous buffer: spaces with specific fg color
+        let mut prev = Buffer::empty(Rect::new(0, 0, 3, 1));
+        prev.content[0].set_symbol(" ");
+        prev.content[0].set_fg(Color::LightBlue); // <-- style A
+        prev.content[1].set_symbol(" ");
+        prev.content[1].set_fg(Color::LightBlue);
+        prev.content[2].set_symbol("x");
+
+        // Next buffer: emoji but DIFFERENT style on main cell,
+        // trailing cell has same symbol but different style
+        let mut next = Buffer::empty(Rect::new(0, 0, 3, 1));
+        next.content[0].set_symbol("⚠️"); // emoji symbol
+        next.content[0].set_fg(Color::Reset); // <-- style B (DIFFERENT from prev!)
+        next.content[1].set_symbol(" "); // same symbol (space), trailing cell (hidden by emoji)
+        next.content[1].set_fg(Color::Reset);
+        next.content[2].set_symbol("x");
+
+        let diff = prev.diff(&next);
+
+        // The first cell (0,0) SHOULD be in the diff because the symbol changed
+        assert!(
+            diff.iter().any(|(x, y, _)| *x == 0 && *y == 0),
+            "Diff should include first cell (0,0) because the symbol changed"
+        );
+
+        // The diff should NOT contain an update for the trailing cell (1, 0)
+        // because the symbol is the same (space) - only the style changed,
+        // and the style of a hidden trailing cell is not visible.
+        assert!(
+            !diff.iter().any(|(x, y, _)| *x == 1 && *y == 0),
+            "Diff should not include trailing cell (1,0) when only style changed. \
+             Found updates: {:?}",
+            diff.iter()
+                .map(|(x, y, c)| (x, y, c.symbol(), c.fg))
+                .collect::<Vec<_>>()
         );
     }
 }


### PR DESCRIPTION
this PR closes #2307 by preventing unnecessary diff updates for trailing cells when only style changes.

This PR was generated by Claude, and validated by me.

## Summary

This PR fixes a visual artifact bug where block borders would appear offset when rendered over a widget that had a foreground color style applied to the entire area.

## The Fix

```diff
- if !next_trailing.skip && prev_trailing != next_trailing {
+ // Only emit update if the SYMBOL changed, not just the style.
+ // The style of hidden trailing cells is not visible, so style
+ // differences alone should not trigger updates that can cause
+ // cursor positioning issues on some terminals.
+ if !next_trailing.skip && prev_trailing.symbol() != next_trailing.symbol() {
```

This aligns the code with the documented intent: only emit updates when the **symbol** (visible content) changes, not when only the style changes.

## Changes

| File | Change |
|------|--------|
| `ratatui-core/src/buffer/buffer.rs:526-530` | Compare only symbol, not full cell |
| `ratatui-core/src/buffer/buffer.rs:1376-1425` | Add regression test |

## Test Added

```rust
#[test]
fn diff_ignores_style_only_changes_in_trailing_cells() {
    // Verifies that trailing cells with same symbol but different style
    // do NOT generate diff updates
}
```

## Why This Is Safe

1. **Trailing cells are hidden** - they are visually covered by the wide character
2. **Style is invisible** - the fg/bg color of a hidden cell has no visual effect
3. **Symbol changes still trigger updates** - if the symbol changes (e.g., from `" "` to `"x"`), the update is still emitted
4. **Aligns with documented intent** - the original comment says "non-blank content", not "different style"

## Related

- The existing test `diff_clears_trailing_cell_for_wide_grapheme` verifies that symbol changes DO trigger updates
- This fix complements that behavior by ensuring style-only changes do NOT trigger updates
