### PR TITLE
fix(core): use correct width for halfwidth dakuten/handakuten

### DIFF
--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -971,18 +971,19 @@ mod tests {
 
         // Combining dakuten (U+3099): forms 1-cell grapheme cluster with width 1
         let mut buffer1 = Buffer::empty(area);
-        buffer1.set_string(0, 0, "ｶ゙", Style::default());
+        let (x1, _) = buffer1.set_stringn(0, 0, "ｶ゙", usize::MAX, Style::default());
         // The combining dakuten merges with ｶ into a single cell (width 1)
         assert_eq!(buffer1.content[0].symbol(), "ｶ゙");
-        assert_eq!(buffer1.content[1].symbol(), " ");
+        assert_eq!(buffer1.content[0].cell_width(), 1);
+        assert_eq!(x1, 1);
 
         // Non-combining halfwidth dakuten (U+FF9E): grapheme cluster with width 2
         let mut buffer2 = Buffer::empty(area);
-        buffer2.set_string(0, 0, "ｶﾞ", Style::default());
+        let (x2, _) = buffer2.set_stringn(0, 0, "ｶﾞ", usize::MAX, Style::default());
         // The grapheme cluster "ｶﾞ" is stored in cell[0], but takes 2 cells width
         assert_eq!(buffer2.content[0].symbol(), "ｶﾞ");
-        assert_eq!(buffer2.content[1].symbol(), " "); // reset cell (hidden by width 2)
-        assert_eq!(buffer2.content[2].symbol(), " ");
+        assert_eq!(buffer2.content[0].cell_width(), 2);
+        assert_eq!(x2, 2);
     }
 
     #[fixture]

--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -914,6 +914,77 @@ mod tests {
         assert_eq!(buffer, Buffer::with_lines(["コン "]));
     }
 
