### PR TITLE
ci: align cliff.toml with Keep a Changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -25,7 +25,7 @@ body = """
 ## [unreleased]
 {% else -%}
 {%- if package -%} {# release-plz specific variable #}
-## {{ package }} - [{{ version }}]({{ release_link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}+{{ package }}]({{ release_link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {%- else -%}
 ## [{{ version }}]({{ self::remote_url() }}/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {%- endif %}


### PR DESCRIPTION
`release-plz` assumes that `CHANGELOG.md` follows the Keep a Changelog format.

When rendering the release PR body, it computes the new changelog entries for each package, inserts them into the workspace-level `CHANGELOG.md`, and then retrieves the latest changelog section per package during this step:

https://github.com/release-plz/release-plz/blob/ede5cd2b73f68e271ec083602dc5acb0d9692345/crates/release_plz_core/src/command/update/packages_update.rs#L98

However, the current `cliff.toml` configuration in Ratatui does not strictly follow the Keep a Changelog format. As a result, `release-plz` fails to correctly identify the latest changelog entries, and previously released sections can end up being
embedded into the release PR body.

This change updates `cliff.toml` to align with the Keep a Changelog format, so that `release-plz` can reliably extract only the newly added changelog entries for each release. This is achieved by encoding the package name as build metadata in the generated changelog entries.

Closes #2354 .