### PR TITLE
fix: text hidden style is not working

### DIFF
--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -834,16 +834,18 @@ mod tests {
         #[case] from: Modifier,
         #[case] to: Modifier,
         #[case] expected_attributes: &[CrosstermAttribute],
-    ) {
+    ) -> io::Result<()> {
         let mut actual = Vec::new();
-        ModifierDiff { from, to }.queue(&mut actual).unwrap();
+        ModifierDiff { from, to }.queue(&mut actual)?;
 
         let mut expected = Vec::new();
         for attribute in expected_attributes {
-            queue!(&mut expected, SetAttribute(*attribute)).unwrap();
+            queue!(&mut expected, SetAttribute(*attribute))?;
         }
 
         assert_eq!(actual, expected);
+
+        Ok(())
     }
 
     mod modifier {


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/3724, see https://github.com/sxyazi/yazi/issues/3724#issuecomment-3970129744 for a reproducer.

This PR adds the missing `Modifier::HIDDEN` style and introduces a `queue_modifier_diff` to test `ModifierDiff::queue()`.

It also fixes a bug where `CrosstermAttribute::Bold` and `CrosstermAttribute::Dim` would be emitted twice when resetting intensity. For example:

```rust
#[case(Modifier::DIM, Modifier::BOLD, &[CrosstermAttribute::NormalIntensity, CrosstermAttribute::Bold])]
```

would become:

```rust
#[case(Modifier::DIM, Modifier::BOLD, &[CrosstermAttribute::NormalIntensity, CrosstermAttribute::Bold, CrosstermAttribute::Bold])]
```