### PR TITLE
fix: duplicated "the" in color.rs and backend.rs doc-comments

### DIFF
--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -38,7 +38,7 @@
 //! # std::io::Result::Ok(())
 //! ```
 //!
-//! See the the [Examples] directory for more examples.
+//! See the [Examples] directory for more examples.
 //!
 //! # Raw Mode
 //!

--- a/ratatui-core/src/style/color.rs
+++ b/ratatui-core/src/style/color.rs
@@ -157,7 +157,7 @@ impl<'de> serde::Deserialize<'de> for Color {
     ///
     /// This implementation uses the `FromStr` trait to deserialize strings, so named colours, RGB,
     /// and indexed values are able to be deserialized. In addition, values that were produced by
-    /// the the older serialization implementation of Color are also able to be deserialized.
+    /// the older serialization implementation of Color are also able to be deserialized.
     ///
     /// Prior to v0.26.0, Ratatui would be serialized using a map for indexed and RGB values, for
     /// examples in json `{"Indexed": 10}` and `{"Rgb": [255, 0, 255]}` respectively. Now they are


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in doc-comments:
- `ratatui-core/src/style/color.rs` — "/// the the older serialization implementation of Color are also able to be deserialized." → "...the older serialization..."
- `ratatui-core/src/backend.rs` — "//! See the the [Examples] directory for more examples." → "//! See the [Examples] directory for more examples."

No code/behavior change.