### PR TITLE
build(deps): tune Dependabot update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,33 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Delay routine version-update PRs for a few days to reduce supply-chain
+    # risk from immediately adopting a newly published release. Security
+    # updates are not delayed by cooldown.
+    cooldown:
+      default-days: 7
+    # Group routine Cargo updates into one reviewable PR to reduce bot traffic.
+    groups:
+      cargo-dependencies:
+        patterns: ["*"]
+    # Keep the queue bounded when grouped updates still produce follow-up PRs.
+    open-pull-requests-limit: 3
+    # For Cargo, leave the manifest requirement alone when it already admits
+    # the new release. For example, a requirement like `0.2.0` already allows
+    # compatible `0.2.x` updates, so Dependabot can update the lockfile without
+    # rewriting the manifest to `0.2.1`.
+    versioning-strategy: increase-if-necessary
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    # Delay routine action bumps for a few days to reduce supply-chain risk
+    # from immediately adopting a newly published release.
+    cooldown:
+      default-days: 7
+    # Group workflow action updates separately from Rust dependency updates.
+    groups:
+      github-actions-dependencies:
+        patterns: ["*"]
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

- add a 7 day Dependabot cooldown for Cargo and GitHub Actions version updates
- group routine Cargo and GitHub Actions updates into one PR per ecosystem
- reduce the open Dependabot PR limit to keep the queue bounded
- use Cargo `versioning-strategy: increase-if-necessary` to avoid unnecessary manifest rewrites
- clarify the policy inline in `.github/dependabot.yml`

## Constraints and Tradeoffs

- `cooldown` reduces supply-chain risk by avoiding immediate adoption of newly published releases, but it also delays routine update PRs
- `groups` reduce PR volume, but they produce broader update PRs that can be noisier to review when several dependencies move together
- `open-pull-requests-limit: 3` keeps bot traffic manageable, but it can slow how quickly Dependabot works through a backlog
- `increase-if-necessary` keeps Cargo requirements honest by leaving compatible manifest requirements alone while still updating the lockfile, but it means fewer explicit `Cargo.toml` bumps when the existing requirement already admits the new release
- some schema validators still flag `versioning-strategy: increase-if-necessary` even though GitHub documents it and Dependabot accepts it

## Follow-up Work

In a future PR, I plan to lower published crate `Cargo.toml` dependency requirements to the lowest compatible versions that Ratatui actually supports and needs. I also plan to add a `cargo minimal-versions` check so those dependency floors stay validated over time.

## References

- Dependabot options reference:
  https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference?learn=dependency_version_updates
- Optimizing PR creation for version updates:
  https://docs.github.com/en/enterprise-cloud@latest/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates
- Dependabot Cargo partial-update support:
  https://github.com/dependabot/dependabot-core/pull/12487

## AI Attribution

This change was generated with Codex.