### PR TITLE
fix: Clear - index outside of buffer

### DIFF
--- a/ratatui-widgets/src/clear.rs
+++ b/ratatui-widgets/src/clear.rs
@@ -75,11 +75,20 @@ mod tests {
     }
 
     #[test]
-    fn render_out_of_bounds() {
+    fn render_partially_out_of_bounds() {
         let mut buffer = Buffer::with_lines(["xxxxxxxxxxxxxxx"; 7]);
         let clear = Clear;
         clear.render(Rect::new(2, 0, 100, 100), &mut buffer);
         let expected = Buffer::with_lines(["xx             "; 7]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn render_fully_out_of_bounds() {
+        let mut buffer = Buffer::with_lines(["xxxxxxxxxxxxxxx"; 7]);
+        let clear = Clear;
+        clear.render(Rect::new(100, 0, 100, 100), &mut buffer);
+        let expected = Buffer::with_lines(["xxxxxxxxxxxxxxx"; 7]);
         assert_eq!(buffer, expected);
     }
 }


### PR DESCRIPTION
If Clear area is at least partially outside of buffer, panic "index outside of buffer" happens on Widget::render

<details>

<summary>Demo source code</summary>

```rs
use crossterm::event::{self, Event, KeyModifiers};
use ratatui::{
    layout::Rect,
    text::Line,
    widgets::{Block, Borders, Clear, Paragraph},
    DefaultTerminal, Frame,
};
use std::iter;

fn main() {
    ratatui::run(app);
}

fn app(terminal: &mut DefaultTerminal) {
    loop {
        if let Event::Key(key_event) = event::read().expect("failed to read event") {
            if key_event.kind.is_press()
                && key_event.modifiers.contains(KeyModifiers::CONTROL)
                && key_event.code.is_char('c')
            {
                break;
            }
        }
        terminal.draw(render).expect("failed to draw frame");
    }
}

fn render(frame: &mut Frame) {
    {
        let width = frame.area().width;
        let area = Rect::new(0, 0, width, 10);
        let line = Line::from("W".repeat(area.width as usize));
        let lines: Vec<Line> = iter::repeat_n(line, area.height as usize).collect();
        frame.render_widget(Paragraph::new(lines), area);
    }
    {
        let area = Rect::new(50, 2, 20, 5);
        let block = Block::default()
            .title_top(Line::from("Popup-with-Clear").centered())
            .borders(Borders::ALL);
        let lines = vec![
            Line::from("one"),
            Line::from("double"),
            Line::from("quadruple"),
        ];
        frame.render_widget(Clear, area);
        frame.render_widget(Paragraph::new(lines).block(block).centered(), area);
    }
    {
        let area = Rect::new(80, 2, 20, 5);
        let block = Block::default()
            .title_top(Line::from("Popup").centered())
            .borders(Borders::ALL);
        let lines = vec![
            Line::from("one"),
            Line::from("double"),
            Line::from("quadruple"),
        ];
        frame.render_widget(Paragraph::new(lines).block(block).centered(), area);
    }
}
```

</details>

Before the fix:

https://github.com/user-attachments/assets/cebae1df-87b2-48ae-9456-7ad8cb72035c

After the fix:

https://github.com/user-attachments/assets/9e0170f3-9c71-4a28-96b3-3f4b7db8ed37

