### PR TITLE
fix: allow ratatui-widgets to be used without default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ ratatui-crossterm = { path = "ratatui-crossterm", version = "0.1.0" }
 ratatui-macros = { path = "ratatui-macros", version = "0.7.0" }
 ratatui-termion = { path = "ratatui-termion", version = "0.1.0" }
 ratatui-termwiz = { path = "ratatui-termwiz", version = "0.1.0" }
-ratatui-widgets = { path = "ratatui-widgets", version = "0.3.0" }
+ratatui-widgets = { path = "ratatui-widgets", version = "0.3.0", default-features = false }
 rstest = "0.26"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -24,7 +24,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["all-widgets"]
 
 ## enables std
-std = ["time/local-offset"]
+std = ["time?/local-offset"]
 
 ## enables serialization and deserialization of style and color types using the [`serde`] crate.
 ## This is useful if you want to save themes to a file.


### PR DESCRIPTION
Previously, ratatui-widgets was always included with default features.
Also, the `std` feature would always enable the `time` crate.

Fixing this gets rid of a few crates: `deranged`, `num-conv`, `time-core`, `time`:
<img width="1719" height="392" alt="image" src="https://github.com/user-attachments/assets/e9fe2ce8-9b0c-4f83-a8ef-2464abceb4e2" />
