### PR TITLE
chore: escape username using backticks in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -34,7 +34,7 @@ body = """
 {% macro commit(commit) -%}
 - [{{ commit.id | truncate(length=7, end="") }}]({{ "https://github.com/ratatui/ratatui/commit/" ~ commit.id }}) \
   *({{commit.scope | default(value = "uncategorized") | lower }})* {{ commit.message | upper_first | trim }}\
-  {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}\
+  {% if commit.remote.username %} by `@{{ commit.remote.username }}`{%- endif -%}\
   {% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}){%- endif %}\
 {%- if commit.breaking %} [**breaking**]{% endif %}
 {%- if commit.body %}\n\n{{ commit.body | indent(prefix="  > ", first=true, blank=true) }}


### PR DESCRIPTION
This PR escapes GitHub usernames with backticks for the changelog generated by `git-cliff`:

```tera
  {% if commit.remote.username %} by `@{{ commit.remote.username }}`{%- endif -%}\
```

The motivation behind this is that GitHub mentions in PR descriptions trigger notifications for every contributor for every release because their username is part of the changelog.

With this change, in GitHub PR descriptions the changelog will change like so:

**Before**

```
1dc18bf (calendar) Add width and height functions by @joshka in #2198
```

**After**

```
1dc18bf (calendar) Add width and height functions by `@joshka` in #2198
```

