### PR TITLE
feat(core): implement from slice for line and text (#2279)

### DIFF
--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -1045,11 +1045,7 @@ mod tests {
 
     #[test]
     fn from_slice_of_strs() {
-        let slice = [
-            "Hello",
-            "world!",
-            "Extra",
-        ];
+        let slice = ["Hello", "world!", "Extra"];
         let line = Line::from(&slice[0..2]);
         let line2 = Line::from(&slice[1..]);
         assert_eq!(line.spans, vec![Span::from("Hello"), Span::from("world!")]);

--- a/ratatui-core/src/text/text.rs
+++ b/ratatui-core/src/text/text.rs
@@ -928,11 +928,7 @@ mod tests {
 
     #[test]
     fn from_slice_of_strs() {
-        let slice = [
-            "Hello",
-            "world!",
-            "Extra",
-        ];
+        let slice = ["Hello", "world!", "Extra"];
         let text = Text::from(&slice[0..1]);
         let text2 = Text::from(&slice[1..]);
         assert_eq!(text.lines, [Line::from("Hello")]);


### PR DESCRIPTION
This PR adds the following implementations of the From trait for Line and Text structs:

- Implements From<&[T]> where T is Into\<Span> for Line, allowing using of slices to construct Lines.
- Implements From<&[T]> where T is Into\<Line> for Text, allowing using of slices of various types to construct Texts.

This should close issue #2279 too.