### PR TITLE
feat: add `impl From<u16>` for `Padding` and `Margin`

### DIFF
--- a/ratatui-core/src/layout/margin.rs
+++ b/ratatui-core/src/layout/margin.rs
@@ -49,6 +49,12 @@ impl Margin {
     }
 }
 
+impl From<u16> for Margin {
+    fn from(value: u16) -> Self {
+        Self::new(value, value)
+    }
+}
+
 impl fmt::Display for Margin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}x{}", self.horizontal, self.vertical)
@@ -73,6 +79,18 @@ mod tests {
             Margin {
                 horizontal: 1,
                 vertical: 2
+            }
+        );
+    }
+
+    #[test]
+    fn from_u16() {
+        let m: Margin = 5_u16.into();
+        assert_eq!(
+            m,
+            Margin {
+                horizontal: 5,
+                vertical: 5
             }
         );
     }

--- a/ratatui-widgets/src/block/padding.rs
+++ b/ratatui-widgets/src/block/padding.rs
@@ -159,6 +159,12 @@ impl Padding {
     }
 }
 
+impl From<u16> for Padding {
+    fn from(value: u16) -> Self {
+        Self::uniform(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,5 +207,11 @@ mod tests {
         const _RIGHT: Padding = Padding::right(1);
         const _TOP: Padding = Padding::top(1);
         const _BOTTOM: Padding = Padding::bottom(1);
+    }
+
+    #[test]
+    fn from_u16() {
+        let m: Padding = 5_u16.into();
+        assert_eq!(m, Padding::uniform(5));
     }
 }


### PR DESCRIPTION
cc: @orhun 

PS: I noticed that there's a discrepancy between the methods of `Padding` and `Margin`. If its okay, i can write a PR that adds similar methods (`uniform`, `vertical` and `horizontal`) to `Margin` as well.