### PR TITLE
docs(canvas): add usage example for Line widget

### DIFF
--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -8,14 +8,13 @@ use crate::canvas::{Painter, Shape};
 /// # Examples
 ///
 /// ```rust
-/// use crate::canvas::Line;
-///
-/// let red_line = Line::new(0.0, 0.0, 10.0, 10.0, ratatui_core::style::Color::Red);
-///
-/// let blue_line = Line::new(0.0, 10.0, 10.0, 0.0, ratatui_core::style::Color::Blue);
-///
-/// let mut green_line = Line::new(5.0, 5.0, 15.0, 15.0, ratatui_core::style::Color::Green);
-/// green_line.color = ratatui_core::style::Color::Yellow;
+/// # use ratatui_core::style::Color;
+/// # use ratatui_widgets::canvas::{Canvas, Line};
+/// Canvas::default().paint(|ctx| {
+///     ctx.draw(&Line::new(0.0, 0.0, 1.0, 0.0, Color::Red));
+///     ctx.draw(&Line::new(1.0, 0.0, 0.5, 1.0, Color::Red));
+///     ctx.draw(&Line::new(0.5, 1.0, 0.0, 0.0, Color::Red));
+/// });
 /// ```
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Line {

--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -4,6 +4,15 @@ use ratatui_core::style::Color;
 use crate::canvas::{Painter, Shape};
 
 /// A line from `(x1, y1)` to `(x2, y2)` with the given color
+///
+/// #Examples
+/// 
+/// ```rust
+/// use ratatui::widgets::canvas::Line;
+/// use ratatui_core::style::Color;
+/// 
+/// let line = Line::new(0.0, 0.0, 10.0, 10.0, Color::Red);
+/// ```
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Line {
     /// `x` of the starting point

--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -6,11 +6,11 @@ use crate::canvas::{Painter, Shape};
 /// A line from `(x1, y1)` to `(x2, y2)` with the given color
 ///
 /// #Examples
-/// 
+///
 /// ```rust
 /// use ratatui::widgets::canvas::Line;
 /// use ratatui_core::style::Color;
-/// 
+///
 /// let line = Line::new(0.0, 0.0, 10.0, 10.0, Color::Red);
 /// ```
 #[derive(Debug, Default, Clone, PartialEq)]

--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -9,9 +9,14 @@ use crate::canvas::{Painter, Shape};
 ///
 /// ```rust
 /// use ratatui::widgets::canvas::Line;
-/// use ratatui_core::style::Color;
+/// use ratatui::style::Color;
 ///
-/// let line = Line::new(0.0, 0.0, 10.0, 10.0, Color::Red);
+/// let red_line = Line::new(0.0, 0.0, 10.0, 10.0, Color::Red);
+///
+/// let blue_line = Line::new(0.0, 10.0, 10.0, 0.0, Color::Blue);
+///
+/// let mut green_line = Line::new(5.0, 5.0, 15.0, 15.0, Color::Green);
+/// green_line.color = Color::Yellow;
 /// ```
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Line {

--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -5,18 +5,17 @@ use crate::canvas::{Painter, Shape};
 
 /// A line from `(x1, y1)` to `(x2, y2)` with the given color
 ///
-/// #Examples
+/// # Examples
 ///
 /// ```rust
 /// use crate::canvas::Line;
-/// use ratatui_core::style::Color;
 ///
-/// let red_line = Line::new(0.0, 0.0, 10.0, 10.0, Color::Red);
+/// let red_line = Line::new(0.0, 0.0, 10.0, 10.0, ratatui_core::style::Color::Red);
 ///
-/// let blue_line = Line::new(0.0, 10.0, 10.0, 0.0, Color::Blue);
+/// let blue_line = Line::new(0.0, 10.0, 10.0, 0.0, ratatui_core::style::Color::Blue);
 ///
-/// let mut green_line = Line::new(5.0, 5.0, 15.0, 15.0, Color::Green);
-/// green_line.color = Color::Yellow;
+/// let mut green_line = Line::new(5.0, 5.0, 15.0, 15.0, ratatui_core::style::Color::Green);
+/// green_line.color = ratatui_core::style::Color::Yellow;
 /// ```
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Line {

--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -8,8 +8,8 @@ use crate::canvas::{Painter, Shape};
 /// #Examples
 ///
 /// ```rust
-/// use ratatui::widgets::canvas::Line;
-/// use ratatui::style::Color;
+/// use crate::canvas::Line;
+/// use ratatui_core::style::Color;
 ///
 /// let red_line = Line::new(0.0, 0.0, 10.0, 10.0, Color::Red);
 ///


### PR DESCRIPTION
Added a doc-tested example for the Line struct in canvas to improve documentation and help new users understand how to render lines with color.