### PR TITLE
docs: improve terminal and setup docs for app authors

### DIFF
--- a/ratatui-core/README.md
+++ b/ratatui-core/README.md
@@ -11,15 +11,22 @@
 providing the essential building blocks for creating rich terminal user interfaces in Rust.
 
 [ratatui]: https://github.com/ratatui/ratatui
-<!-- markdownlint-disable-next-line heading-increment -->
-### Why `ratatui-core`?
 
-The `ratatui-core` crate is split from the main [`ratatui`](https://crates.io/crates/ratatui) crate
-to offer better stability for widget library authors. Widget libraries should generally depend
-on `ratatui-core`, benefiting from a stable API and reducing the need for frequent updates.
+## Why `ratatui-core`?
 
-Applications, on the other hand, should depend on the main `ratatui` crate, which includes
-built-in widgets and additional features.
+The `ratatui-core` crate is split from the main [`ratatui`](https://crates.io/crates/ratatui)
+crate to offer better stability for widget library authors and advanced integrations. Widget
+libraries should generally depend on `ratatui-core`, benefiting from a stable API and reducing
+the need for frequent updates.
+
+Most applications, on the other hand, should depend on the main `ratatui` crate, which
+includes built-in widgets, backend re-exports, and higher-level setup helpers.
+
+In practice:
+
+- Use [`ratatui`] to build applications.
+- Use `ratatui-core` to implement widgets, backend integrations, or other code that needs the
+  core rendering and layout contracts directly.
 
 ## Installation
 
@@ -38,15 +45,14 @@ foundational types and traits that other crates in the workspace depend on.
 **When to use `ratatui-core`:**
 
 - Building widget libraries that implement [`Widget`] or [`StatefulWidget`]
-- Creating lightweight applications that don't need built-in widgets
+- Building custom integrations on top of Ratatui's core rendering contracts
 - You want minimal dependencies and faster compilation times
 - You need maximum API stability (core types change less frequently)
 
 **When to use the main [`ratatui`] crate:**
 
-- Building applications that use built-in widgets
-- You want convenience and don't mind slightly longer compilation times
-- You need backend implementations and terminal management utilities
+- Building applications
+- You want built-in widgets, backend re-exports, and setup helpers such as `ratatui::run`
 
 For detailed information about the workspace organization, see [ARCHITECTURE.md].
 

--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -321,7 +321,10 @@ pub trait Backend {
     /// syscall, and the user is also most likely to need columns and rows along with pixel size.
     fn window_size(&mut self) -> Result<WindowSize, Self::Error>;
 
-    /// Flush any buffered content to the terminal screen.
+    /// Flush any backend-buffered output to the terminal screen.
+    ///
+    /// This is distinct from [`Terminal::flush`](crate::terminal::Terminal::flush), which computes
+    /// a diff between Ratatui's screen buffers and sends draw commands to the backend.
     fn flush(&mut self) -> Result<(), Self::Error>;
 
     /// Scroll a region of the screen upwards, where a region is specified by a (half-open) range

--- a/ratatui-core/src/lib.rs
+++ b/ratatui-core/src/lib.rs
@@ -9,8 +9,8 @@
 //! providing the essential building blocks for creating rich terminal user interfaces in Rust.
 //!
 //! [ratatui]: https://github.com/ratatui/ratatui
-//! <!-- markdownlint-disable-next-line heading-increment -->
-//! ## Why `ratatui-core`?
+//!
+//! # Why `ratatui-core`?
 //!
 //! The `ratatui-core` crate is split from the main [`ratatui`](https://crates.io/crates/ratatui)
 //! crate to offer better stability for widget library authors and advanced integrations. Widget

--- a/ratatui-core/src/lib.rs
+++ b/ratatui-core/src/lib.rs
@@ -12,12 +12,19 @@
 //! <!-- markdownlint-disable-next-line heading-increment -->
 //! ## Why `ratatui-core`?
 //!
-//! The `ratatui-core` crate is split from the main [`ratatui`](https://crates.io/crates/ratatui) crate
-//! to offer better stability for widget library authors. Widget libraries should generally depend
-//! on `ratatui-core`, benefiting from a stable API and reducing the need for frequent updates.
+//! The `ratatui-core` crate is split from the main [`ratatui`](https://crates.io/crates/ratatui)
+//! crate to offer better stability for widget library authors and advanced integrations. Widget
+//! libraries should generally depend on `ratatui-core`, benefiting from a stable API and reducing
+//! the need for frequent updates.
 //!
-//! Applications, on the other hand, should depend on the main `ratatui` crate, which includes
-//! built-in widgets and additional features.
+//! Most applications, on the other hand, should depend on the main `ratatui` crate, which
+//! includes built-in widgets, backend re-exports, and higher-level setup helpers.
+//!
+//! In practice:
+//!
+//! - Use [`ratatui`] to build applications.
+//! - Use `ratatui-core` to implement widgets, backend integrations, or other code that needs the
+//!   core rendering and layout contracts directly.
 //!
 //! # Installation
 //!
@@ -36,15 +43,14 @@
 //! **When to use `ratatui-core`:**
 //!
 //! - Building widget libraries that implement [`Widget`] or [`StatefulWidget`]
-//! - Creating lightweight applications that don't need built-in widgets
+//! - Building custom integrations on top of Ratatui's core rendering contracts
 //! - You want minimal dependencies and faster compilation times
 //! - You need maximum API stability (core types change less frequently)
 //!
 //! **When to use the main [`ratatui`] crate:**
 //!
-//! - Building applications that use built-in widgets
-//! - You want convenience and don't mind slightly longer compilation times
-//! - You need backend implementations and terminal management utilities
+//! - Building applications
+//! - You want built-in widgets, backend re-exports, and setup helpers such as `ratatui::run`
 //!
 //! For detailed information about the workspace organization, see [ARCHITECTURE.md].
 //!

--- a/ratatui-core/src/terminal.rs
+++ b/ratatui-core/src/terminal.rs
@@ -1,16 +1,25 @@
 #![deny(missing_docs)]
-//! Provides the [`Terminal`], [`Frame`] and related types.
+//! Provides the [`Terminal`], [`Frame`], [`CompletedFrame`], and [`Viewport`] types.
 //!
-//! The [`Terminal`] is the main interface of this library. It is responsible for drawing and
-//! maintaining the state of the different widgets that compose your application.
+//! This module contains Ratatui's rendering surface abstraction. [`Terminal`] ties together a
+//! backend, a viewport, and a double-buffered renderer. In a typical application you create a
+//! `Terminal`, render by calling [`Terminal::draw`] or [`Terminal::try_draw`] in a loop, and let
+//! Ratatui diff successive frames so only changed cells are sent to the backend.
 //!
-//! The [`Frame`] is a consistent view into the terminal state for rendering. It is obtained via
-//! the closure argument of [`Terminal::draw`]. It is used to render widgets to the terminal and
-//! control the cursor position.
+//! [`Frame`] is the mutable view used during one render pass. Widgets write into the current
+//! buffer through it, and cursor state for the end of the pass is requested through
+//! [`Frame::set_cursor_position`]. After rendering completes, Ratatui applies the buffer diff,
+//! updates the cursor, swaps buffers, and flushes any buffered backend output.
+//!
+//! This module focuses on rendering contracts. Process-wide terminal setup such as raw mode,
+//! alternate screen handling, and panic restoration lives in the higher-level `ratatui` crate.
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust,no_run
+//! # #![allow(unexpected_cfgs)]
+//! # #[cfg(feature = "crossterm")]
+//! # {
 //! use std::io::stdout;
 //!
 //! use ratatui::{backend::CrosstermBackend, widgets::Paragraph, Terminal};
@@ -18,10 +27,10 @@
 //! let backend = CrosstermBackend::new(stdout());
 //! let mut terminal = Terminal::new(backend)?;
 //! terminal.draw(|frame| {
-//!     let area = frame.area();
-//!     frame.render_widget(Paragraph::new("Hello world!"), area);
+//!     frame.render_widget(Paragraph::new("Hello world!"), frame.area());
 //! })?;
-//! # std::io::Result::Ok(())
+//! # }
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! [Crossterm]: https://crates.io/crates/crossterm
@@ -50,15 +59,19 @@ use crate::layout::{Position, Rect};
 
 /// An interface to interact and draw [`Frame`]s on the user's terminal.
 ///
-/// This is the main entry point for Ratatui. It is responsible for drawing and maintaining the
-/// state of the buffers, cursor and viewport.
+/// This is the main entry point for Ratatui's rendering subsystem. It owns the backend-facing
+/// render state: double buffers, viewport bookkeeping, and cursor synchronization for each render
+/// pass.
 ///
 /// If you're building a fullscreen application with the `ratatui` crate's default backend
 /// ([Crossterm]), prefer [`ratatui::run`] (or [`ratatui::init`] + [`ratatui::restore`]) over
 /// constructing `Terminal` directly. These helpers enable common terminal modes (raw mode +
 /// alternate screen) and restore them on exit and on panic.
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # #![allow(unexpected_cfgs)]
+/// # #[cfg(feature = "crossterm")]
+/// # {
 /// ratatui::run(|terminal| {
 ///     let mut should_quit = false;
 ///     while !should_quit {
@@ -70,6 +83,8 @@ use crate::layout::{Position, Rect};
 ///     }
 ///     Ok(())
 /// })?;
+/// # }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// # Typical Usage
@@ -113,9 +128,15 @@ use crate::layout::{Position, Rect};
 /// the next `draw` is treated as a full redraw.
 ///
 /// Most applications should use [`Terminal::draw`] / [`Terminal::try_draw`]. For manual rendering
-/// (primarily for tests), you can build a frame with [`Terminal::get_frame`], write diffs with
-/// [`Terminal::flush`], then call [`Terminal::swap_buffers`]. If your backend buffers output, also
-/// call [`Backend::flush`].
+/// (primarily for tests), you can build a frame with [`Terminal::get_frame`], apply the current
+/// buffer diff with [`Terminal::flush`], then call [`Terminal::swap_buffers`]. If your backend
+/// buffers output, also call [`Backend::flush`].
+///
+/// [`Terminal::flush`] only knows about Ratatui's two screen buffers. It does not know whether
+/// you have changed terminal modes or switched display surfaces (for example by leaving the
+/// alternate screen). If you call it after such a change, Ratatui may replay a diff computed for
+/// the old surface onto the new one. When you need a complete draw pass that stays synchronized
+/// with cursor updates and backend flushing, prefer [`Terminal::draw`] / [`Terminal::try_draw`].
 ///
 /// ```rust,no_run
 /// # mod ratatui {
@@ -146,22 +167,28 @@ use crate::layout::{Position, Rect};
 /// Most applications use [`Viewport::Fullscreen`], but Ratatui also supports [`Viewport::Inline`]
 /// and [`Viewport::Fixed`].
 ///
+/// Choose a viewport based on how the app should fit into the terminal:
+///
+/// - [`Viewport::Fullscreen`]: the standard TUI case where Ratatui owns the whole terminal window.
+/// - [`Viewport::Inline`]: embed the UI into a larger CLI flow with normal terminal output above
+///   it.
+/// - [`Viewport::Fixed`]: render into one region of a larger terminal layout managed elsewhere.
+///
 /// Choose a viewport at initialization time with [`Terminal::with_options`] and
 /// [`TerminalOptions`].
 ///
-/// In [`Viewport::Fullscreen`], the viewport is the entire terminal and `Frame::area` starts at
-/// (0, 0). Ratatui automatically resizes the internal buffers when the terminal size changes.
+/// `Frame::area` depends on the active viewport. In fullscreen mode it starts at (0, 0); in fixed
+/// and inline mode it may have a non-zero origin, so prefer using `frame.area()` as your root
+/// layout rectangle. The variant docs on [`Viewport`] describe each mode in more detail, and
+/// inline-specific behavior is covered in the "Inline Viewport" section below.
 ///
-/// In [`Viewport::Fixed`], the viewport is a user-provided [`Rect`] in terminal coordinates.
-/// `Frame::area` is that exact rectangle (including its `x`/`y` offset). Fixed viewports are not
-/// automatically resized; if the region should change, call [`Terminal::resize`].
-///
-/// In [`Viewport::Inline`], Ratatui draws into a rectangle anchored to where the UI started. This
-/// mode is described in more detail in the "Inline Viewport" section below.
-///
-/// ```rust,ignore
-/// use ratatui::{layout::Rect, Terminal, TerminalOptions, Viewport};
+/// ```rust,no_run
+/// # #![allow(unexpected_cfgs)]
+/// # #[cfg(feature = "crossterm")]
+/// # {
+/// use ratatui::layout::{Constraint, Layout, Rect};
 /// use ratatui::backend::CrosstermBackend;
+/// use ratatui::{Terminal, TerminalOptions, Viewport};
 ///
 /// // Fullscreen (most common):
 /// let fullscreen = Terminal::new(CrosstermBackend::new(std::io::stdout()))?;
@@ -172,28 +199,42 @@ use crate::layout::{Position, Rect};
 ///     CrosstermBackend::new(std::io::stdout()),
 ///     TerminalOptions { viewport },
 /// )?;
+///
+/// fixed.draw(|frame| {
+///     // Split the fixed viewport itself instead of assuming the viewport starts at `(0, 0)`.
+///     let [header, body] =
+///         Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(frame.area());
+///
+///     frame.render_widget("Fixed panel header", header);
+///     frame.render_widget("Render the panel body relative to frame.area()", body);
+/// })?;
+/// # }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
-/// Applications should detect terminal resizes and call [`Terminal::draw`] to redraw the
-/// application with the new size. This will automatically resize the internal buffers to match the
-/// new size for inline and fullscreen viewports. Fixed viewports are not resized automatically.
+/// Applications should redraw after terminal resizes with [`Terminal::draw`] /
+/// [`Terminal::try_draw`]. Fullscreen and inline viewports resize automatically during those render
+/// passes; fixed viewports do not.
 ///
 /// # Inline Viewport
 ///
 /// Inline mode is designed for applications that want to embed a UI into a larger CLI flow. In
-/// [`Viewport::Inline`], Ratatui anchors the viewport to the backend cursor row at initialization
-/// time and always starts drawing at column 0.
+/// [`Viewport::Inline`], Ratatui anchors the viewport to the backend cursor row and always starts
+/// drawing at column 0.
 ///
 /// To reserve vertical space for the requested height, Ratatui may append lines. When the cursor is
 /// near the bottom edge, terminals scroll; Ratatui accounts for that scrolling by shifting the
 /// computed viewport origin upward so the viewport stays fully visible.
 ///
 /// While running in inline mode, [`Terminal::insert_before`] can be used to print output above the
-/// viewport without disturbing the UI.
-/// When Ratatui is built with the `scrolling-regions` feature, `insert_before` can do this without
-/// clearing and redrawing the viewport.
+/// viewport without disturbing the UI's logical position. When Ratatui is built with the
+/// `scrolling-regions` feature, `insert_before` can do this without clearing and redrawing the
+/// viewport.
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # #![allow(unexpected_cfgs)]
+/// # #[cfg(feature = "crossterm")]
+/// # {
 /// use ratatui::{TerminalOptions, Viewport};
 ///
 /// println!("Some output above the UI");
@@ -207,6 +248,13 @@ use crate::layout::{Position, Rect};
 ///     // Render a single line of output into `buf` before the UI.
 ///     // (For example: logs, status updates, or command output.)
 /// })?;
+///
+/// terminal.draw(|frame| {
+///     // Continue rendering the inline UI relative to the inline viewport.
+///     frame.render_widget("inline ui", frame.area());
+/// })?;
+/// # }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// # More Information
@@ -331,10 +379,10 @@ where
     /// [`Terminal::draw`]. Accessing the backend can be useful for backend-specific testing and
     /// inspection (see [`Terminal::backend`]).
     backend: B,
-    /// Double-buffered render state.
+    /// Double-buffered render state for the current viewport.
     ///
-    /// [`Terminal::flush`] diffs `buffers[current]` against the other buffer to compute a minimal
-    /// set of updates to send to the backend.
+    /// [`Terminal::flush`] diffs `buffers[current]` against the other buffer to compute the next
+    /// batch of cell updates to send to the backend.
     buffers: [Buffer; 2],
     /// Index of the "current" buffer in [`Terminal::buffers`].
     ///
@@ -361,14 +409,16 @@ where
     /// For fullscreen and inline viewports this tracks the backend-reported terminal size. For
     /// fixed viewports, this tracks the user-provided fixed area.
     ///
-    /// This is used by [`Terminal::autoresize`] and is reported via [`CompletedFrame::area`].
+    /// This is used by [`Terminal::autoresize`] to detect size changes and is reported via
+    /// [`CompletedFrame::area`].
     last_known_area: Rect,
     /// Last known cursor position in terminal coordinates.
     ///
     /// This is updated when:
     ///
     /// - [`Terminal::set_cursor_position`] is called directly.
-    /// - [`Frame::set_cursor_position`] is used during [`Terminal::draw`].
+    /// - [`Frame::set_cursor_position`] is used during [`Terminal::draw`] /
+    ///   [`Terminal::try_draw`].
     /// - [`Terminal::flush`] observes a diff update (used as a proxy for the "last written" cell).
     ///
     /// Inline viewports use this during [`Terminal::resize`] to preserve the cursor's relative

--- a/ratatui-core/src/terminal.rs
+++ b/ratatui-core/src/terminal.rs
@@ -103,6 +103,10 @@ use crate::layout::{Position, Rect};
 ///    fullscreen and inline viewports during `draw`; fixed viewports require an explicit call to
 ///    [`Terminal::resize`] if you want the region to change.
 ///
+/// The normal mental model is: redraw the whole UI each pass, let Ratatui compute the diff, and
+/// treat `Frame::area` as the source of truth for where this pass can render. Most application
+/// code can stay entirely within that model.
+///
 /// # Rendering Pipeline
 ///
 /// A single call to [`Terminal::draw`] (or [`Terminal::try_draw`]) represents one render pass. In
@@ -127,16 +131,28 @@ use crate::layout::{Position, Rect};
 /// an explicit [`Terminal::resize`]), Ratatui clears the viewport and resets the previous buffer so
 /// the next `draw` is treated as a full redraw.
 ///
-/// Most applications should use [`Terminal::draw`] / [`Terminal::try_draw`]. For manual rendering
-/// (primarily for tests), you can build a frame with [`Terminal::get_frame`], apply the current
-/// buffer diff with [`Terminal::flush`], then call [`Terminal::swap_buffers`]. If your backend
-/// buffers output, also call [`Backend::flush`].
+/// If [`Terminal::try_draw`] returns an error, the render pass ends early. Depending on where the
+/// failure happened, Ratatui may have already resized internal buffers, written part of the diff,
+/// or left cursor state unapplied. In most applications, treat that error as fatal for the current
+/// terminal session and let higher-level setup code restore terminal state before continuing.
+///
+/// Most applications should use [`Terminal::draw`] / [`Terminal::try_draw`]. Manual rendering is a
+/// separate, lower-level path intended primarily for tests and specialized integrations. In that
+/// mode you build a frame with [`Terminal::get_frame`], apply the current buffer diff with
+/// [`Terminal::flush`], then call [`Terminal::swap_buffers`]. If your backend buffers output, also
+/// call [`Backend::flush`].
 ///
 /// [`Terminal::flush`] only knows about Ratatui's two screen buffers. It does not know whether
 /// you have changed terminal modes or switched display surfaces (for example by leaving the
 /// alternate screen). If you call it after such a change, Ratatui may replay a diff computed for
 /// the old surface onto the new one. When you need a complete draw pass that stays synchronized
 /// with cursor updates and backend flushing, prefer [`Terminal::draw`] / [`Terminal::try_draw`].
+///
+/// The same caution applies to direct backend mutation and direct cursor manipulation. If you
+/// write to the backend or move the cursor outside Ratatui's normal render pass, the next draw may
+/// overwrite those changes or may diff against stale assumptions. Use those escape hatches only
+/// when you intentionally manage resynchronization yourself, typically by calling
+/// [`Terminal::clear`] or performing a full render pass afterward.
 ///
 /// ```rust,no_run
 /// # mod ratatui {
@@ -216,6 +232,12 @@ use crate::layout::{Position, Rect};
 /// [`Terminal::try_draw`]. Fullscreen and inline viewports resize automatically during those render
 /// passes; fixed viewports do not.
 ///
+/// If your event loop receives a resize event, treat that event as a signal to render again rather
+/// than as a complete source of truth for layout. During a render pass, use [`Frame::area`] as the
+/// rectangle that Ratatui has actually prepared for drawing. Ratatui checks the backend's current
+/// size during `draw` / `try_draw` so layout reflects the terminal size that exists at render
+/// time, even if resize events were coalesced, missed, or arrived before your app handled them.
+///
 /// # Inline Viewport
 ///
 /// Inline mode is designed for applications that want to embed a UI into a larger CLI flow. In
@@ -262,6 +284,8 @@ use crate::layout::{Position, Rect};
 /// - Choosing a viewport: [`Terminal::with_options`], [`TerminalOptions`], and [`Viewport`]
 /// - The rendering pipeline: [`Terminal::draw`] and [`Terminal::try_draw`]
 /// - Resize handling: [`Terminal::autoresize`] and [`Terminal::resize`]
+/// - Cursor behavior: [`Frame::set_cursor_position`], [`Terminal::set_cursor_position`], and
+///   [`Terminal::show_cursor`]
 /// - Manual rendering and testing: [`Terminal::get_frame`], [`Terminal::flush`], and
 ///   [`Terminal::swap_buffers`]
 /// - Printing above an inline UI: [`Terminal::insert_before`]

--- a/ratatui-core/src/terminal.rs
+++ b/ratatui-core/src/terminal.rs
@@ -22,7 +22,9 @@
 //! # {
 //! use std::io::stdout;
 //!
-//! use ratatui::{backend::CrosstermBackend, widgets::Paragraph, Terminal};
+//! use ratatui::Terminal;
+//! use ratatui::backend::CrosstermBackend;
+//! use ratatui::widgets::Paragraph;
 //!
 //! let backend = CrosstermBackend::new(stdout());
 //! let mut terminal = Terminal::new(backend)?;
@@ -202,8 +204,8 @@ use crate::layout::{Position, Rect};
 /// # #![allow(unexpected_cfgs)]
 /// # #[cfg(feature = "crossterm")]
 /// # {
-/// use ratatui::layout::{Constraint, Layout, Rect};
 /// use ratatui::backend::CrosstermBackend;
+/// use ratatui::layout::{Constraint, Layout, Rect};
 /// use ratatui::{Terminal, TerminalOptions, Viewport};
 ///
 /// // Fullscreen (most common):

--- a/ratatui-core/src/terminal/backend.rs
+++ b/ratatui-core/src/terminal/backend.rs
@@ -6,8 +6,11 @@ impl<B: Backend> Terminal<B> {
     /// Returns a shared reference to the backend.
     ///
     /// This is primarily useful for backend-specific inspection in tests (e.g. reading
-    /// [`TestBackend`]'s buffer). Most applications should interact with the terminal via
-    /// [`Terminal::draw`] rather than calling backend methods directly.
+    /// [`TestBackend`]'s buffer) or for backend-specific APIs that Ratatui does not model.
+    ///
+    /// Reading from the backend does not desynchronize Ratatui, but values observed here may lag
+    /// behind the current render callback because Ratatui does not apply a frame to the backend
+    /// until the end of [`Terminal::draw`] / [`Terminal::try_draw`].
     ///
     /// [`TestBackend`]: crate::backend::TestBackend
     pub const fn backend(&self) -> &B {
@@ -17,20 +20,31 @@ impl<B: Backend> Terminal<B> {
     /// Returns a mutable reference to the backend.
     ///
     /// This is an advanced escape hatch. Mutating the backend directly can desynchronize Ratatui's
-    /// internal buffers from what's on-screen; if you do this, you may need to call
-    /// [`Terminal::clear`] to force a full redraw.
+    /// internal buffers, cursor tracking, or viewport assumptions from what's on-screen. If you do
+    /// this, call [`Terminal::clear`] or perform a full draw pass before relying on Ratatui's view
+    /// of the terminal again.
+    ///
+    /// [`Terminal::clear`]: crate::terminal::Terminal::clear
+    /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+    /// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
     pub const fn backend_mut(&mut self) -> &mut B {
         &mut self.backend
     }
 
     /// Queries the real size of the backend.
     ///
-    /// This returns the size of the underlying terminal. The current renderable area depends on
-    /// the configured [`Viewport`]; use [`Frame::area`] inside [`Terminal::draw`] if you want the
-    /// area you should render into.
+    /// This returns the backend's current terminal size and does not update Ratatui's internal
+    /// viewport bookkeeping by itself. The current renderable area depends on the configured
+    /// [`Viewport`]; use [`Frame::area`] inside [`Terminal::draw`] / [`Terminal::try_draw`] if you
+    /// want the area you should render into for the current pass.
+    ///
+    /// To make Ratatui observe backend size changes for fullscreen or inline viewports, see
+    /// [`Terminal::autoresize`].
     ///
     /// [`Frame::area`]: crate::terminal::Frame::area
+    /// [`Terminal::autoresize`]: crate::terminal::Terminal::autoresize
     /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+    /// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
     /// [`Viewport`]: crate::terminal::Viewport
     pub fn size(&self) -> Result<Size, B::Error> {
         self.backend.size()

--- a/ratatui-core/src/terminal/backend.rs
+++ b/ratatui-core/src/terminal/backend.rs
@@ -19,10 +19,16 @@ impl<B: Backend> Terminal<B> {
 
     /// Returns a mutable reference to the backend.
     ///
-    /// This is an advanced escape hatch. Mutating the backend directly can desynchronize Ratatui's
-    /// internal buffers, cursor tracking, or viewport assumptions from what's on-screen. If you do
-    /// this, call [`Terminal::clear`] or perform a full draw pass before relying on Ratatui's view
-    /// of the terminal again.
+    /// This is an advanced escape hatch. Normal applications should render through
+    /// [`Terminal::draw`] / [`Terminal::try_draw`] instead of mutating the backend directly.
+    ///
+    /// Use this when integrating with backend-specific APIs that Ratatui does not model, or when
+    /// tests need direct control over backend state.
+    ///
+    /// Mutating the backend directly can desynchronize Ratatui's internal buffers, cursor
+    /// tracking, or viewport assumptions from what's on-screen. If you do this, call
+    /// [`Terminal::clear`] or perform a full draw pass before relying on Ratatui's view of the
+    /// terminal again.
     ///
     /// [`Terminal::clear`]: crate::terminal::Terminal::clear
     /// [`Terminal::draw`]: crate::terminal::Terminal::draw

--- a/ratatui-core/src/terminal/buffers.rs
+++ b/ratatui-core/src/terminal/buffers.rs
@@ -10,9 +10,15 @@ impl<B: Backend> Terminal<B> {
     /// exposes the frame construction step used by [`Terminal::try_draw`] so tests and advanced
     /// callers can render without running the full draw pipeline.
     ///
+    /// This is primarily useful for tests, backend adapters, and specialized integrations that
+    /// intentionally manage presentation themselves.
+    ///
     /// Unlike `draw` / `try_draw`, this does not call [`Terminal::autoresize`], does not write
     /// updates to the backend, and does not apply any cursor changes. After rendering, you
     /// typically call [`Terminal::flush`], [`Terminal::swap_buffers`], and [`Backend::flush`].
+    ///
+    /// For the full render-pass behavior that also handles resizing, cursor updates, buffer
+    /// swapping, and backend flushing, see [`Terminal::draw`] and [`Terminal::try_draw`].
     ///
     /// The returned `Frame` mutably borrows the current buffer, so it must be dropped before you
     /// can call methods like [`Terminal::flush`]. The example below uses a scope to make that
@@ -57,15 +63,28 @@ impl<B: Backend> Terminal<B> {
     /// This is the buffer that the next [`Frame`] will render into (see [`Terminal::get_frame`]).
     /// Most applications should render inside [`Terminal::draw`] and access the buffer via
     /// [`Frame::buffer_mut`] instead.
+    ///
+    /// Mutating this buffer does not update the backend immediately. The changes become visible
+    /// only after a later [`Terminal::flush`] or full draw pass applies the diff.
     pub const fn current_buffer_mut(&mut self) -> &mut Buffer {
         &mut self.buffers[self.current]
     }
 
-    /// Writes the current buffer to the backend using a diff against the previous buffer.
+    /// Applies the current buffer diff to the backend's active display surface.
     ///
-    /// This is one of the building blocks used by [`Terminal::draw`] / [`Terminal::try_draw`]. It
-    /// does not swap buffers or flush the backend; see [`Terminal::swap_buffers`] and
-    /// [`Backend::flush`].
+    /// This compares the current buffer with the previous buffer and passes only the changed cells
+    /// to [`Backend::draw`]. It is one of the building blocks used by [`Terminal::draw`] /
+    /// [`Terminal::try_draw`].
+    ///
+    /// This method does not swap buffers, does not update cursor visibility or position, and does
+    /// not call [`Backend::flush`]. See [`Terminal::swap_buffers`] and [`Backend::flush`].
+    ///
+    /// `Terminal::flush` only reasons about Ratatui's internal buffers. It does not know whether
+    /// the backend's display surface changed since the last render pass. For example, if you leave
+    /// the alternate screen and then call `Terminal::flush`, Ratatui may replay a diff that was
+    /// computed for the alternate screen onto the main screen. In normal applications, prefer
+    /// [`Terminal::draw`] / [`Terminal::try_draw`] unless you are intentionally managing the whole
+    /// render pipeline yourself.
     ///
     /// Implementation note: when there are updates, Ratatui records the position of the last
     /// updated cell as the "last known cursor position". Inline viewports use this to preserve the
@@ -94,8 +113,8 @@ impl<B: Backend> Terminal<B> {
     /// Clears the inactive buffer and swaps it with the current buffer.
     ///
     /// This is part of the standard rendering flow (see [`Terminal::try_draw`]). If you render
-    /// manually using [`Terminal::get_frame`] and [`Terminal::flush`], call this afterward so the
-    /// next flush can compute diffs against the correct "previous" buffer.
+    /// manually using [`Terminal::get_frame`] and [`Terminal::flush`], call this immediately
+    /// afterward so the next flush can compute diffs against the correct "previous" buffer.
     pub fn swap_buffers(&mut self) {
         self.buffers[1 - self.current].reset();
         self.current = 1 - self.current;
@@ -114,10 +133,12 @@ impl<B: Backend> Terminal<B> {
     /// the end of the visible display area, not just the viewport's rectangle. This is an
     /// implementation detail rather than a contract; do not rely on it.
     ///
-    /// This preserves the cursor position.
+    /// This preserves the backend's current cursor position.
     ///
     /// This also resets the "previous" buffer so the next [`Terminal::flush`] redraws the full
     /// viewport. [`Terminal::resize`] calls this internally.
+    ///
+    /// [`Terminal::resize`]: crate::terminal::Terminal::resize
     ///
     /// Implementation note: this uses [`ClearType::AfterCursor`] starting at the viewport origin.
     pub fn clear(&mut self) -> Result<(), B::Error> {

--- a/ratatui-core/src/terminal/buffers.rs
+++ b/ratatui-core/src/terminal/buffers.rs
@@ -6,9 +6,9 @@ use crate::terminal::{Frame, Terminal, Viewport};
 impl<B: Backend> Terminal<B> {
     /// Returns a [`Frame`] for manual rendering.
     ///
-    /// Most applications should render via [`Terminal::draw`] / [`Terminal::try_draw`]. This method
-    /// exposes the frame construction step used by [`Terminal::try_draw`] so tests and advanced
-    /// callers can render without running the full draw pipeline.
+    /// Most applications should render via [`Terminal::draw`] / [`Terminal::try_draw`]. This is an
+    /// escape hatch that exposes the frame construction step used by [`Terminal::try_draw`] so
+    /// tests and advanced callers can render without running the full draw pipeline.
     ///
     /// This is primarily useful for tests, backend adapters, and specialized integrations that
     /// intentionally manage presentation themselves.
@@ -61,11 +61,14 @@ impl<B: Backend> Terminal<B> {
     /// Gets the current buffer as a mutable reference.
     ///
     /// This is the buffer that the next [`Frame`] will render into (see [`Terminal::get_frame`]).
-    /// Most applications should render inside [`Terminal::draw`] and access the buffer via
-    /// [`Frame::buffer_mut`] instead.
+    /// This is a low-level escape hatch; normal applications should render inside
+    /// [`Terminal::draw`] and access the buffer through widgets, or through [`Frame::buffer_mut`]
+    /// when they intentionally need direct cell access during a render pass.
     ///
     /// Mutating this buffer does not update the backend immediately. The changes become visible
-    /// only after a later [`Terminal::flush`] or full draw pass applies the diff.
+    /// only after a later [`Terminal::flush`] or full draw pass applies the diff. Because this
+    /// bypasses the usual render callback structure, it is mainly useful for tests and specialized
+    /// integrations that intentionally manage presentation themselves.
     pub const fn current_buffer_mut(&mut self) -> &mut Buffer {
         &mut self.buffers[self.current]
     }

--- a/ratatui-core/src/terminal/cursor.rs
+++ b/ratatui-core/src/terminal/cursor.rs
@@ -5,11 +5,13 @@ use crate::terminal::Terminal;
 impl<B: Backend> Terminal<B> {
     /// Hides the cursor.
     ///
-    /// When using [`Terminal::draw`], prefer controlling the cursor with
-    /// [`Frame::set_cursor_position`]. Mixing the APIs can lead to surprising results.
+    /// When using [`Terminal::draw`] / [`Terminal::try_draw`], prefer controlling the cursor with
+    /// [`Frame::set_cursor_position`]. A later successful [`Terminal::draw`] /
+    /// [`Terminal::try_draw`] call may overwrite this change.
     ///
     /// [`Frame::set_cursor_position`]: crate::terminal::Frame::set_cursor_position
     /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+    /// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
     pub fn hide_cursor(&mut self) -> Result<(), B::Error> {
         self.backend.hide_cursor()?;
         self.hidden_cursor = true;
@@ -18,11 +20,13 @@ impl<B: Backend> Terminal<B> {
 
     /// Shows the cursor.
     ///
-    /// When using [`Terminal::draw`], prefer controlling the cursor with
-    /// [`Frame::set_cursor_position`]. Mixing the APIs can lead to surprising results.
+    /// When using [`Terminal::draw`] / [`Terminal::try_draw`], prefer controlling the cursor with
+    /// [`Frame::set_cursor_position`]. A later successful [`Terminal::draw`] /
+    /// [`Terminal::try_draw`] call may overwrite this change.
     ///
     /// [`Frame::set_cursor_position`]: crate::terminal::Frame::set_cursor_position
     /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+    /// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
     pub fn show_cursor(&mut self) -> Result<(), B::Error> {
         self.backend.show_cursor()?;
         self.hidden_cursor = false;
@@ -31,8 +35,8 @@ impl<B: Backend> Terminal<B> {
 
     /// Gets the current cursor position.
     ///
-    /// This is the position of the cursor after the last draw call and is returned as a tuple of
-    /// `(x, y)` coordinates.
+    /// This queries the backend for the current cursor position and returns it as an `(x, y)`
+    /// tuple.
     #[deprecated = "use `get_cursor_position()` instead which returns `Result<Position>`"]
     pub fn get_cursor(&mut self) -> Result<(u16, u16), B::Error> {
         let Position { x, y } = self.get_cursor_position()?;
@@ -47,13 +51,15 @@ impl<B: Backend> Terminal<B> {
 
     /// Gets the current cursor position.
     ///
-    /// This queries the backend for the current cursor position.
+    /// This queries the backend for the current cursor position. It is not limited to Ratatui's
+    /// last render pass, so direct backend mutations may also affect the returned value.
     ///
-    /// When using [`Terminal::draw`], prefer controlling the cursor with
+    /// When using [`Terminal::draw`] / [`Terminal::try_draw`], prefer controlling the cursor with
     /// [`Frame::set_cursor_position`]. For direct control, see [`Terminal::set_cursor_position`].
     ///
     /// [`Frame::set_cursor_position`]: crate::terminal::Frame::set_cursor_position
     /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+    /// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
     pub fn get_cursor_position(&mut self) -> Result<Position, B::Error> {
         self.backend.get_cursor_position()
     }
@@ -63,11 +69,14 @@ impl<B: Backend> Terminal<B> {
     /// This updates the backend cursor and Ratatui's internal cursor tracking. Inline viewports
     /// use that tracking when recomputing the viewport on resize.
     ///
-    /// When using [`Terminal::draw`], consider using [`Frame::set_cursor_position`] instead so the
-    /// cursor is updated as part of the normal rendering flow.
+    /// When using [`Terminal::draw`] / [`Terminal::try_draw`], consider using
+    /// [`Frame::set_cursor_position`] instead so the cursor is updated as part of the normal
+    /// rendering flow. A later successful
+    /// [`Terminal::draw`] / [`Terminal::try_draw`] call may overwrite a direct cursor move.
     ///
     /// [`Frame::set_cursor_position`]: crate::terminal::Frame::set_cursor_position
     /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+    /// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
     pub fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), B::Error> {
         let position = position.into();
         self.backend.set_cursor_position(position)?;

--- a/ratatui-core/src/terminal/frame.rs
+++ b/ratatui-core/src/terminal/frame.rs
@@ -4,21 +4,26 @@ use crate::widgets::{StatefulWidget, Widget};
 
 /// A consistent view into the terminal state for rendering a single frame.
 ///
-/// This is obtained via the closure argument of [`Terminal::draw`]. It is used to render widgets
-/// to the terminal and control the cursor position.
+/// You usually get a `Frame` from the closure argument of [`Terminal::draw`] /
+/// [`Terminal::try_draw`]. For manual rendering, use [`Terminal::get_frame`].
+///
+/// A `Frame` is used to render widgets into Ratatui's current buffer and request the cursor state
+/// for the end of the render pass.
 ///
 /// The changes drawn to the frame are applied only to the current [`Buffer`]. After the closure
-/// returns, the current buffer is compared to the previous buffer and only the changes are applied
-/// to the terminal. This avoids drawing redundant cells.
+/// returns, the current buffer is compared to the previous buffer and only the changed cells are
+/// sent to the backend. This avoids drawing redundant cells.
 ///
 /// [`Buffer`]: crate::buffer::Buffer
 /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+/// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
 #[derive(Debug, Hash)]
 pub struct Frame<'a> {
     /// Where should the cursor be after drawing this frame?
     ///
-    /// If `None`, the cursor is hidden and its position is controlled by the backend. If `Some((x,
-    /// y))`, the cursor is shown and placed at `(x, y)` after the call to `Terminal::draw()`.
+    /// If `None`, the cursor is hidden at the end of the render pass. If `Some((x, y))`, the
+    /// cursor is shown and placed at `(x, y)` after the frame's buffer diff has been applied to
+    /// the backend.
     pub(crate) cursor_position: Option<Position>,
 
     /// The area of the viewport
@@ -31,11 +36,16 @@ pub struct Frame<'a> {
     pub(crate) count: usize,
 }
 
-/// `CompletedFrame` represents the state of the terminal after all changes performed in the last
-/// [`Terminal::draw`] call have been applied. Therefore, it is only valid until the next call to
-/// [`Terminal::draw`].
+/// `CompletedFrame` represents the state of the terminal after the last successful
+/// [`Terminal::draw`] / [`Terminal::try_draw`] render pass has been applied. Therefore, it is only
+/// valid until the next successful draw call.
+///
+/// This lifetime follows Ratatui's double-buffering model: the next render pass swaps buffers via
+/// [`Terminal::swap_buffers`], so the previously completed buffer is no longer the current output.
 ///
 /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+/// [`Terminal::swap_buffers`]: crate::terminal::Terminal::swap_buffers
+/// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct CompletedFrame<'a> {
     /// The buffer that was used to draw the last frame.
@@ -47,24 +57,24 @@ pub struct CompletedFrame<'a> {
 }
 
 impl Frame<'_> {
-    /// The area of the current frame
+    /// Returns the area of the current frame.
     ///
     /// This is guaranteed not to change during rendering, so may be called multiple times.
     ///
-    /// If your app listens for a resize event from the backend, it should ignore the values from
-    /// the event for any calculations that are used to render the current frame and use this value
-    /// instead as this is the area of the buffer that is used to render the current frame.
+    /// If your app listens for a resize event from the backend, ignore that event's dimensions for
+    /// calculations performed during the current render callback and use this value instead. It is
+    /// the area of the buffer that is actually being rendered for this pass.
     pub const fn area(&self) -> Rect {
         self.viewport_area
     }
 
-    /// The area of the current frame
+    /// Returns the area of the current frame.
     ///
     /// This is guaranteed not to change during rendering, so may be called multiple times.
     ///
-    /// If your app listens for a resize event from the backend, it should ignore the values from
-    /// the event for any calculations that are used to render the current frame and use this value
-    /// instead as this is the area of the buffer that is used to render the current frame.
+    /// If your app listens for a resize event from the backend, ignore that event's dimensions for
+    /// calculations performed during the current render callback and use this value instead. It is
+    /// the area of the buffer that is actually being rendered for this pass.
     #[deprecated = "use `area()` instead"]
     pub const fn size(&self) -> Rect {
         self.viewport_area
@@ -75,18 +85,20 @@ impl Frame<'_> {
     /// Usually the area argument is the size of the current frame or a sub-area of the current
     /// frame (which can be obtained using [`Layout`] to split the total area).
     ///
+    /// Rendering writes directly into the current frame buffer. If multiple widgets cover the same
+    /// cells, later renders win for those cells.
+    ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// # use ratatui::{backend::TestBackend, Terminal};
+    /// ```rust
+    /// # use ratatui_core::{backend::TestBackend, terminal::Terminal};
     /// # let backend = TestBackend::new(5, 5);
     /// # let mut terminal = Terminal::new(backend).unwrap();
     /// # let mut frame = terminal.get_frame();
-    /// use ratatui::{layout::Rect, widgets::Block};
+    /// use ratatui_core::layout::Rect;
     ///
-    /// let block = Block::new();
     /// let area = Rect::new(0, 0, 5, 5);
-    /// frame.render_widget(block, area);
+    /// frame.render_widget("Hello", area);
     /// ```
     ///
     /// [`Layout`]: crate::layout::Layout
@@ -102,22 +114,32 @@ impl Frame<'_> {
     /// The last argument should be an instance of the [`StatefulWidget::State`] associated to the
     /// given [`StatefulWidget`].
     ///
+    /// Like [`Frame::render_widget`], this writes directly into the current frame buffer. The
+    /// widget owns how it interprets and mutates the provided state.
+    ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// # use ratatui::{backend::TestBackend, Terminal};
+    /// ```rust
+    /// # use ratatui_core::{backend::TestBackend, buffer::Buffer, layout::Rect, terminal::Terminal};
     /// # let backend = TestBackend::new(5, 5);
     /// # let mut terminal = Terminal::new(backend).unwrap();
     /// # let mut frame = terminal.get_frame();
-    /// use ratatui::{
-    ///     layout::Rect,
-    ///     widgets::{List, ListItem, ListState},
-    /// };
+    /// use ratatui_core::widgets::StatefulWidget;
     ///
-    /// let mut state = ListState::default().with_selected(Some(1));
-    /// let list = List::new(vec![ListItem::new("Item 1"), ListItem::new("Item 2")]);
+    /// struct DemoWidget;
+    ///
+    /// impl StatefulWidget for DemoWidget {
+    ///     type State = bool;
+    ///
+    ///     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    ///         let symbol = if *state { "Y" } else { "N" };
+    ///         buf[(area.x, area.y)].set_symbol(symbol);
+    ///     }
+    /// }
+    ///
+    /// let mut state = true;
     /// let area = Rect::new(0, 0, 5, 5);
-    /// frame.render_stateful_widget(list, area, &mut state);
+    /// frame.render_stateful_widget(DemoWidget, area, &mut state);
     /// ```
     ///
     /// [`Layout`]: crate::layout::Layout
@@ -128,8 +150,10 @@ impl Frame<'_> {
         widget.render(area, self.buffer, state);
     }
 
-    /// After drawing this frame, make the cursor visible and put it at the specified (x, y)
+    /// After this frame is rendered, make the cursor visible and put it at the specified `(x, y)`
     /// coordinates. If this method is not called, the cursor will be hidden.
+    ///
+    /// The cursor is applied after Ratatui flushes the frame's buffer diff to the backend.
     ///
     /// Note that this will interfere with calls to [`Terminal::hide_cursor`],
     /// [`Terminal::show_cursor`], and [`Terminal::set_cursor_position`]. Pick one of the APIs and
@@ -142,7 +166,7 @@ impl Frame<'_> {
         self.cursor_position = Some(position.into());
     }
 
-    /// After drawing this frame, make the cursor visible and put it at the specified (x, y)
+    /// After this frame is rendered, make the cursor visible and put it at the specified `(x, y)`
     /// coordinates. If this method is not called, the cursor will be hidden.
     ///
     /// Note that this will interfere with calls to [`Terminal::hide_cursor`],
@@ -158,6 +182,22 @@ impl Frame<'_> {
     }
 
     /// Gets the buffer that this `Frame` draws into as a mutable reference.
+    ///
+    /// This is an escape hatch for direct buffer manipulation. Prefer the widget rendering methods
+    /// when possible so layout and rendering intent stay visible at the call site.
+    ///
+    /// Changes written here are not visible on the backend until the render pass is applied by
+    /// [`Terminal::flush`] or a full [`Terminal::draw`] / [`Terminal::try_draw`] pass.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use ratatui_core::{backend::TestBackend, terminal::Terminal};
+    /// # let backend = TestBackend::new(5, 1);
+    /// # let mut terminal = Terminal::new(backend).unwrap();
+    /// # let mut frame = terminal.get_frame();
+    /// frame.buffer_mut()[(0, 0)].set_symbol("h");
+    /// ```
     pub const fn buffer_mut(&mut self) -> &mut Buffer {
         self.buffer
     }
@@ -178,8 +218,8 @@ impl Frame<'_> {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
-    /// # use ratatui::{backend::TestBackend, Terminal};
+    /// ```rust
+    /// # use ratatui_core::{backend::TestBackend, terminal::Terminal};
     /// # let backend = TestBackend::new(5, 5);
     /// # let mut terminal = Terminal::new(backend).unwrap();
     /// # let mut frame = terminal.get_frame();

--- a/ratatui-core/src/terminal/frame.rs
+++ b/ratatui-core/src/terminal/frame.rs
@@ -5,7 +5,8 @@ use crate::widgets::{StatefulWidget, Widget};
 /// A consistent view into the terminal state for rendering a single frame.
 ///
 /// You usually get a `Frame` from the closure argument of [`Terminal::draw`] /
-/// [`Terminal::try_draw`]. For manual rendering, use [`Terminal::get_frame`].
+/// [`Terminal::try_draw`]. For manual rendering, use
+/// [`Terminal::get_frame`](crate::terminal::Terminal::get_frame).
 ///
 /// A `Frame` is used to render widgets into Ratatui's current buffer and request the cursor state
 /// for the end of the render pass.
@@ -183,11 +184,16 @@ impl Frame<'_> {
 
     /// Gets the buffer that this `Frame` draws into as a mutable reference.
     ///
-    /// This is an escape hatch for direct buffer manipulation. Prefer the widget rendering methods
-    /// when possible so layout and rendering intent stay visible at the call site.
+    /// This is an escape hatch for direct buffer manipulation. Normal applications should prefer
+    /// the widget rendering methods so layout and rendering intent stay visible at the call site.
+    ///
+    /// Use this when tests, custom widgets, or specialized integrations need direct cell access
+    /// during a render pass.
     ///
     /// Changes written here are not visible on the backend until the render pass is applied by
-    /// [`Terminal::flush`] or a full [`Terminal::draw`] / [`Terminal::try_draw`] pass.
+    /// [`Terminal::flush`](crate::terminal::Terminal::flush) or a full
+    /// [`Terminal::draw`](crate::terminal::Terminal::draw) /
+    /// [`Terminal::try_draw`](crate::terminal::Terminal::try_draw) pass.
     ///
     /// # Example
     ///

--- a/ratatui-core/src/terminal/init.rs
+++ b/ratatui-core/src/terminal/init.rs
@@ -8,6 +8,8 @@ impl<B: Backend> Terminal<B> {
     /// Creates a new [`Terminal`] with the given [`Backend`] with a full screen viewport.
     ///
     /// This is a convenience for [`Terminal::with_options`] with [`Viewport::Fullscreen`].
+    /// Ratatui initializes two empty buffers sized to the backend's current screen area and treats
+    /// future backend size changes as redraw-triggering resizes during render passes.
     ///
     /// After creating a terminal, call [`Terminal::draw`] (or [`Terminal::try_draw`]) in a loop to
     /// render your UI.
@@ -62,10 +64,16 @@ impl<B: Backend> Terminal<B> {
 
     /// Creates a new [`Terminal`] with the given [`Backend`] and [`TerminalOptions`].
     ///
-    /// The viewport determines what area is exposed to widgets via [`Frame::area`]. See
-    /// [`Viewport`] for an overview of the available modes.
+    /// The viewport determines what area is exposed to widgets via [`Frame::area`] and how Ratatui
+    /// keeps its internal buffers synchronized with the backend. See [`Viewport`] for an overview
+    /// of the available modes.
+    ///
+    /// For viewport behavior after initialization, see [`Terminal::resize`] and
+    /// [`Terminal::autoresize`].
     ///
     /// [`Frame::area`]: crate::terminal::Frame::area
+    /// [`Terminal::autoresize`]: crate::terminal::Terminal::autoresize
+    /// [`Terminal::resize`]: crate::terminal::Terminal::resize
     ///
     /// After creating a terminal, call [`Terminal::draw`] (or [`Terminal::try_draw`]) in a loop to
     /// render your UI.
@@ -73,7 +81,7 @@ impl<B: Backend> Terminal<B> {
     /// Resize behavior depends on the selected viewport:
     ///
     /// - [`Viewport::Fullscreen`] and [`Viewport::Inline`] are automatically resized during
-    ///   [`Terminal::draw`] (via [`Terminal::autoresize`]).
+    ///   [`Terminal::draw`] / [`Terminal::try_draw`] (via [`Terminal::autoresize`]).
     /// - [`Viewport::Fixed`] is not automatically resized; call [`Terminal::resize`] if the region
     ///   should change.
     ///
@@ -108,8 +116,9 @@ impl<B: Backend> Terminal<B> {
     /// ```
     ///
     /// When the viewport is [`Viewport::Inline`], Ratatui anchors the viewport to the current
-    /// cursor row at initialization time (always starting at column 0). Ratatui may scroll the
-    /// terminal to make enough room for the requested height so the viewport stays fully visible.
+    /// cursor row at initialization time (always starting at column 0). Ratatui may append lines
+    /// and thereby scroll the terminal to make enough room for the requested height so the
+    /// viewport stays fully visible.
     pub fn with_options(mut backend: B, options: TerminalOptions) -> Result<Self, B::Error> {
         let area = match options.viewport {
             Viewport::Fullscreen | Viewport::Inline(_) => backend.size()?.into(),

--- a/ratatui-core/src/terminal/inline.rs
+++ b/ratatui-core/src/terminal/inline.rs
@@ -16,7 +16,8 @@ impl<B: Backend> Terminal<B> {
     ///
     /// When Ratatui is built with the `scrolling-regions` feature, this can be done without
     /// clearing and redrawing the viewport. Without `scrolling-regions`, Ratatui falls back to a
-    /// more portable approach and clears the viewport so the next [`Terminal::draw`] repaints it.
+    /// more portable approach and clears the viewport so the next [`Terminal::draw`] /
+    /// [`Terminal::try_draw`] repaints it.
     ///
     /// If the viewport isn't yet at the bottom of the screen, inserted lines will push it towards
     /// the bottom. Once the viewport is at the bottom of the screen, inserted lines will scroll
@@ -383,7 +384,8 @@ impl<B: Backend> Terminal<B> {
 /// Related viewport code lives in:
 ///
 /// - [`Terminal::with_options`] (selects the viewport and computes the initial area)
-/// - [`Terminal::autoresize`] (detects backend size changes during [`Terminal::draw`])
+/// - [`Terminal::autoresize`] (detects backend size changes during [`Terminal::draw`] /
+///   [`Terminal::try_draw`])
 /// - [`Terminal::resize`] (recomputes the viewport and clears before the next draw)
 pub(crate) fn compute_inline_size<B: Backend>(
     backend: &mut B,

--- a/ratatui-core/src/terminal/render.rs
+++ b/ratatui-core/src/terminal/render.rs
@@ -27,11 +27,14 @@ impl<B: Backend> Terminal<B> {
     ///
     /// - call [`Terminal::autoresize`] if necessary
     /// - call the render callback, passing it a [`Frame`] reference to render to
-    /// - call [`Terminal::flush`] to write changes to the backend
+    /// - call [`Terminal::flush`] to apply the current buffer diff to the backend
     /// - show/hide the cursor based on [`Frame::set_cursor_position`]
     /// - call [`Terminal::swap_buffers`] to prepare for the next render pass
-    /// - call [`Backend::flush`]
+    /// - call [`Backend::flush`] to flush any buffered backend output
     /// - return a [`CompletedFrame`] with the current buffer and the area used for rendering
+    ///
+    /// If any backend step fails, the error is returned immediately and later steps in the render
+    /// pass are skipped.
     ///
     /// The [`CompletedFrame`] returned by this method can be useful for debugging or testing
     /// purposes, but it is often not used in regular applications.
@@ -111,11 +114,14 @@ impl<B: Backend> Terminal<B> {
     ///
     /// - call [`Terminal::autoresize`] if necessary
     /// - call the render callback, passing it a [`Frame`] reference to render to
-    /// - call [`Terminal::flush`] to write changes to the backend
+    /// - call [`Terminal::flush`] to apply the current buffer diff to the backend
     /// - show/hide the cursor based on [`Frame::set_cursor_position`]
     /// - call [`Terminal::swap_buffers`] to prepare for the next render pass
-    /// - call [`Backend::flush`]
+    /// - call [`Backend::flush`] to flush any buffered backend output
     /// - return a [`CompletedFrame`] with the current buffer and the area used for rendering
+    ///
+    /// If the render callback returns an error, Ratatui leaves the backend, buffers, cursor state,
+    /// and frame count unchanged.
     ///
     /// The render callback passed to `try_draw` can return any [`Result`] with an error type that
     /// can be converted into `B::Error` using the [`Into`] trait. This makes it possible to use the

--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -7,14 +7,19 @@ impl<B: Backend> Terminal<B> {
     /// Updates the Terminal so that internal buffers match the requested area.
     ///
     /// This updates the buffer size used for rendering and triggers a full clear so the next
-    /// [`Terminal::draw`] paints into a consistent area.
+    /// [`Terminal::draw`] / [`Terminal::try_draw`] paints into a consistent area.
     ///
     /// When the viewport is [`Viewport::Inline`], the `area` argument is treated as the new
     /// terminal size and the viewport origin is recomputed relative to the current cursor position.
     /// Ratatui attempts to keep the cursor at the same relative row within the viewport across
     /// resizes.
     ///
-    /// See also: [`Terminal::autoresize`] (automatic resizing during [`Terminal::draw`]).
+    /// See also: [`Terminal::autoresize`] (automatic resizing during [`Terminal::draw`] /
+    /// [`Terminal::try_draw`]).
+    ///
+    /// For [`Viewport::Fixed`] and [`Viewport::Fullscreen`], `area` becomes the new viewport area.
+    /// For [`Viewport::Inline`], `area` is interpreted as the backend's new terminal size and the
+    /// viewport origin may move to preserve the cursor's relative row within the inline UI.
     pub fn resize(&mut self, area: Rect) -> Result<(), B::Error> {
         let mut next_area = match self.viewport {
             Viewport::Inline(height) => {
@@ -48,10 +53,11 @@ impl<B: Backend> Terminal<B> {
 
     /// Queries the backend for size and resizes if it doesn't match the previous size.
     ///
-    /// This is called automatically during [`Terminal::draw`] for fullscreen and inline viewports.
-    /// Fixed viewports are not automatically resized.
+    /// This is called automatically during [`Terminal::draw`] / [`Terminal::try_draw`] for
+    /// fullscreen and inline viewports. Fixed viewports are not automatically resized.
     ///
-    /// If the size changed, this calls [`Terminal::resize`] (which clears the screen).
+    /// If the size changed, this calls [`Terminal::resize`] and therefore clears the affected
+    /// region before the next frame is rendered.
     pub fn autoresize(&mut self) -> Result<(), B::Error> {
         // fixed viewports do not get autoresized
         if matches!(self.viewport, Viewport::Fullscreen | Viewport::Inline(_)) {

--- a/ratatui-core/src/terminal/viewport.rs
+++ b/ratatui-core/src/terminal/viewport.rs
@@ -73,6 +73,7 @@ pub enum Viewport {
     ///
     /// [`Terminal::new`]: crate::terminal::Terminal::new
     /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+    /// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
     #[default]
     Fullscreen,
     /// Draw the application inline with the rest of the terminal output.
@@ -90,7 +91,11 @@ pub enum Viewport {
     /// Inline viewports always span the full terminal width.
     ///
     /// For the full inline rendering model, including output inserted above the UI, see the
-    /// "Inline Viewport" section on [`Terminal`] and [`Terminal::insert_before`].
+    /// "Inline Viewport" section on [`Terminal`](crate::terminal::Terminal) and
+    /// [`Terminal::insert_before`](crate::terminal::Terminal::insert_before).
+    ///
+    /// [`Terminal::draw`]: crate::terminal::Terminal::draw
+    /// [`Terminal::try_draw`]: crate::terminal::Terminal::try_draw
     Inline(u16),
     /// Draw into a fixed region of the terminal.
     ///

--- a/ratatui-core/src/terminal/viewport.rs
+++ b/ratatui-core/src/terminal/viewport.rs
@@ -9,16 +9,49 @@ use crate::layout::Rect;
 /// For a higher-level overview of viewports in the context of an application (including
 /// examples), see [`Terminal`].
 ///
-/// Most applications use [`Viewport::Fullscreen`]. Use [`Viewport::Inline`] when you want to embed
-/// a UI into a larger CLI flow (for example: print some text, then start an interactive UI below
-/// it). Use [`Viewport::Fixed`] when you want Ratatui to render into a specific region of the
-/// terminal.
+/// Choose a viewport based on how the Ratatui UI should fit into the terminal:
+///
+/// - [`Viewport::Fullscreen`] for the standard case: your app owns the whole terminal surface.
+/// - [`Viewport::Inline`] when the UI should live inside a larger CLI flow, with normal terminal
+///   output above it.
+/// - [`Viewport::Fixed`] when Ratatui should render into one region of a terminal layout managed
+///   elsewhere.
 ///
 /// In fullscreen mode, the viewport starts at (0, 0). In inline and fixed mode, the viewport may
 /// have a non-zero `x`/`y` origin; prefer using `Frame::area()` as your root layout rectangle.
+/// Code that assumes `(0, 0)` as the origin is therefore only correct for fullscreen viewports.
 ///
 /// See [`Terminal::with_options`] for how to select a viewport, and [`Terminal::resize`] /
 /// [`Terminal::autoresize`] for resize behavior.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # #![allow(unexpected_cfgs)]
+/// # #[cfg(feature = "crossterm")]
+/// # {
+/// use ratatui::backend::CrosstermBackend;
+/// use ratatui::layout::{Constraint, Layout, Rect};
+/// use ratatui::{Terminal, TerminalOptions, Viewport};
+///
+/// let mut terminal = Terminal::with_options(
+///     CrosstermBackend::new(std::io::stdout()),
+///     TerminalOptions {
+///         viewport: Viewport::Fixed(Rect::new(10, 5, 20, 4)),
+///     },
+/// )?;
+///
+/// terminal.draw(|frame| {
+///     // `frame.area()` is `Rect::new(10, 5, 20, 4)`, not `(0, 0, 20, 4)`.
+///     let [title, body] =
+///         Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(frame.area());
+///
+///     frame.render_widget("panel title", title);
+///     frame.render_widget("render the body relative to the fixed viewport", body);
+/// })?;
+/// # }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 ///
 /// [`Frame::area`]: crate::terminal::Frame::area
 /// [`Terminal`]: crate::terminal::Terminal
@@ -31,8 +64,10 @@ pub enum Viewport {
     ///
     /// This is the default viewport used by [`Terminal::new`].
     ///
+    /// Choose this when the Ratatui app should own the whole terminal window.
+    ///
     /// When the terminal size changes, Ratatui automatically resizes internal buffers during
-    /// [`Terminal::draw`].
+    /// [`Terminal::draw`] / [`Terminal::try_draw`].
     ///
     /// `Frame::area()` always starts at (0, 0).
     ///
@@ -42,18 +77,25 @@ pub enum Viewport {
     Fullscreen,
     /// Draw the application inline with the rest of the terminal output.
     ///
+    /// Choose this when the UI should appear inside a larger command-line flow instead of taking
+    /// over the entire terminal.
+    ///
     /// The viewport spans the full terminal width and its top-left corner is anchored to column 0
-    /// of the current cursor row when the terminal is created (and when it is resized). Ratatui
-    /// reserves space for the requested height; if the cursor is near the bottom of the screen,
-    /// this may scroll the terminal so the viewport remains fully visible.
+    /// of the current cursor row when the terminal is created and whenever it is recomputed during
+    /// resize. Ratatui reserves space for the requested height; if the cursor is near the bottom
+    /// of the screen, this may scroll the terminal so the viewport remains fully visible.
     ///
     /// The height is specified in rows and is clamped to the current terminal height.
+    ///
+    /// Inline viewports always span the full terminal width.
+    ///
+    /// For the full inline rendering model, including output inserted above the UI, see the
+    /// "Inline Viewport" section on [`Terminal`] and [`Terminal::insert_before`].
     Inline(u16),
     /// Draw into a fixed region of the terminal.
     ///
-    /// This can be useful when Ratatui is responsible for only part of the screen (for example, a
-    /// status panel beside another renderer), or when you want to manage the overall layout
-    /// yourself.
+    /// Choose this when Ratatui is responsible for only part of the screen, for example a panel in
+    /// a larger terminal layout managed by another renderer or by surrounding application code.
     ///
     /// Fixed viewports are not automatically resized. If the region should change (for example, on
     /// terminal resize), call [`Terminal::resize`] yourself.
@@ -61,7 +103,12 @@ pub enum Viewport {
     /// The area is specified as a [`Rect`] in terminal coordinates.
     ///
     /// `Frame::area()` returns this rectangle as-is (including its `x`/`y` offset).
+    /// Ratatui does not keep this rectangle synchronized with backend resizes unless you call
+    /// [`Terminal::resize`] yourself.
     ///
+    /// See also [`Terminal::with_options`] for initialization behavior.
+    ///
+    /// [`Terminal::with_options`]: crate::terminal::Terminal::with_options
     /// [`Terminal::resize`]: crate::terminal::Terminal::resize
     Fixed(Rect),
 }

--- a/ratatui-crossterm/README.md
+++ b/ratatui-crossterm/README.md
@@ -4,8 +4,13 @@
 
 This crate provides [`CrosstermBackend`], an implementation of the [`Backend`] trait for the
 [Ratatui] library. It uses the [Crossterm] library for all terminal manipulation.
-<!-- markdownlint-disable-next-line heading-increment -->
-### Crossterm Version and Re-export
+
+Most application authors should start with the main [`ratatui`] crate, which re-exports this
+backend and provides higher-level setup helpers. Reach for `ratatui-crossterm` directly when
+you need to depend on the backend crate itself, choose the Crossterm version explicitly, or
+integrate with Crossterm APIs beyond Ratatui's higher-level surface.
+
+## Crossterm Version and Re-export
 
 `ratatui-crossterm` requires you to specify a version of the [Crossterm] library to be used.
 This is managed via feature flags. The highest enabled feature flag of the available
@@ -45,14 +50,16 @@ This crate provides the [Crossterm] backend implementation for Ratatui.
 
 **When to use `ratatui-crossterm`:**
 
-- You need fine-grained control over dependencies
-- Building a widget library that needs backend functionality
-- You want to use only the Crossterm backend without other backends
+- You want to depend on the Crossterm backend crate directly
+- You need fine-grained control over the selected Crossterm version
+- You integrate with Crossterm APIs alongside Ratatui and want the re-exported
+  `ratatui_crossterm::crossterm` path
 
 **When to use the main [`ratatui`] crate:**
 
-- Building applications (recommended - includes crossterm backend by default)
-- You want the convenience of having everything available
+- Building applications
+- You want the common Ratatui path that already includes the Crossterm backend by default
+- You want the backend and higher-level terminal setup in one crate
 
 For detailed information about the workspace organization, see [ARCHITECTURE.md].
 

--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -12,8 +12,8 @@
 //! backend and provides higher-level setup helpers. Reach for `ratatui-crossterm` directly when
 //! you need to depend on the backend crate itself, choose the Crossterm version explicitly, or
 //! integrate with Crossterm APIs beyond Ratatui's higher-level surface.
-//! <!-- markdownlint-disable-next-line heading-increment -->
-//! ## Crossterm Version and Re-export
+//!
+//! # Crossterm Version and Re-export
 //!
 //! `ratatui-crossterm` requires you to specify a version of the [Crossterm] library to be used.
 //! This is managed via feature flags. The highest enabled feature flag of the available

--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -7,6 +7,11 @@
 #![warn(missing_docs)]
 //! This crate provides [`CrosstermBackend`], an implementation of the [`Backend`] trait for the
 //! [Ratatui] library. It uses the [Crossterm] library for all terminal manipulation.
+//!
+//! Most application authors should start with the main [`ratatui`] crate, which re-exports this
+//! backend and provides higher-level setup helpers. Reach for `ratatui-crossterm` directly when
+//! you need to depend on the backend crate itself, choose the Crossterm version explicitly, or
+//! integrate with Crossterm APIs beyond Ratatui's higher-level surface.
 //! <!-- markdownlint-disable-next-line heading-increment -->
 //! ## Crossterm Version and Re-export
 //!
@@ -48,14 +53,16 @@
 //!
 //! **When to use `ratatui-crossterm`:**
 //!
-//! - You need fine-grained control over dependencies
-//! - Building a widget library that needs backend functionality
-//! - You want to use only the Crossterm backend without other backends
+//! - You want to depend on the Crossterm backend crate directly
+//! - You need fine-grained control over the selected Crossterm version
+//! - You integrate with Crossterm APIs alongside Ratatui and want the re-exported
+//!   `ratatui_crossterm::crossterm` path
 //!
 //! **When to use the main [`ratatui`] crate:**
 //!
-//! - Building applications (recommended - includes crossterm backend by default)
-//! - You want the convenience of having everything available
+//! - Building applications
+//! - You want the common Ratatui path that already includes the Crossterm backend by default
+//! - You want the backend and higher-level terminal setup in one crate
 //!
 //! For detailed information about the workspace organization, see [ARCHITECTURE.md].
 //!

--- a/ratatui-termion/README.md
+++ b/ratatui-termion/README.md
@@ -5,6 +5,10 @@
 This module provides the [`TermionBackend`] implementation for the [`Backend`] trait. It uses
 the [Termion] crate to interact with the terminal.
 
+Most application authors should start with the main [`ratatui`] crate and only depend on
+`ratatui-termion` directly when they specifically want the Termion backend. This crate is the
+backend layer, not the primary docs.rs entry point for building applications.
+
 [`Backend`]: ratatui_core::backend::Backend
 [Termion]: https://docs.rs/termion
 
@@ -15,15 +19,13 @@ This crate provides the [Termion] backend implementation for Ratatui.
 
 **When to use `ratatui-termion`:**
 
-- You need fine-grained control over dependencies
-- Building a widget library that needs backend functionality
-- You want to use only the Termion backend without other backends
+- You want to depend on the Termion backend crate directly
 - You prefer Termion's Unix-focused approach
 
 **When to use the main [`ratatui`] crate:**
 
-- Building applications (recommended - includes termion backend when enabled)
-- You want the convenience of having everything available
+- Building applications
+- You want backend selection to stay behind Ratatui's re-exports
 
 For detailed information about the workspace organization, see [ARCHITECTURE.md].
 

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -8,6 +8,10 @@
 //! This module provides the [`TermionBackend`] implementation for the [`Backend`] trait. It uses
 //! the [Termion] crate to interact with the terminal.
 //!
+//! Most application authors should start with the main [`ratatui`] crate and only depend on
+//! `ratatui-termion` directly when they specifically want the Termion backend. This crate is the
+//! backend layer, not the primary docs.rs entry point for building applications.
+//!
 //! [`Backend`]: ratatui_core::backend::Backend
 //! [Termion]: https://docs.rs/termion
 //!
@@ -18,15 +22,13 @@
 //!
 //! **When to use `ratatui-termion`:**
 //!
-//! - You need fine-grained control over dependencies
-//! - Building a widget library that needs backend functionality
-//! - You want to use only the Termion backend without other backends
+//! - You want to depend on the Termion backend crate directly
 //! - You prefer Termion's Unix-focused approach
 //!
 //! **When to use the main [`ratatui`] crate:**
 //!
-//! - Building applications (recommended - includes termion backend when enabled)
-//! - You want the convenience of having everything available
+//! - Building applications
+//! - You want backend selection to stay behind Ratatui's re-exports
 //!
 //! For detailed information about the workspace organization, see [ARCHITECTURE.md].
 //!

--- a/ratatui-termwiz/README.md
+++ b/ratatui-termwiz/README.md
@@ -5,6 +5,11 @@
 This module provides the [`TermwizBackend`] implementation for the [`Backend`] trait. It uses
 the [Termwiz] crate to interact with the terminal.
 
+Most application authors should start with the main [`ratatui`] crate and only depend on
+`ratatui-termwiz` directly when they specifically want the Termwiz backend or its advanced
+terminal capabilities. This crate is the backend layer, not the primary docs.rs entry point for
+building applications.
+
 [`Backend`]: trait.Backend.html
 [Termwiz]: https://crates.io/crates/termwiz
 
@@ -15,15 +20,13 @@ This crate provides the [Termwiz] backend implementation for Ratatui.
 
 **When to use `ratatui-termwiz`:**
 
-- You need fine-grained control over dependencies
-- Building a widget library that needs backend functionality
-- You want to use only the Termwiz backend without other backends
+- You want to depend on the Termwiz backend crate directly
 - You need Termwiz's advanced terminal capabilities
 
 **When to use the main [`ratatui`] crate:**
 
-- Building applications (recommended - includes termwiz backend when enabled)
-- You want the convenience of having everything available
+- Building applications
+- You want backend selection to stay behind Ratatui's re-exports
 
 For detailed information about the workspace organization, see [ARCHITECTURE.md].
 

--- a/ratatui-termwiz/src/lib.rs
+++ b/ratatui-termwiz/src/lib.rs
@@ -8,6 +8,11 @@
 //! This module provides the [`TermwizBackend`] implementation for the [`Backend`] trait. It uses
 //! the [Termwiz] crate to interact with the terminal.
 //!
+//! Most application authors should start with the main [`ratatui`] crate and only depend on
+//! `ratatui-termwiz` directly when they specifically want the Termwiz backend or its advanced
+//! terminal capabilities. This crate is the backend layer, not the primary docs.rs entry point for
+//! building applications.
+//!
 //! [`Backend`]: trait.Backend.html
 //! [Termwiz]: https://crates.io/crates/termwiz
 //!
@@ -18,15 +23,13 @@
 //!
 //! **When to use `ratatui-termwiz`:**
 //!
-//! - You need fine-grained control over dependencies
-//! - Building a widget library that needs backend functionality
-//! - You want to use only the Termwiz backend without other backends
+//! - You want to depend on the Termwiz backend crate directly
 //! - You need Termwiz's advanced terminal capabilities
 //!
 //! **When to use the main [`ratatui`] crate:**
 //!
-//! - Building applications (recommended - includes termwiz backend when enabled)
-//! - You want the convenience of having everything available
+//! - Building applications
+//! - You want backend selection to stay behind Ratatui's re-exports
 //!
 //! For detailed information about the workspace organization, see [ARCHITECTURE.md].
 //!

--- a/ratatui/src/init.rs
+++ b/ratatui/src/init.rs
@@ -21,18 +21,18 @@
 //!
 //! # Which function should I start with?
 //!
-//! Choose the entry point that matches how you want to structure the app:
+//! Start with the simplest path that fits your application:
 //!
-//! - [`run`] for the normal case: Ratatui owns setup and cleanup around your application closure.
-//! - [`init`] / [`restore`] when you want explicit control over setup, teardown, or event loop
-//!   structure.
-//! - [`try_init`] / [`try_restore`] when you want the same control but need explicit error
-//!   handling instead of panicking or printing cleanup failures.
-//! - [`init_with_options`] / [`try_init_with_options`] when you need a custom [`TerminalOptions`]
-//!   such as inline or fixed viewports.
-//!
-//! If you need a non-default backend or terminal setup that should happen outside these helpers,
-//! construct [`Terminal`] manually instead.
+//! 1. Use [`run`] for the normal case: Ratatui owns setup and cleanup around your application
+//!    closure.
+//! 2. Move to [`init`] / [`restore`] when you want explicit control over setup, teardown, or event
+//!    loop structure.
+//! 3. Use [`try_init`] / [`try_restore`] when you want the same control but need explicit error
+//!    handling instead of panicking or printing cleanup failures.
+//! 4. Use [`init_with_options`] / [`try_init_with_options`] when you need a custom
+//!    [`TerminalOptions`] such as inline or fixed viewports.
+//! 5. Construct [`Terminal`] manually only when these helpers do not match the backend or terminal
+//!    lifecycle you need.
 //!
 //! # Available Types and Functions
 //!
@@ -62,7 +62,7 @@
 //!
 //! # Usage Guide
 //!
-//! For the simplest setup with automatic cleanup, use [`run`]:
+//! Start with the normal fullscreen application path:
 //!
 //! ```rust,no_run
 //! fn main() -> std::io::Result<()> {
@@ -77,7 +77,7 @@
 //! }
 //! ```
 //!
-//! For a typical event loop that redraws after resize events:
+//! Then add resize-aware redraws to the event loop:
 //!
 //! ```rust,no_run
 //! use crossterm::event::{self, Event, KeyCode, KeyEventKind};
@@ -105,7 +105,7 @@
 //! }
 //! ```
 //!
-//! For standard full-screen applications with manual control over initialization and cleanup:
+//! Reach for [`init`] / [`restore`] when you want manual control over setup and teardown:
 //!
 //! ```rust,no_run
 //! // Using init() - panics on failure
@@ -120,8 +120,8 @@
 //! # Ok::<(), std::io::Error>(())
 //! ```
 //!
-//! For applications that need custom terminal behavior (inline rendering, custom viewport sizes,
-//! or applications that don't want alternate screen buffer):
+//! Use [`init_with_options`] when the UI should not use the normal fullscreen path, for example
+//! for an inline UI that continues to share the terminal with earlier output:
 //!
 //! ```rust,no_run
 //! use crossterm::event::{self, Event, KeyCode, KeyEventKind};
@@ -165,6 +165,9 @@
 //! ratatui::try_restore()?;
 //! # Ok::<(), std::io::Error>(())
 //! ```
+//!
+//! These higher-level helpers are the normal application path. Manual [`Terminal`] construction is
+//! still available for custom backends and specialized integrations, but it is an advanced path.
 //!
 //! For cleanup, use [`restore`] in most cases where you want to attempt restoration but don't need
 //! to handle errors (they are printed to stderr). Use [`try_restore`] when you need to handle

--- a/ratatui/src/init.rs
+++ b/ratatui/src/init.rs
@@ -19,6 +19,21 @@
 //! convenience, so you can call `ratatui::run()`, `ratatui::init()`, etc. instead of
 //! `ratatui::init::run()`, `ratatui::init::init()`, etc.
 //!
+//! # Which function should I start with?
+//!
+//! Choose the entry point that matches how you want to structure the app:
+//!
+//! - [`run`] for the normal case: Ratatui owns setup and cleanup around your application closure.
+//! - [`init`] / [`restore`] when you want explicit control over setup, teardown, or event loop
+//!   structure.
+//! - [`try_init`] / [`try_restore`] when you want the same control but need explicit error
+//!   handling instead of panicking or printing cleanup failures.
+//! - [`init_with_options`] / [`try_init_with_options`] when you need a custom [`TerminalOptions`]
+//!   such as inline or fixed viewports.
+//!
+//! If you need a non-default backend or terminal setup that should happen outside these helpers,
+//! construct [`Terminal`] manually instead.
+//!
 //! # Available Types and Functions
 //!
 //! ## Types
@@ -62,6 +77,34 @@
 //! }
 //! ```
 //!
+//! For a typical event loop that redraws after resize events:
+//!
+//! ```rust,no_run
+//! use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+//!
+//! fn main() -> std::io::Result<()> {
+//!     ratatui::run(|terminal| {
+//!         loop {
+//!             terminal.draw(|frame| {
+//!                 frame.render_widget("Resize the terminal or press q to quit", frame.area());
+//!             })?;
+//!
+//!             match event::read()? {
+//!                 Event::Resize(_, _) => {
+//!                     // The next `draw` pass re-renders the UI at the new size.
+//!                 }
+//!                 Event::Key(key)
+//!                     if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('q') =>
+//!                 {
+//!                     break Ok(());
+//!                 }
+//!                 _ => {}
+//!             }
+//!         }
+//!     })
+//! }
+//! ```
+//!
 //! For standard full-screen applications with manual control over initialization and cleanup:
 //!
 //! ```rust,no_run
@@ -81,15 +124,34 @@
 //! or applications that don't want alternate screen buffer):
 //!
 //! ```rust,no_run
+//! use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+//! use ratatui::widgets::Widget;
 //! use ratatui::{TerminalOptions, Viewport};
 //!
 //! let options = TerminalOptions {
 //!     viewport: Viewport::Inline(10),
 //! };
 //!
-//! // Using init_with_options() - panics on failure
 //! let mut terminal = ratatui::init_with_options(options);
-//! // ... app logic ...
+//!
+//! terminal.insert_before(1, |buf| {
+//!     "> Ready".render(buf.area, buf);
+//! })?;
+//!
+//! loop {
+//!     terminal.draw(|frame| {
+//!         frame.render_widget("Inline UI lives below earlier terminal output", frame.area());
+//!     })?;
+//!
+//!     if matches!(
+//!         event::read()?,
+//!         Event::Key(key)
+//!             if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('q')
+//!     ) {
+//!         break;
+//!     }
+//! }
+//!
 //! ratatui::restore();
 //!
 //! // Using try_init_with_options() - returns Result for custom error handling
@@ -97,7 +159,9 @@
 //!     viewport: Viewport::Inline(10),
 //! };
 //! let mut terminal = ratatui::try_init_with_options(options)?;
-//! // ... app logic ...
+//! terminal.draw(|frame| {
+//!     frame.render_widget("Inline UI", frame.area());
+//! })?;
 //! ratatui::try_restore()?;
 //! # Ok::<(), std::io::Error>(())
 //! ```

--- a/ratatui/src/lib.rs
+++ b/ratatui/src/lib.rs
@@ -64,8 +64,8 @@
 //!   restores the terminal on exit.
 //! - Use [`init()`] / [`restore()`] (or [`try_init()`] / [`try_restore()`]) when you want manual
 //!   control over terminal lifetime and the event loop structure.
-//! - Use [`init_with_options()`] / [`try_init_with_options()`] when you need a custom
-//!   [`Viewport`], such as inline rendering or a fixed drawing region.
+//! - Use [`init_with_options()`] / [`try_init_with_options()`] when you need a custom [`Viewport`],
+//!   such as inline rendering or a fixed drawing region.
 //!
 //! Reach for [`Terminal::new`] or [`Terminal::with_options`] directly only when you need custom
 //! backend construction or terminal setup that Ratatui's convenience functions do not manage.
@@ -80,8 +80,8 @@
 //! - [`ratatui-core`] for widget libraries, custom integrations, and lower-level rendering
 //!   contracts
 //! - [`ratatui-widgets`] when you only need the built-in widgets crate as a dependency
-//! - [`ratatui-crossterm`], [`ratatui-termion`], or [`ratatui-termwiz`] when you need to select
-//!   and depend on a backend crate directly
+//! - [`ratatui-crossterm`], [`ratatui-termion`], or [`ratatui-termwiz`] when you need to select and
+//!   depend on a backend crate directly
 //!
 //! # Other documentation
 //!
@@ -246,26 +246,23 @@
 //!
 //! ### What happens if...
 //!
-//! - **If the terminal is resized:**  
-//!   Ratatui does not redraw automatically when a resize event arrives. Your app should continue
-//!   the event loop and call [`Terminal::draw`] again. During that render pass, Ratatui checks the
-//!   backend's current size instead of assuming the resize events were complete or up to date.
-//!   This keeps layout based on the size that actually exists when rendering, even if multiple
-//!   resize events were coalesced, missed, or delivered before the UI redraws. Fullscreen and
-//!   inline viewports update their internal size during that render pass; fixed viewports keep
-//!   their configured rectangle until you call [`Terminal::resize`].
-//! - **If [`Terminal::try_draw`] returns an error:**  
-//!   The render pass stops early and Ratatui does not promise that the terminal, cursor, and
-//!   internal buffers are still synchronized. In most applications, return the error and let the
-//!   surrounding setup path restore terminal state on exit.
-//! - **If you move the cursor directly:**  
-//!   Cursor changes made through backend-specific APIs or [`Terminal`] cursor methods can be
-//!   overwritten by the next render pass if that pass sets cursor state through [`Frame`].
-//!   Prefer choosing one path and using it consistently.
-//! - **If you mutate the backend directly:**  
-//!   Direct backend changes bypass Ratatui's diffing and viewport bookkeeping. After doing that,
-//!   run a full draw pass or clear the terminal before assuming Ratatui's internal view still
-//!   matches the screen.
+//! - **If the terminal is resized:**<br> Ratatui does not redraw automatically when a resize event
+//!   arrives. Your app should continue the event loop and call [`Terminal::draw`] again. During
+//!   that render pass, Ratatui checks the backend's current size instead of assuming the resize
+//!   events were complete or up to date. This keeps layout based on the size that actually exists
+//!   when rendering, even if multiple resize events were coalesced, missed, or delivered before the
+//!   UI redraws. Fullscreen and inline viewports update their internal size during that render
+//!   pass; fixed viewports keep their configured rectangle until you call [`Terminal::resize`].
+//! - **If [`Terminal::try_draw`] returns an error:**<br> The render pass stops early and Ratatui
+//!   does not promise that the terminal, cursor, and internal buffers are still synchronized. In
+//!   most applications, return the error and let the surrounding setup path restore terminal state
+//!   on exit.
+//! - **If you move the cursor directly:**<br> Cursor changes made through backend-specific APIs or
+//!   [`Terminal`] cursor methods can be overwritten by the next render pass if that pass sets
+//!   cursor state through [`Frame`]. Prefer choosing one path and using it consistently.
+//! - **If you mutate the backend directly:**<br> Direct backend changes bypass Ratatui's diffing
+//!   and viewport bookkeeping. After doing that, run a full draw pass or clear the terminal before
+//!   assuming Ratatui's internal view still matches the screen.
 //!
 //! ## Handling events
 //!

--- a/ratatui/src/lib.rs
+++ b/ratatui/src/lib.rs
@@ -70,6 +70,19 @@
 //! Reach for [`Terminal::new`] or [`Terminal::with_options`] directly only when you need custom
 //! backend construction or terminal setup that Ratatui's convenience functions do not manage.
 //!
+//! ## Which crate should I use?
+//!
+//! Most application authors should stay in this `ratatui` crate. It is the docs.rs entry point
+//! for building apps and re-exports the pieces most applications need.
+//!
+//! Reach for other crates in the workspace only when you specifically need a lower-level layer:
+//!
+//! - [`ratatui-core`] for widget libraries, custom integrations, and lower-level rendering
+//!   contracts
+//! - [`ratatui-widgets`] when you only need the built-in widgets crate as a dependency
+//! - [`ratatui-crossterm`], [`ratatui-termion`], or [`ratatui-termwiz`] when you need to select
+//!   and depend on a backend crate directly
+//!
 //! # Other documentation
 //!
 //! - [Ratatui Website] - explains the library's concepts and provides step-by-step tutorials
@@ -106,7 +119,7 @@
 //! - **Backend crates**: [`ratatui-crossterm`], [`ratatui-termion`], [`ratatui-termwiz`]
 //! - **[`ratatui-macros`]**: Macros for simplifying the boilerplate
 //!
-//! **For application developers**: No changes needed - continue using `ratatui` as before.
+//! **For application developers**: `ratatui` remains the recommended starting point.
 //!
 //! **For widget library authors**: Consider depending on [`ratatui-core`] instead of the full
 //! `ratatui` crate for better API stability and reduced dependencies.
@@ -183,21 +196,9 @@
 //! # fn should_quit() -> std::io::Result<bool> { Ok(false) }
 //! ```
 //!
-//! Note that when using [`init()`] and [`restore()`], it's important to use a separate function
-//! for the main loop to ensure that [`restore()`] is always called, even if the `?` operator
-//! causes early return from an error.
-//!
-//! Choose the setup path based on how much control you need:
-//!
-//! - [`run()`]: best default for most applications.
-//! - [`init()`] / [`restore()`]: use when you want explicit control over setup, teardown, or the
-//!   event loop structure.
-//! - [`try_init()`] / [`try_restore()`]: same as above, but with explicit error handling.
-//! - [`init_with_options()`] / [`try_init_with_options()`]: use when the app should not use the
-//!   default fullscreen + alternate-screen setup, for example with inline or fixed viewports.
-//!
-//! For more detailed information about initialization options and when to use each function, see
-//! the [`init` module] documentation.
+//! Use [`run()`] as the default. Reach for [`init()`] / [`restore()`] when setup and teardown
+//! should surround code outside the application closure, and see the [`init` module] documentation
+//! for the full chooser including `try_*` and `*_with_options`.
 //!
 //! ### Manual Terminal and Backend Construction
 //!
@@ -242,6 +243,29 @@
 //! }
 //! # fn handle_events() -> std::io::Result<bool> { Ok(false) }
 //! ```
+//!
+//! ### What happens if...
+//!
+//! - **If the terminal is resized:**  
+//!   Ratatui does not redraw automatically when a resize event arrives. Your app should continue
+//!   the event loop and call [`Terminal::draw`] again. During that render pass, Ratatui checks the
+//!   backend's current size instead of assuming the resize events were complete or up to date.
+//!   This keeps layout based on the size that actually exists when rendering, even if multiple
+//!   resize events were coalesced, missed, or delivered before the UI redraws. Fullscreen and
+//!   inline viewports update their internal size during that render pass; fixed viewports keep
+//!   their configured rectangle until you call [`Terminal::resize`].
+//! - **If [`Terminal::try_draw`] returns an error:**  
+//!   The render pass stops early and Ratatui does not promise that the terminal, cursor, and
+//!   internal buffers are still synchronized. In most applications, return the error and let the
+//!   surrounding setup path restore terminal state on exit.
+//! - **If you move the cursor directly:**  
+//!   Cursor changes made through backend-specific APIs or [`Terminal`] cursor methods can be
+//!   overwritten by the next render pass if that pass sets cursor state through [`Frame`].
+//!   Prefer choosing one path and using it consistently.
+//! - **If you mutate the backend directly:**  
+//!   Direct backend changes bypass Ratatui's diffing and viewport bookkeeping. After doing that,
+//!   run a full draw pass or clear the terminal before assuming Ratatui's internal view still
+//!   matches the screen.
 //!
 //! ## Handling events
 //!

--- a/ratatui/src/lib.rs
+++ b/ratatui/src/lib.rs
@@ -56,6 +56,20 @@
 //! various [Examples]. There are also several starter [Templates] available to help you get
 //! started quickly with common patterns.
 //!
+//! ## Which setup path should I use?
+//!
+//! Most application authors should start with one of these entry points:
+//!
+//! - Use [`run()`] for normal applications. It initializes the terminal, runs your app, and
+//!   restores the terminal on exit.
+//! - Use [`init()`] / [`restore()`] (or [`try_init()`] / [`try_restore()`]) when you want manual
+//!   control over terminal lifetime and the event loop structure.
+//! - Use [`init_with_options()`] / [`try_init_with_options()`] when you need a custom
+//!   [`Viewport`], such as inline rendering or a fixed drawing region.
+//!
+//! Reach for [`Terminal::new`] or [`Terminal::with_options`] directly only when you need custom
+//! backend construction or terminal setup that Ratatui's convenience functions do not manage.
+//!
 //! # Other documentation
 //!
 //! - [Ratatui Website] - explains the library's concepts and provides step-by-step tutorials
@@ -173,6 +187,15 @@
 //! for the main loop to ensure that [`restore()`] is always called, even if the `?` operator
 //! causes early return from an error.
 //!
+//! Choose the setup path based on how much control you need:
+//!
+//! - [`run()`]: best default for most applications.
+//! - [`init()`] / [`restore()`]: use when you want explicit control over setup, teardown, or the
+//!   event loop structure.
+//! - [`try_init()`] / [`try_restore()`]: same as above, but with explicit error handling.
+//! - [`init_with_options()`] / [`try_init_with_options()`]: use when the app should not use the
+//!   default fullscreen + alternate-screen setup, for example with inline or fixed viewports.
+//!
 //! For more detailed information about initialization options and when to use each function, see
 //! the [`init` module] documentation.
 //!
@@ -181,7 +204,8 @@
 //! Before the convenience functions were introduced in version 0.28.1 ([`init()`]/[`restore()`])
 //! and 0.30.0 ([`run()`]), applications constructed [`Terminal`] and [`Backend`] instances
 //! manually. This approach is still supported for applications that need fine-grained control over
-//! initialization. See the [`Terminal`] and [`backend`] module documentation for details.
+//! initialization, custom backends, or terminal setup that should happen outside Ratatui's
+//! convenience helpers. See the [`Terminal`] and [`backend`] module documentation for details.
 //!
 //! See the [`backend` module] and the [Backends] section of the [Ratatui Website] for more info on
 //! the alternate screen and raw mode. Learn more about different backend options in the [Backend


### PR DESCRIPTION
## Summary

This updates the terminal and setup docs to better match the rendering behavior Ratatui actually implements, while also making the docs.rs path clearer for application authors.

The main docs changes are split into two commits:

1. `docs: align terminal docs with behavior`
   - align `Terminal`, viewport, frame, and flush docs with the real render pipeline
   - clarify the boundary between `Terminal::flush` and `Backend::flush`
   - improve examples for fullscreen, inline, and fixed viewport usage
2. `docs: improve terminal docs for app authors`
   - improve setup-path guidance across `ratatui`, `ratatui-core`, and backend crates
   - clarify viewport choice, escape hatches, and common edge cases
   - reduce duplication so crate-level docs explain choices while method docs hold detailed contracts

A small follow-up also fixes the crate-doc heading hierarchy in `ratatui-core` and
`ratatui-crossterm` so the generated READMEs no longer need
`markdownlint-disable-next-line heading-increment` suppressions.

## Verification

- `cargo test -p ratatui --doc`
- `cargo test -p ratatui-core --doc`
- `cargo test -p ratatui-crossterm --doc`
- `cargo test -p ratatui-termion --doc`
- `cargo test -p ratatui-termwiz --doc`
- `cargo test --workspace --all-targets --no-run`
- `cargo doc -p ratatui --no-deps`
- `cargo doc -p ratatui-core --no-deps`
- `cargo xtask format --check`
- `cargo xtask readme --check`

Note: `cargo doc -p ratatui-core --no-deps` still reports pre-existing warnings outside this pass in `layout` and `text` docs. The terminal-doc warnings introduced during this work were fixed.
