### PR TITLE
chore: Remove `@` sign from github release and PR

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,3 +3,7 @@ changelog_path = "./CHANGELOG.md"
 changelog_config = "cliff.toml"
 release_always = false
 semver_check = false
+
+git_release_body = """
+{{ changelog | replace(from=" by @", to=" by ") }}
+"""


### PR DESCRIPTION
Previous PR (https://github.com/ratatui/ratatui/pull/2336) didn't solve the problem, and everyone still seems to be getting notifications (e.g. https://github.com/ratatui/ratatui/pull/2348). 

This PR removes the `@` for GitHub usernames in the autogenerated PR body by `release-plz`.

```tera
{{ changelog | replace(from=" by @", to=" by ") }}
```

The motivation behind this is that GitHub mentions in PR descriptions trigger notifications for every contributor for every release because their username is part of the changelog.

With this change, in GitHub PR descriptions the changelog will change like so:

**Before**

```
1dc18bf (calendar) Add width and height functions by @joshka in #2198
```

**After**

```
1dc18bf (calendar) Add width and height functions by joshka in #2198
```