+    #[test]
+    fn set_string_halfwidth_katakana_with_dakuten() {
+        let area = Rect::new(0, 0, 5, 1);
+
+        // Fullwidth katakana: 2 cells
+        let mut buffer = Buffer::empty(area);
+        buffer.set_string(0, 0, "ガ", Style::default());
+        let mut expected = Buffer::empty(area);
+        expected.set_string(0, 0, "ガ", Style::default());
+        assert_eq!(buffer, expected);
+
+        // Halfwidth katakana (no dakuten): 1 cell
+        let mut buffer = Buffer::empty(area);
+        buffer.set_string(0, 0, "ｶ", Style::default());
+        assert_eq!(buffer.content[0].symbol(), "ｶ");
+        assert_eq!(buffer.content[1].symbol(), " ");
+
+        // Halfwidth katakana + non-combining dakuten (U+FF9E): grapheme cluster takes 2 cells
+        let mut buffer = Buffer::empty(area);
+        buffer.set_string(0, 0, "ｶﾞ", Style::default());
+        // The whole grapheme cluster "ｶﾞ" is placed in cell[0], and cell[1] is reset (width=2)
+        assert_eq!(buffer.content[0].symbol(), "ｶﾞ");
+        assert_eq!(buffer.content[1].symbol(), " "); // reset cell
+        assert_eq!(buffer.content[2].symbol(), " ");
+
+        // Halfwidth katakana + non-combining handakuten (U+FF9F): grapheme cluster takes 2 cells
+        let mut buffer = Buffer::empty(area);
+        buffer.set_string(0, 0, "ﾊﾟ", Style::default());
+        assert_eq!(buffer.content[0].symbol(), "ﾊﾟ");
+        assert_eq!(buffer.content[1].symbol(), " "); // reset cell
+        assert_eq!(buffer.content[2].symbol(), " ");
+
+        // Multiple halfwidth katakana with dakuten: each cluster takes 2 cells (4 total)
+        let mut buffer = Buffer::empty(area);
+        buffer.set_string(0, 0, "ｶﾞｷﾞ", Style::default());
+        assert_eq!(buffer.content[0].symbol(), "ｶﾞ"); // first cluster: width 2
+        assert_eq!(buffer.content[1].symbol(), " "); // reset by first cluster
+        assert_eq!(buffer.content[2].symbol(), "ｷﾞ"); // second cluster: width 2
+        assert_eq!(buffer.content[3].symbol(), " "); // reset by second cluster
+        assert_eq!(buffer.content[4].symbol(), " ");
+
+        // Overflow: only first 2 grapheme clusters fit (4 cells out of 5)
+        let mut buffer = Buffer::empty(area);
+        buffer.set_string(0, 0, "ｶﾞｷﾞｸﾞ", Style::default());
+        assert_eq!(buffer.content[0].symbol(), "ｶﾞ");
+        assert_eq!(buffer.content[1].symbol(), " ");
+        assert_eq!(buffer.content[2].symbol(), "ｷﾞ");
+        assert_eq!(buffer.content[3].symbol(), " ");
+        assert_eq!(buffer.content[4].symbol(), " ");
+    }
+
+    #[test]
+    fn set_string_combining_vs_halfwidth_dakuten() {
+        let area = Rect::new(0, 0, 5, 1);
+
+        // Combining dakuten (U+3099): forms 1-cell grapheme cluster with width 1
+        let mut buffer1 = Buffer::empty(area);
+        buffer1.set_string(0, 0, "ｶ゙", Style::default());
+        // The combining dakuten merges with ｶ into a single cell (width 1)
+        assert_eq!(buffer1.content[0].symbol(), "ｶ゙");
+        assert_eq!(buffer1.content[1].symbol(), " ");
+
+        // Non-combining halfwidth dakuten (U+FF9E): grapheme cluster with width 2
+        let mut buffer2 = Buffer::empty(area);
+        buffer2.set_string(0, 0, "ｶﾞ", Style::default());
+        // The grapheme cluster "ｶﾞ" is stored in cell[0], but takes 2 cells width
+        assert_eq!(buffer2.content[0].symbol(), "ｶﾞ");
+        assert_eq!(buffer2.content[1].symbol(), " "); // reset cell (hidden by width 2)
+        assert_eq!(buffer2.content[2].symbol(), " ");
+    }
+
     #[fixture]
     fn small_one_line_buffer() -> Buffer {
         Buffer::empty(Rect::new(0, 0, 5, 1))

--- a/ratatui-core/src/buffer/cell_width.rs
+++ b/ratatui-core/src/buffer/cell_width.rs
@@ -82,9 +82,9 @@ mod tests {
         s.cell_width()
     }
 
-    #[test]
-    fn ascii() {
-        assert_eq!("a".cell_width(), 1);
+    fn width_char(c: char) -> u16 {
+        let mut buf = [0; 4];
+        width(c.encode_utf8(&mut buf))
     }
 
     #[test]
@@ -99,12 +99,12 @@ mod tests {
 
     #[test]
     fn halfwidth_dakuten_alone() {
-        assert_eq!(width("\u{FF9E}"), 1); // ﾞ
+        assert_eq!(width_char(HALFWIDTH_KATAKANA_VOICED_SOUND_MARK), 1); // ﾞ
     }
 
     #[test]
     fn halfwidth_handakuten_alone() {
-        assert_eq!(width("\u{FF9F}"), 1); // ﾟ
+        assert_eq!(width_char(HALFWIDTH_KATAKANA_SEMI_VOICED_SOUND_MARK), 1); // ﾟ
     }
 
     #[test]

--- a/ratatui-core/src/buffer/cell_width.rs
+++ b/ratatui-core/src/buffer/cell_width.rs
@@ -1,12 +1,18 @@
 use unicode_width::UnicodeWidthStr;
 
+/// Halfwidth Katakana Voiced Sound Mark (dakuten).
+const HALFWIDTH_KATAKANA_VOICED_SOUND_MARK: char = '\u{FF9E}';
+/// Halfwidth Katakana Semi-Voiced Sound Mark (handakuten).
+const HALFWIDTH_KATAKANA_SEMI_VOICED_SOUND_MARK: char = '\u{FF9F}';
+
 /// Returns the display width of a value in terminal cells.
 ///
 /// This trait provides a unified way to compute cell widths for both string content
 /// and [`Cell`](super::Cell)s:
 ///
 /// - **`str`**: width is derived from [`UnicodeWidthStr`], with a fast path for single-byte ASCII
-///   characters.
+///   characters and a terminal-compatibility adjustment for halfwidth katakana dakuten/handakuten
+///   (`U+FF9E`/`U+FF9F`).
 /// - **[`Cell`](super::Cell)**: returns the
 ///   [`CellDiffOption::ForcedWidth`](super::CellDiffOption::ForcedWidth) when set, otherwise falls
 ///   back to the width of the cell's symbol.
@@ -33,14 +39,48 @@ impl CellWidth for str {
             );
             1
         } else {
-            self.width() as u16
+            let width = self.width() as u16;
+            width.saturating_add(count_halfwidth_sound_marks(self))
         }
     }
+}
+
+/// Returns how many halfwidth dakuten/handakuten marks are present.
+///
+/// `unicode-width` reports U+FF9E (ﾞ) and U+FF9F (ﾟ) as zero-width because
+/// they have the `Grapheme_Extend` property, but terminals typically render
+/// them as independent halfwidth characters occupying one cell each.
+///
+/// We compensate for that terminal behavior by adding `+1` for each occurrence.
+/// This does not affect the combining variants U+3099 and U+309A, which keep
+/// their normal combining behavior and width handling through `unicode-width`.
+///
+/// # References
+///
+/// - Ruby reline PR [#832](https://github.com/ruby/reline/pull/832): Fix cursor positioning for
+///   invalid halfwidth dakuten/handakuten
+/// - Microsoft Terminal Issue [#18087](https://github.com/microsoft/terminal/issues/18087):
+///   Half-width Katakana and (han)dakuten should not overlap
+/// - [Unicode L2/19-039](https://www.unicode.org/L2/L2019/19039-grapheme-break.pdf): Grapheme break
+///   property for U+FF9E and U+FF9F
+fn count_halfwidth_sound_marks(s: &str) -> u16 {
+    s.chars()
+        .filter(|c| {
+            matches!(
+                *c,
+                HALFWIDTH_KATAKANA_VOICED_SOUND_MARK | HALFWIDTH_KATAKANA_SEMI_VOICED_SOUND_MARK
+            )
+        })
+        .count() as u16
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn width(s: &str) -> u16 {
+        s.cell_width()
+    }
 
     #[test]
     fn ascii() {
@@ -55,5 +95,66 @@ mod tests {
     #[test]
     fn empty() {
         assert_eq!("".cell_width(), 0);
+    }
+
+    #[test]
+    fn halfwidth_dakuten_alone() {
+        assert_eq!(width("\u{FF9E}"), 1); // ﾞ
+    }
+
+    #[test]
+    fn halfwidth_handakuten_alone() {
+        assert_eq!(width("\u{FF9F}"), 1); // ﾟ
+    }
+
+    #[test]
+    fn halfwidth_katakana_with_dakuten() {
+        // Valid combinations (halfwidth katakana + non-combining dakuten)
+        assert_eq!(width("ｶﾞ"), 2); // U+FF76 + U+FF9E
+        assert_eq!(width("ｻﾞ"), 2); // U+FF7B + U+FF9E
+    }
+
+    #[test]
+    fn halfwidth_katakana_with_handakuten() {
+        // Valid combinations (halfwidth katakana + non-combining handakuten)
+        assert_eq!(width("ﾊﾟ"), 2); // U+FF8A + U+FF9F
+        assert_eq!(width("ﾋﾟ"), 2); // U+FF8B + U+FF9F
+    }
+
+    #[test]
+    fn non_katakana_with_halfwidth_dakuten() {
+        // Non-katakana characters + halfwidth dakuten.
+        // These form valid grapheme clusters but are linguistically incorrect.
+        // The dakuten still takes 1 column width regardless.
+        assert_eq!(width("aﾞ"), 2); // ASCII (1) + dakuten (1)
+        assert_eq!(width("1ﾟ"), 2); // Digit (1) + handakuten (1)
+        assert_eq!(width("あﾞ"), 3); // Hiragana (2) + dakuten (1)
+        assert_eq!(width("紅ﾞ"), 3); // Kanji (2) + dakuten (1)
+    }
+
+    #[test]
+    #[allow(clippy::unicode_not_nfc)]
+    fn combining_dakuten_no_special_handling() {
+        // Combining dakuten (U+3099) should follow unicode-width behavior.
+        assert_eq!(width("ｶ゙"), 1); // U+FF76 + U+3099
+        assert_eq!(width("ガ"), 2); // U+30AB + U+3099
+    }
+
+    #[test]
+    #[allow(clippy::unicode_not_nfc)]
+    fn combining_handakuten_no_special_handling() {
+        // Combining handakuten (U+309A) should follow unicode-width behavior.
+        assert_eq!(width("ﾊ゚"), 1); // U+FF8A + U+309A
+        assert_eq!(width("パ"), 2); // U+30CF + U+309A
+    }
+
+    #[test]
+    fn mixed_text_unchanged() {
+        assert_eq!(width("a"), 1);
+        assert_eq!(width("あ"), 2);
+        assert_eq!(width("ｶ"), 1);
+        assert_eq!(width("カ"), 2);
+        assert_eq!(width("aｶﾞb"), 4); // a(1) + ｶﾞ(2) + b(1)
+        assert_eq!(width("あｶﾞ"), 4); // あ(2) + ｶﾞ(2)
     }
 }

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -990,6 +990,108 @@ mod tests {
     }
 
     #[test]
+    fn test_render_paragraph_with_ascii_and_background() {
+        // Test actual Paragraph behavior
+        let text = "abc";
+        let paragraph = Paragraph::new(text).style(Style::default().bg(Color::Green));
+
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
+        paragraph.render(Rect::new(0, 0, 10, 1), &mut buffer);
+
+        // If all cells have green background, the test passes
+        for x in 0..10 {
+            assert_eq!(
+                buffer[(x, 0)].bg,
+                Color::Green,
+                "Cell {x} should have green bg"
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_paragraph_with_fullwidth_and_background() {
+        // "あいう" should be width 6 (each character is width 2)
+        let text = "あいう";
+        let paragraph = Paragraph::new(text).style(Style::default().bg(Color::Green));
+
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
+        paragraph.render(Rect::new(0, 0, 10, 1), &mut buffer);
+
+        // Check content - should have spaces for skip cells
+        assert_eq!(buffer[(0, 0)].symbol(), "あ", "Cell 0 should be あ");
+        assert_eq!(
+            buffer[(1, 0)].symbol(),
+            " ",
+            "Cell 1 should be space (skip cell)"
+        );
+        assert_eq!(buffer[(2, 0)].symbol(), "い", "Cell 2 should be い");
+        assert_eq!(
+            buffer[(3, 0)].symbol(),
+            " ",
+            "Cell 3 should be space (skip cell)"
+        );
+        assert_eq!(buffer[(4, 0)].symbol(), "う", "Cell 4 should be う");
+        assert_eq!(
+            buffer[(5, 0)].symbol(),
+            " ",
+            "Cell 5 should be space (skip cell)"
+        );
+
+        // Check background - all cells should have green background from set_style
+        // Skip cells are not rendered to terminal (excluded by diff), so their bg color doesn't
+        // matter
+        for x in 0..10 {
+            assert_eq!(
+                buffer[(x, 0)].bg,
+                Color::Green,
+                "Cell {x} should have green bg"
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_paragraph_with_halfwidth_katakana_dakuten_and_background() {
+        // "ｶﾞｷﾞｸﾞ" should be width 6 (each grapheme is width 2)
+        let text = "ｶﾞｷﾞｸﾞ";
+        let paragraph = Paragraph::new(text).style(Style::default().bg(Color::Green));
+
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
+        paragraph.render(Rect::new(0, 0, 10, 1), &mut buffer);
+
+        // Check content - should have spaces for wide characters like "あいう"
+        // Expected: "ｶﾞ ｷﾞ ｸﾞ     " (spaces at x=1, 3, 5)
+        assert_eq!(buffer[(0, 0)].symbol(), "ｶﾞ", "Cell 0 should be ｶﾞ");
+        assert_eq!(
+            buffer[(1, 0)].symbol(),
+            " ",
+            "Cell 1 should be space (skip cell)"
+        );
+        assert_eq!(buffer[(2, 0)].symbol(), "ｷﾞ", "Cell 2 should be ｷﾞ");
+        assert_eq!(
+            buffer[(3, 0)].symbol(),
+            " ",
+            "Cell 3 should be space (skip cell)"
+        );
+        assert_eq!(buffer[(4, 0)].symbol(), "ｸﾞ", "Cell 4 should be ｸﾞ");
+        assert_eq!(
+            buffer[(5, 0)].symbol(),
+            " ",
+            "Cell 5 should be space (skip cell)"
+        );
+
+        // Check background - all cells should have green background from set_style
+        // Skip cells are not rendered to terminal (excluded by diff), so their bg color doesn't
+        // matter
+        for x in 0..10 {
+            assert_eq!(
+                buffer[(x, 0)].bg,
+                Color::Green,
+                "Cell {x} should have green bg"
+            );
+        }
+    }
+
+    #[test]
     fn test_render_paragraph_with_unicode_characters() {
         let text = "こんにちは, 世界! 😃";
         let truncated_paragraph = Paragraph::new(text);

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -497,7 +497,7 @@ impl Styled for Paragraph<'_> {
 mod tests {
     use alloc::vec;
 
-    use ratatui_core::buffer::Buffer;
+    use ratatui_core::buffer::{Buffer, CellWidth};
     use ratatui_core::layout::{Alignment, Rect};
     use ratatui_core::style::{Color, Modifier, Style, Stylize};
     use ratatui_core::text::{Line, Span, Text};
@@ -1017,25 +1017,13 @@ mod tests {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
         paragraph.render(Rect::new(0, 0, 10, 1), &mut buffer);
 
-        // Check content - should have spaces for skip cells
+        // Check content and effective cell widths for wide cells.
         assert_eq!(buffer[(0, 0)].symbol(), "あ", "Cell 0 should be あ");
-        assert_eq!(
-            buffer[(1, 0)].symbol(),
-            " ",
-            "Cell 1 should be space (skip cell)"
-        );
+        assert_eq!(buffer[(0, 0)].cell_width(), 2, "Cell 0 should be width 2");
         assert_eq!(buffer[(2, 0)].symbol(), "い", "Cell 2 should be い");
-        assert_eq!(
-            buffer[(3, 0)].symbol(),
-            " ",
-            "Cell 3 should be space (skip cell)"
-        );
+        assert_eq!(buffer[(2, 0)].cell_width(), 2, "Cell 2 should be width 2");
         assert_eq!(buffer[(4, 0)].symbol(), "う", "Cell 4 should be う");
-        assert_eq!(
-            buffer[(5, 0)].symbol(),
-            " ",
-            "Cell 5 should be space (skip cell)"
-        );
+        assert_eq!(buffer[(4, 0)].cell_width(), 2, "Cell 4 should be width 2");
 
         // Check background - all cells should have green background from set_style
         // Skip cells are not rendered to terminal (excluded by diff), so their bg color doesn't
@@ -1058,26 +1046,13 @@ mod tests {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
         paragraph.render(Rect::new(0, 0, 10, 1), &mut buffer);
 
-        // Check content - should have spaces for wide characters like "あいう"
-        // Expected: "ｶﾞ ｷﾞ ｸﾞ     " (spaces at x=1, 3, 5)
+        // Check content and effective cell widths for wide grapheme clusters.
         assert_eq!(buffer[(0, 0)].symbol(), "ｶﾞ", "Cell 0 should be ｶﾞ");
-        assert_eq!(
-            buffer[(1, 0)].symbol(),
-            " ",
-            "Cell 1 should be space (skip cell)"
-        );
+        assert_eq!(buffer[(0, 0)].cell_width(), 2, "Cell 0 should be width 2");
         assert_eq!(buffer[(2, 0)].symbol(), "ｷﾞ", "Cell 2 should be ｷﾞ");
-        assert_eq!(
-            buffer[(3, 0)].symbol(),
-            " ",
-            "Cell 3 should be space (skip cell)"
-        );
+        assert_eq!(buffer[(2, 0)].cell_width(), 2, "Cell 2 should be width 2");
         assert_eq!(buffer[(4, 0)].symbol(), "ｸﾞ", "Cell 4 should be ｸﾞ");
-        assert_eq!(
-            buffer[(5, 0)].symbol(),
-            " ",
-            "Cell 5 should be space (skip cell)"
-        );
+        assert_eq!(buffer[(4, 0)].cell_width(), 2, "Cell 4 should be width 2");
 
         // Check background - all cells should have green background from set_style
         // Skip cells are not rendered to terminal (excluded by diff), so their bg color doesn't


### PR DESCRIPTION
unicode-width reports U+FF9E/U+FF9F as zero-width, but terminals render them as 1 cell.
Adjusts `CellWidth` trait accordingly for fixing this behavior.

fixes #2188
