### PR TITLE
build: use latest released cargo-machete action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: bnjbvr/cargo-machete@b81ce1560c5fbd0210cb66d88bf210329ff04266
+      - uses: bnjbvr/cargo-machete@ac30a525c0a8d163a92d727b3ff079ee3f6ecb08 # v0.9.2
 
   # Run cargo clippy.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: taiki-e/install-action@e9e8e031bcd90cdbe8ac6bb1d376f8596e587fbf # v2
-        with:
-          tool: cargo-machete
-      - run: cargo-machete
+      - uses: bnjbvr/cargo-machete@b81ce1560c5fbd0210cb66d88bf210329ff04266
 
   # Run cargo clippy.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: bnjbvr/cargo-machete@7959c845782fed02ee69303126d4a12d64f1db18 # v0.9.1
+      - uses: taiki-e/install-action@e9e8e031bcd90cdbe8ac6bb1d376f8596e587fbf # v2
+        with:
+          tool: cargo-machete
+      - run: cargo-machete
 
   # Run cargo clippy.
   #


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
Currently, we spend every continuous integration downloading and compiling `cargo-machete`. 
<img width="902" height="595" alt="image" src="https://github.com/user-attachments/assets/e7ea21c9-446f-481b-9031-72f77d73a7e4" />

(see https://github.com/ratatui/ratatui/actions/runs/23771316569/job/69263233437?pr=2424#step:3:12)

We can skip that by using `install-action` to get prebuilt binaries, which cuts it down by a lot!

<img width="900" height="356" alt="image" src="https://github.com/user-attachments/assets/05becfbd-e141-4aef-b8bb-fd9dddf8ff76" />

(see my fork:s CI job https://github.com/sermuns/ratatui/actions/runs/23811047729/job/69397859972#step:4:5)

We _could_ also update to use the latest `cargo-machete` action, which also [downloads binaries](https://github.com/bnjbvr/cargo-machete/blob/b81ce1560c5fbd0210cb66d88bf210329ff04266/action/entrypoint.sh), but I don't see the point as `install-action` is common and battle tested.