### PR TITLE
docs: Add Documentation on the Map Projection / CRS

### DIFF
--- a/ratatui-widgets/src/canvas/map.rs
+++ b/ratatui-widgets/src/canvas/map.rs
@@ -31,7 +31,7 @@ impl MapResolution {
     }
 }
 
-/// A world map. It represents the world using the EPSG:4326 coordinate reference system.
+/// A world map. It represents the world using the [EPSG:4326 coordinate reference system](https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset).
 ///
 /// A world map can be rendered with different [resolutions](MapResolution) and [colors](Color).
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]


### PR DESCRIPTION
Currently the `Map` struct in ratatui does not specify what Projection/[Coordinate Reference System](https://en.wikipedia.org/wiki/Spatial_reference_system) it uses. 

If the user wants to plot geospatial data on the ratatui map, they may need to reproject it if they are using a different CRS. In order to reproject it you need to know the spatial projection / crs of the original map.

If you download the coastline dataset that is called out in the map resolution array here, 
https://github.com/ratatui/ratatui/blob/1e0ab0c54935c27a9729e7a1c4a918d3e5a10c21/ratatui-widgets/src/canvas/world.rs#L1

it links to gnuplot which in turn appears to be sourcing the coastline data from the coastline dataset on this page: https://www.naturalearthdata.com/downloads/110m-physical-vectors/ 

If you introspect its metadata, you will see that it is using EPSG:4326

```
gdalsrsinfo ne_110m_coastline.shp

PROJ.4 : +proj=longlat +datum=WGS84 +no_defs

OGC WKT2:2019 :
GEOGCRS["WGS 84",
    DATUM["World Geodetic System 1984",
        ELLIPSOID["WGS 84",6378137,298.257223563,
            LENGTHUNIT["metre",1]]],
    PRIMEM["Greenwich",0,
        ANGLEUNIT["degree",0.0174532925199433]],
    CS[ellipsoidal,2],
        AXIS["latitude",north,
            ORDER[1],
            ANGLEUNIT["degree",0.0174532925199433]],
        AXIS["longitude",east,
            ORDER[2],
            ANGLEUNIT["degree",0.0174532925199433]],
    ID["EPSG",4326]]
```

There is a lot of complicated details about CRS info vs datum but I think EPSG:4326 is the proper way to call this out. 

## Context

I created a simple TUI with ratatui that plots a special geospatial data format to the terminal: https://github.com/C-Loftus/fgbdump  and wanted to add this CRS info to the docs so other developers using the map might have clarity on how to represent their geospatial data.