### PR TITLE
chore: Remove `@` sign from github release and PR

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,3 +3,7 @@ changelog_path = "./CHANGELOG.md"
 changelog_config = "cliff.toml"
 release_always = false
 semver_check = false
+
+git_release_body = """
+{{ changelog | replace(from=" by @", to=" by ") }}
+"""


### PR DESCRIPTION
This PR removes the `@` for GitHub usernames in the autogenerated PR body by `release-plz`.

```tera
{{ changelog | replace(from=" by @", to=" by ") }}
```

The motivation behind this is that GitHub mentions in PR descriptions trigger notifications for every contributor for every release because their username is part of the changelog.

With this change, in GitHub PR descriptions the changelog will change like so:

**Before**

```
1dc18bf (calendar) Add width and height functions by @joshka in #2198
```

**After**

```
1dc18bf (calendar) Add width and height functions by joshka in #2198
```

Ideally this would be implemented using backticks (`@joshka` does not trigger a notification), but tera doesn't support regex replacements, so this is the simplest solution for now.