### PR TITLE
fix(core): avoid cursor position queries during resize

### DIFF
--- a/ratatui-core/src/terminal/buffers.rs
+++ b/ratatui-core/src/terminal/buffers.rs
@@ -117,11 +117,24 @@ impl<B: Backend> Terminal<B> {
     /// This preserves the cursor position.
     ///
     /// This also resets the "previous" buffer so the next [`Terminal::flush`] redraws the full
-    /// viewport. [`Terminal::resize`] calls this internally.
+    /// viewport.
     ///
     /// Implementation note: this uses [`ClearType::AfterCursor`] starting at the viewport origin.
     pub fn clear(&mut self) -> Result<(), B::Error> {
-        let original_cursor = self.backend.get_cursor_position()?;
+        self.clear_viewport(true)
+    }
+
+    /// Clears according to the current viewport and resets the back buffer.
+    ///
+    /// When `preserve_cursor` is `true`, this snapshots and restores the backend cursor position.
+    /// When `false`, it skips cursor queries (useful in resize paths where querying the cursor can
+    /// fail on some backends).
+    pub(crate) fn clear_viewport(&mut self, preserve_cursor: bool) -> Result<(), B::Error> {
+        let original_cursor = if preserve_cursor {
+            Some(self.backend.get_cursor_position()?)
+        } else {
+            None
+        };
         match self.viewport {
             Viewport::Fullscreen => self.backend.clear_region(ClearType::All)?,
             Viewport::Inline(_) => {
@@ -134,7 +147,9 @@ impl<B: Backend> Terminal<B> {
                 self.clear_fixed_viewport(area)?;
             }
         }
-        self.backend.set_cursor_position(original_cursor)?;
+        if let Some(original_cursor) = original_cursor {
+            self.backend.set_cursor_position(original_cursor)?;
+        }
         // Reset the back buffer to make sure the next update will redraw everything.
         self.buffers[1 - self.current].reset();
         Ok(())

--- a/ratatui-core/src/terminal/buffers.rs
+++ b/ratatui-core/src/terminal/buffers.rs
@@ -121,20 +121,17 @@ impl<B: Backend> Terminal<B> {
     ///
     /// Implementation note: this uses [`ClearType::AfterCursor`] starting at the viewport origin.
     pub fn clear(&mut self) -> Result<(), B::Error> {
-        self.clear_viewport(true)
+        let original_cursor = self.backend.get_cursor_position()?;
+        self.clear_viewport()?;
+        self.backend.set_cursor_position(original_cursor)?;
+        Ok(())
     }
 
     /// Clears according to the current viewport and resets the back buffer.
     ///
-    /// When `preserve_cursor` is `true`, this snapshots and restores the backend cursor position.
-    /// When `false`, it skips cursor queries (useful in resize paths where querying the cursor can
-    /// fail on some backends).
-    pub(crate) fn clear_viewport(&mut self, preserve_cursor: bool) -> Result<(), B::Error> {
-        let original_cursor = if preserve_cursor {
-            Some(self.backend.get_cursor_position()?)
-        } else {
-            None
-        };
+    /// Unlike [`Terminal::clear`], this does not snapshot and restore the backend cursor
+    /// position. Callers that need to preserve the cursor should do so outside this helper.
+    pub(super) fn clear_viewport(&mut self) -> Result<(), B::Error> {
         match self.viewport {
             Viewport::Fullscreen => self.backend.clear_region(ClearType::All)?,
             Viewport::Inline(_) => {
@@ -146,9 +143,6 @@ impl<B: Backend> Terminal<B> {
                 let area = self.viewport_area;
                 self.clear_fixed_viewport(area)?;
             }
-        }
-        if let Some(original_cursor) = original_cursor {
-            self.backend.set_cursor_position(original_cursor)?;
         }
         // Reset the back buffer to make sure the next update will redraw everything.
         self.buffers[1 - self.current].reset();
@@ -399,6 +393,32 @@ mod tests {
         assert_eq!(
             terminal.backend().cursor_position(),
             Position { x: 3, y: 0 }
+        );
+    }
+
+    #[test]
+    fn clear_viewport_inline_leaves_cursor_at_viewport_origin() {
+        let mut backend = TestBackend::with_lines([
+            "before 1  ",
+            "before 2  ",
+            "viewport 1",
+            "viewport 2",
+            "after 1   ",
+            "after 2   ",
+        ]);
+        backend
+            .set_cursor_position(Position { x: 2, y: 2 })
+            .unwrap();
+        let options = TerminalOptions {
+            viewport: Viewport::Inline(2),
+        };
+        let mut terminal = Terminal::with_options(backend, options).unwrap();
+
+        terminal.clear_viewport().unwrap();
+
+        assert_eq!(
+            terminal.backend().cursor_position(),
+            terminal.viewport_area.as_position()
         );
     }
 }

--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -40,7 +40,7 @@ impl<B: Backend> Terminal<B> {
         }
 
         self.set_viewport_area(next_area);
-        self.clear()?;
+        self.clear_viewport(false)?;
 
         self.last_known_area = area;
         Ok(())

--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -40,7 +40,7 @@ impl<B: Backend> Terminal<B> {
         }
 
         self.set_viewport_area(next_area);
-        self.clear_viewport(false)?;
+        self.clear_viewport()?;
 
         self.last_known_area = area;
         Ok(())

--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -16,21 +16,21 @@ impl<B: Backend> Terminal<B> {
     ///
     /// See also: [`Terminal::autoresize`] (automatic resizing during [`Terminal::draw`]).
     pub fn resize(&mut self, area: Rect) -> Result<(), B::Error> {
-        let mut next_area = match self.viewport {
+        let (mut next_area, cursor_to_restore) = match self.viewport {
             Viewport::Inline(height) => {
                 let offset_in_previous_viewport = self
                     .last_known_cursor_pos
                     .y
                     .saturating_sub(self.viewport_area.top());
-                compute_inline_size(
+                let (next_area, cursor_position) = compute_inline_size(
                     &mut self.backend,
                     height,
                     area.as_size(),
                     offset_in_previous_viewport,
-                )?
-                .0
+                )?;
+                (next_area, Some(cursor_position))
             }
-            Viewport::Fixed(_) | Viewport::Fullscreen => area,
+            Viewport::Fixed(_) | Viewport::Fullscreen => (area, None),
         };
 
         // clear screen on horizontal shrink to avoid line wrapping issues
@@ -41,6 +41,9 @@ impl<B: Backend> Terminal<B> {
 
         self.set_viewport_area(next_area);
         self.clear_viewport()?;
+        if let Some(cursor_position) = cursor_to_restore {
+            self.backend.set_cursor_position(cursor_position)?;
+        }
 
         self.last_known_area = area;
         Ok(())
@@ -258,6 +261,42 @@ mod tests {
         terminal.resize(Rect::new(0, 0, 10, 3)).unwrap();
 
         assert_eq!(terminal.viewport_area, Rect::new(0, 0, 10, 3));
+    }
+
+    #[test]
+    fn resize_inline_preserves_backend_cursor_across_repeated_resizes() {
+        let mut backend = TestBackend::new(10, 10);
+        backend
+            .set_cursor_position(Position { x: 0, y: 4 })
+            .unwrap();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(4),
+            },
+        )
+        .unwrap();
+
+        terminal.last_known_cursor_pos = Position { x: 0, y: 5 };
+        terminal
+            .backend_mut()
+            .set_cursor_position(Position { x: 0, y: 6 })
+            .unwrap();
+
+        terminal.resize(Rect::new(0, 0, 10, 12)).unwrap();
+        assert_eq!(terminal.viewport_area, Rect::new(0, 5, 10, 4));
+        assert_eq!(
+            terminal.backend().cursor_position(),
+            Position { x: 0, y: 6 }
+        );
+
+        terminal.resize(Rect::new(0, 0, 10, 14)).unwrap();
+
+        assert_eq!(terminal.viewport_area, Rect::new(0, 6, 10, 4));
+        assert_eq!(
+            terminal.backend().cursor_position(),
+            Position { x: 0, y: 6 }
+        );
     }
 
     // This tests for the case where the new width is smaller than the old


### PR DESCRIPTION
`Terminal::resize()` now clears without calling `get_cursor_position()`,
so that CPR (Cursor position report) calls does not interfere with
stdin.

Keeps `Terminal::clear()` semantics for explicit calls.

Fixes #2483
