### PR TITLE
fix(core): avoid overflow in BufferDiff forced-width advance

### DIFF
--- a/ratatui-core/src/buffer/diff.rs
+++ b/ratatui-core/src/buffer/diff.rs
@@ -110,7 +110,9 @@ impl<'next> Iterator for BufferDiff<'_, 'next> {
                 _ if is_skip(current) => {}
 
                 CellDiffOption::ForcedWidth(width) => {
-                    self.pos += width.get().saturating_sub(1) as usize;
+                    self.pos = self
+                        .pos
+                        .saturating_add(width.get().saturating_sub(1) as usize);
                     if current != previous {
                         let (x, y) = self.pos_of(i);
                         return Some((x, y, &self.next[i]));


### PR DESCRIPTION
### Motivation
- Prevent arithmetic overflow when advancing `self.pos` for `CellDiffOption::ForcedWidth(NonZeroU16)` in `ratatui-core/src/buffer/diff.rs`, which could panic in debug or wrap in release and cause an iterator hang/DoS.

### Description
- Replace the unchecked `self.pos += width.get().saturating_sub(1)` with a saturating addition via `self.pos = self.pos.saturating_add(width.get().saturating_sub(1) as usize)` to avoid overflow while preserving existing iterator semantics.

### Testing
- Ran `cargo test -p ratatui-core buffer::diff --lib` and the buffer diff tests completed successfully (`10 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd3420b74833089a87f6021475610)